### PR TITLE
Fix blueman startup when .cache dir doesn't exist

### DIFF
--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -279,7 +279,10 @@ def create_menuitem(text, image):
 
 def check_single_instance(id, unhide_func=None):
     print "%s version %s starting" % (id, VERSION)
-    lockfile = os.path.expanduser("~/.cache/%s-%s" % (id, os.getuid()))
+    cachedir = os.path.expanduser("~/.cache/")
+    if not os.path.exists(cachedir):
+        os.mkdir(cachedir)
+    lockfile = os.path.join(cachedir, "%s-%s" % (id, os.getuid()))
 
     def handler(signum, frame):
         if unhide_func:


### PR DESCRIPTION
When blueman checks, if another instance is already running, it relies on the `~/.cache` directory already having been created before. It tries to write a file into that dir and raises an exception which is misinterpreted as another instance running.
