### PR TITLE
trivial: s,_Exit,Exit, in ExitItem.py

### DIFF
--- a/blueman/plugins/applet/ExitItem.py
+++ b/blueman/plugins/applet/ExitItem.py
@@ -26,7 +26,7 @@ class ExitItem(AppletPlugin):
 	__icon__ = "application-exit"
 	
 	def on_load(self, applet):
-		item = Gtk.MenuItem.new_with_label("_Exit")
+		item = Gtk.MenuItem.new_with_label("Exit")
 		item.connect("activate", lambda x: Gtk.main_quit())
 		applet.Plugins.Menu.Register(self, item, 100)
 		


### PR DESCRIPTION
I think this was supposed to be relevant to translations, but
the underscore ("_") shows up in the UI text, so it's incorrect.
