### PR TITLE
Add blueman apapters config to Xfce settings dialog (xfce branch ONLY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [sendto] Make thunar sendto integration optional (@rworkman / Robby Workman)
 * [configure] Rename --enable-sendto to --enable-nautilus-sendto
   (@rworkman / Robby Workman)
+* Add optional xfce settings entry (@rworkman / Robby Workman)
 
 ### Bugs fixed
 

--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,11 @@ AC_ARG_ENABLE(thunar-sendto,
 
 AM_CONDITIONAL(HAVE_THUNAR, test "x$have_thunar" = "xyes")
 
+AC_ARG_ENABLE(xfce-settings,
+[  --enable-xfce-settings=[yes/no] Enable xfce settings entry],have_xfce=$enableval,have_xfce=yes)
+
+AM_CONDITIONAL(HAVE_XFCE, test "x$have_xfce" = "xyes")
+
 dnl ----------------------------
 
 if test $deps_check = 1; then
@@ -252,5 +257,6 @@ echo sysconfig dir : $sysconfdir
 echo Policykit-1 Enabled: $polkit_val
 echo Nautilus sendto plugin enabled: $have_nst
 echo Thunar sendto installation enabled: $have_thunar
+echo Xfce settings entry enabled: $have_xfce
 echo Dhcpd 3 configuration file: $dhconfig
 echo

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -9,6 +9,7 @@ app_in_files = blueman-manager.desktop.in
 app_DATA = $(app_in_files:.desktop.in=.desktop)
 
 thunar_in_files = thunar-sendto-blueman.desktop.in
+xfce_in_files = blueman-adapters.desktop.in
 
 if HAVE_THUNAR
 @INTLTOOL_DESKTOP_RULE@
@@ -16,10 +17,16 @@ thunardir = $(datadir)/Thunar/sendto
 thunar_DATA = $(thunar_in_files:.desktop.in=.desktop)
 endif
 
+if HAVE_XFCE
+@INTLTOOL_DESKTOP_RULE@
+xfcedir = $(datadir)/applications
+xfce_DATA = $(xfce_in_files:.desktop.in=.desktop)
+endif
 
 EXTRA_DIST = 	$(autostart_in_files)	\
-		$(app_in_files)	\
-		$(thunar_in_files)
+		$(app_in_files)		\
+		$(thunar_in_files)	\
+		$(xfce_in_files)
 
 SUBDIRS = 		\
 	configs		\
@@ -29,6 +36,7 @@ SUBDIRS = 		\
 
 CLEANFILES =		\
 	thunar-sendto-blueman.desktop	\
+	blueman-adapters.desktop	\
 	blueman-manager.desktop	\
 	blueman.desktop		\
 	$(BUILT_SOURCES)

--- a/data/blueman-adapters.desktop.in
+++ b/data/blueman-adapters.desktop.in
@@ -1,0 +1,13 @@
+[Desktop Entry]
+_Name=Bluetooth Adapters
+_Comment=Set Bluetooth Adapter Properties
+Exec=blueman-adapters
+Icon=blueman-device
+Terminal=false
+Type=Application
+Categories=X-XFCE;Settings;DesktopSettings;X-XFCE-SettingsDialog;X-XFCE-HardwareSettings;
+StartupNotify=true
+OnlyShowIn=XFCE;
+NoDisplay=false
+X-XfceSettingsName=Bluetooth
+X-XfcePluggable=false


### PR DESCRIPTION
This branch implements _only_ xfce settings dialog support for blueman adapter configuration. 

Since the "thunar" branch conflicts with this, I'm also going to do a "thunar+xfce" branch pull request, which includes the commits from both branches merged together without the conflicts. Assuming both sets of changes are wanted, take that one instead.
