### PR TITLE
Fixup a few issues with thunar-sendto support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,12 +125,12 @@ else
 fi
 AC_SUBST(polkit_val)
 
-AC_ARG_ENABLE(sendto,
+AC_ARG_ENABLE(nautilus-sendto,
 [  --enable-nautilus-sendto=[yes/no] Enable nautilus-sendto plugin build],have_nst=$enableval,have_nst=yes)
 
 AM_CONDITIONAL(HAVE_NST, test "x$have_nst" = "xyes")
 
-AC_ARG_ENABLE(thunar,
+AC_ARG_ENABLE(thunar-sendto,
 [  --enable-thunar-sendto=[yes/no] Enable thunar-sendto installation],have_thunar=$enableval,have_thunar=yes)
 
 AM_CONDITIONAL(HAVE_THUNAR, test "x$have_thunar" = "xyes")

--- a/data/thunar-sendto-blueman.desktop.in
+++ b/data/thunar-sendto-blueman.desktop.in
@@ -1,7 +1,6 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
-Encoding=UTF-8
 Name=_Bluetooth Device
 Icon=blueman
 Exec=blueman-sendto %F


### PR DESCRIPTION
This completes the rename of configure options and removes a deprecated Encoding key from the desktop file
