### PR TITLE
Remove misleading plugin conflicts re NMIntegration

### DIFF
--- a/blueman/plugins/applet/NMDUNSupport.py
+++ b/blueman/plugins/applet/NMDUNSupport.py
@@ -82,7 +82,7 @@ class ConnectionHandler:
 
 class NMDUNSupport(AppletPlugin):
     __depends__ = ["StatusIcon", "DBusService"]
-    __conflicts__ = ["PPPSupport", "NMIntegration"]
+    __conflicts__ = ["PPPSupport"]
     __icon__ = "modem"
     __author__ = "Walmis"
     __description__ = _("Provides support for Dial Up Networking (DUN) with ModemManager and NetworkManager 0.8")

--- a/blueman/plugins/applet/NMPANSupport.py
+++ b/blueman/plugins/applet/NMPANSupport.py
@@ -165,7 +165,7 @@ class NewConnectionBuilder:
 
 class NMPANSupport(AppletPlugin):
     __depends__ = ["DBusService"]
-    __conflicts__ = ["DhcpClient", "NMIntegration"]
+    __conflicts__ = ["DhcpClient"]
     __icon__ = "network"
     __author__ = "Walmis"
     __description__ = _("Provides support for Personal Area Networking (PAN) introduced in NetworkManager 0.8")

--- a/blueman/plugins/applet/PPPSupport.py
+++ b/blueman/plugins/applet/PPPSupport.py
@@ -54,7 +54,6 @@ class Connection:
 
 class PPPSupport(AppletPlugin):
     __depends__ = ["DBusService"]
-    __conflicts__ = ["NMIntegration"]
     __description__ = _("Provides basic support for connecting to the internet via DUN profile.")
     __author__ = "Walmis"
     __icon__ = "modem"


### PR DESCRIPTION
I was checking to see if the network-manager branch was usable (with respect to the NMPan stuff and anything else it's supposed to support), and along the way I noticed what seems to be leftover cruft - that's what this patch removes. Review carefully.

For the record, the branch doesn't work, at least not with my phone. Even worse, I'm unable to wrap my head around the NM API enough to even start figuring out why :/
