### PR TITLE
Make AppIndicator.py installation depend on pkg-config check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * [configure] Rename --enable-sendto to --enable-nautilus-sendto
   (@rworkman / Robby Workman)
 * Add optional xfce settings entry (@rworkman / Robby Workman)
+* Make installation of AppIndicator.py depend on pkg-config check for
+  appindicator3-0.1 (@rworkman / Robby Workman)
 
 ### Bugs fixed
 

--- a/blueman/plugins/applet/Makefile.am
+++ b/blueman/plugins/applet/Makefile.am
@@ -1,6 +1,10 @@
 bluemandir = $(pythondir)/blueman/plugins/applet
 
-blueman_PYTHON = AppIndicator.py ExitItem.py ShowConnected.py AuthAgent.py DhcpClient.py NMPANSupport.py DBusService.py DiscvManager.py NetUsage.py Headset.py __init__.py KillSwitch.py Menu.py Networking.py PowerManager.py PPPSupport.py NMDUNSupport.py RecentConns.py SerialManager.py StandardItems.py StatusIcon.py TransferService.py
+if USE_APPINDICATOR3
+APPINDICATOR3_FILES=AppIndicator.py
+endif
+
+blueman_PYTHON = ExitItem.py ShowConnected.py AuthAgent.py DhcpClient.py NMPANSupport.py DBusService.py DiscvManager.py NetUsage.py Headset.py __init__.py KillSwitch.py Menu.py Networking.py PowerManager.py PPPSupport.py NMDUNSupport.py RecentConns.py SerialManager.py StandardItems.py StatusIcon.py TransferService.py $(APPINDICATOR3_FILES)
 
 CLEANFILES =		\
 	$(BUILT_SOURCES)

--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,11 @@ PKG_CHECK_MODULES([PYGOBJECT],
 AC_SUBST(PYGOBJECT_CFLAGS)
 AC_SUBST(PYGOBJECT_LIBS)
 
+PKG_CHECK_MODULES(APPINDICATOR3, appindicator3-0.1,
+		HAVE_APPINDICATOR3="yes", HAVE_APPINDICATOR3="no")
+
+AM_CONDITIONAL(USE_APPINDICATOR3, test "x$HAVE_APPINDICATOR3" = "xyes")
+
 
 AC_OUTPUT([
 Makefile
@@ -259,4 +264,5 @@ echo Nautilus sendto plugin enabled: $have_nst
 echo Thunar sendto installation enabled: $have_thunar
 echo Xfce settings entry enabled: $have_xfce
 echo Dhcpd 3 configuration file: $dhconfig
+echo Install AppIndicator.py (requires libappindicator3): $USE_APPINDICATOR3
 echo


### PR DESCRIPTION
Someone who _does_ have libappindicator installed needs to test this and verify that it still correctly installs the AppIndicator.py file. It should, of course, but I don't have a system here to verify that.
