### PR TITLE
Refactor DbusService

### DIFF
--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -1,6 +1,7 @@
 from gi.repository import GObject
 
 from gi.repository import Gtk
+import inspect
 import traceback
 
 from blueman.plugins.ConfigurablePlugin import ConfigurablePlugin
@@ -26,10 +27,6 @@ class AppletPlugin(ConfigurablePlugin):
 
         self.Applet = applet
 
-        # self.__methods = []
-        self.__dbus_methods = []
-        self.__dbus_signals = []
-
         self.__overrides = []
 
     def override_method(self, object, method, override):
@@ -43,26 +40,14 @@ class AppletPlugin(ConfigurablePlugin):
 
         super(AppletPlugin, self)._unload()
 
-        for met in self.__dbus_methods:
-            self.Applet.DbusSvc.remove_registration(met)
-
-        for sig in self.__dbus_signals:
-            self.Applet.DbusSvc.remove_registration(sig)
-
+        self.Applet.DbusSvc.remove_definitions(self)
 
     def _load(self, applet):
         super(AppletPlugin, self)._load(applet)
 
+        self.Applet.DbusSvc.add_definitions(self)
+
         self.on_manager_state_changed(applet.Manager != None)
-
-
-    def add_dbus_method(self, func, *args, **kwargs):
-        self.Applet.DbusSvc.add_method(func, *args, **kwargs)
-        self.__dbus_methods.append(func.__name__)
-
-    def add_dbus_signal(self, func, *args, **kwargs):
-        self.__dbus_signals.append(func)
-        return self.Applet.DbusSvc.add_signal(func, *args, **kwargs)
 
     # virtual funcs
     def on_manager_state_changed(self, state):

--- a/blueman/plugins/MechanismPlugin.py
+++ b/blueman/plugins/MechanismPlugin.py
@@ -7,14 +7,7 @@ class MechanismPlugin(object):
 
         self.on_load()
 
-    def add_dbus_method(self, func, *args, **kwargs):
-        self.m.add_method(func, *args, **kwargs)
-
-    def add_dbus_signal(self, func, *args, **kwargs):
-        self.m.add_signal(func, *args, **kwargs)
-
-    def check_auth(self, id, caller):
-        self.m.confirm_authorization(id, caller)
+        self.m.add_definitions(self.__class__)
 
     def on_load(self):
         pass

--- a/blueman/plugins/MechanismPlugin.py
+++ b/blueman/plugins/MechanismPlugin.py
@@ -7,7 +7,7 @@ class MechanismPlugin(object):
 
         self.on_load()
 
-        self.m.add_definitions(self.__class__)
+        self.m.add_definitions(self)
 
     def on_load(self):
         pass

--- a/blueman/plugins/applet/AuthAgent.py
+++ b/blueman/plugins/applet/AuthAgent.py
@@ -1,3 +1,4 @@
+import dbus.service
 from blueman.Functions import *
 from blueman.plugins.AppletPlugin import AppletPlugin
 import blueman.main.applet.BluezAgent as BluezAgent
@@ -15,13 +16,13 @@ class AuthAgent(AppletPlugin):
 
     def on_load(self, applet):
         self.Applet = applet
-        self.add_dbus_method(self.SetTimeHint, in_signature="u")
 
         self.agents = []
         self.last_event_time = 0
 
         self.agent_manager = Bluez.AgentManager()
 
+    @dbus.service.method('org.blueman.Applet', in_signature="u")
     def SetTimeHint(self, time):
         self.last_event_time = time
 

--- a/blueman/plugins/applet/DhcpClient.py
+++ b/blueman/plugins/applet/DhcpClient.py
@@ -1,3 +1,4 @@
+import dbus.service
 from blueman.gui.Notification import Notification
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.main.Mechanism import Mechanism
@@ -14,8 +15,6 @@ class DhcpClient(AppletPlugin):
     def on_load(self, applet):
         self.Signals = SignalTracker()
 
-        self.add_dbus_method(self.DhcpClient, in_signature="s")
-
         self.Signals.Handle('bluez', Network(), self.on_network_prop_changed, 'PropertyChanged', path_keyword="path")
 
         self.quering = []
@@ -23,6 +22,7 @@ class DhcpClient(AppletPlugin):
     def on_unload(self):
         self.Signals.DisconnectAll()
 
+    @dbus.service.method('org.blueman.Applet', in_signature="s")
     def DhcpClient(self, interface):
         self.dhcp_acquire(interface)
 

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -1,3 +1,4 @@
+import dbus.service
 from blueman.Functions import *
 from blueman.plugins.AppletPlugin import AppletPlugin
 import blueman.bluez as Bluez
@@ -17,18 +18,6 @@ class PowerManager(AppletPlugin):
         AppletPlugin.add_method(self.on_power_state_query)
         AppletPlugin.add_method(self.on_power_state_change_requested)
         AppletPlugin.add_method(self.on_power_state_changed)
-
-        self.add_dbus_method(self.SetBluetoothStatus,
-                             in_signature="b",
-                             out_signature="")
-
-        self.add_dbus_method(self.GetBluetoothStatus,
-                             in_signature="",
-                             out_signature="b")
-
-        self.BluetoothStatusChanged = self.add_dbus_signal(
-            "BluetoothStatusChanged",
-            signature="b")
 
         self.Applet = applet
 
@@ -190,11 +179,15 @@ class PowerManager(AppletPlugin):
             self.Applet.Plugins.Run("on_power_state_changed", self, new_state)
             self.Applet.Plugins.StatusIcon.IconShouldChange()
 
-    #dbus method
+    @dbus.service.signal('org.blueman.Applet', signature="b")
+    def BluetoothStatusChanged(self, status):
+        pass
+
+    @dbus.service.method('org.blueman.Applet', in_signature="b", out_signature="")
     def SetBluetoothStatus(self, status):
         self.RequestPowerState(status)
 
-    #dbus method
+    @dbus.service.method('org.blueman.Applet', in_signature="", out_signature="b")
     def GetBluetoothStatus(self):
         return self.CurrentState
 

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -5,6 +5,7 @@ from blueman.main.applet.Transfer import Transfer
 from gi.repository import GObject
 from gi.repository import Gtk
 import dbus
+import dbus.service
 
 
 class TransferService(AppletPlugin):
@@ -14,9 +15,6 @@ class TransferService(AppletPlugin):
 
     def on_load(self, applet):
         self.Transfer = None
-
-        self.add_dbus_method(self.TransferControl, in_signature="ss", out_signature="")
-        self.add_dbus_method(self.TransferStatus, in_signature="s", out_signature="i")
 
         self.sess_bus = dbus.SessionBus()
 
@@ -59,7 +57,7 @@ class TransferService(AppletPlugin):
                 self.Transfer.DisconnectAll()
             self.Transfer = None
 
-
+    @dbus.service.method('org.blueman.Applet', in_signature="ss", out_signature="")
     def TransferControl(self, pattern, action):
         dprint(pattern, action)
         if not self.Transfer:
@@ -81,6 +79,7 @@ class TransferService(AppletPlugin):
         else:
             dprint("Got unknown action")
 
+    @dbus.service.method('org.blueman.Applet', in_signature="s", out_signature="i")
     def TransferStatus(self, pattern):
         if not self.Transfer:
             return -1

--- a/blueman/plugins/mechanism/Config.py
+++ b/blueman/plugins/mechanism/Config.py
@@ -1,3 +1,4 @@
+import dbus.service
 from blueman.plugins.MechanismPlugin import MechanismPlugin
 from blueman.main.BluezConfig import BluezConfig
 import os
@@ -6,12 +7,9 @@ from gi.repository import GObject
 
 class Config(MechanismPlugin):
     def on_load(self):
-        self.add_dbus_method(self.SetBluezConfig, in_signature="ssss", out_signature="", sender_keyword="caller")
-        self.add_dbus_method(self.SaveBluezConfig, in_signature="s", out_signature="", sender_keyword="caller")
-        self.add_dbus_method(self.RestartBluez, in_signature="", out_signature="", sender_keyword="caller")
-
         self.configs = {}
 
+    @dbus.service.method('org.blueman.Mechanism', in_signature="ssss", out_signature="", sender_keyword="caller")
     def SetBluezConfig(self, file, section, key, value, caller):
         self.confirm_authorization(caller, "org.blueman.bluez.config")
 
@@ -22,6 +20,7 @@ class Config(MechanismPlugin):
 
         c.set(section, key, value)
 
+    @dbus.service.method('org.blueman.Mechanism', in_signature="s", out_signature="", sender_keyword="caller")
     def SaveBluezConfig(self, file, caller):
         self.confirm_authorization(caller, "org.blueman.bluez.config")
 
@@ -29,6 +28,7 @@ class Config(MechanismPlugin):
             self.configs[file].write()
             del self.configs[file]
 
+    @dbus.service.method('org.blueman.Mechanism', in_signature="", out_signature="", sender_keyword="caller")
     def RestartBluez(self, caller):
         self.confirm_authorization(caller, "org.blueman.bluez.config")
 

--- a/blueman/plugins/mechanism/Ppp.py
+++ b/blueman/plugins/mechanism/Ppp.py
@@ -1,13 +1,10 @@
 from blueman.plugins.MechanismPlugin import MechanismPlugin
 import os
 import dbus
+import dbus.service
 
 
 class Ppp(MechanismPlugin):
-    def on_load(self):
-        self.add_dbus_method(self.PPPConnect, in_signature="sss", out_signature="s", sender_keyword="caller",
-                             async_callbacks=("ok", "err"))
-
     def ppp_connected(self, ppp, port, ok, err):
         ok(port)
         self.timer.resume()
@@ -16,6 +13,8 @@ class Ppp(MechanismPlugin):
         err(dbus.DBusException(message))
         self.timer.resume()
 
+    @dbus.service.method('org.blueman.Mechanism', in_signature="sss", out_signature="s", sender_keyword="caller",
+                         async_callbacks=("ok", "err"))
     def PPPConnect(self, port, number, apn, caller, ok, err):
         self.timer.stop()
         from blueman.main.PPPConnection import PPPConnection

--- a/blueman/plugins/mechanism/RfKill.py
+++ b/blueman/plugins/mechanism/RfKill.py
@@ -1,18 +1,17 @@
+import dbus.service
 from blueman.plugins.MechanismPlugin import MechanismPlugin
 import os
 
 
 class RfKill(MechanismPlugin):
-    def on_load(self):
-        self.add_dbus_method(self.SetRfkillState, in_signature="b", out_signature="")
-        self.add_dbus_method(self.DevRfkillChmod, in_signature="", out_signature="")
-
+    @dbus.service.method('org.blueman.Mechanism', in_signature="b", out_signature="")
     def SetRfkillState(self, state):
         from blueman.main.KillSwitchNG import KillSwitchNG
 
         k = KillSwitchNG()
         k.SetGlobalState(state)
 
+    @dbus.service.method('org.blueman.Mechanism', in_signature="", out_signature="")
     def DevRfkillChmod(self):
         try:
             os.chmod("/dev/rfkill", 0o655)


### PR DESCRIPTION
* Use the standard dbus-python decorators to add decorated methods to the plugin classes.
* When initializing the plugin class create wrappers for all dbus methods and copy the dbus attributes from the original methods.
* No more `exec` and similar magic is involved anymore. (References #168)
* Re-run `dbus.service.InterfaceType.__init__` to refresh the internal dbus class table instead of modifying it directly. (References #161)