### PR TITLE
Add blueman-report

### DIFF
--- a/apps/blueman-report
+++ b/apps/blueman-report
@@ -6,9 +6,15 @@ import signal
 import subprocess
 import time
 from threading import Thread, Lock
-import urllib2
 from blueman.Constants import VERSION
 from blueman.Functions import get_lockfile, get_pid, is_running
+
+import sys
+if sys.version_info.major == 2:
+    input = raw_input
+    import urllib2
+else:
+    import urllib.request as urllib2
 
 for program in 'adapters', 'applet', 'manager', 'services':
     name = 'blueman-' + program
@@ -33,7 +39,7 @@ def copy_output():
     for line in iter(applet.stdout.readline, b''):
         lock.acquire()
         lines += 1
-        log += line
+        log += line.decode('UTF-8')
         lock.release()
 
 t = Thread(target=copy_output)
@@ -41,7 +47,7 @@ t.daemon = True
 t.start()
 
 while True:
-    action = raw_input('Describe your next action (keep empty if done): ')
+    action = input('Describe your next action (keep empty if done): ')
     if not action:
         break
     lock.acquire()
@@ -55,8 +61,8 @@ while True:
 lock.acquire()
 
 data = json.dumps({'files': {'log': {'content': log}}})
-
-url = json.loads(urllib2.urlopen('https://api.github.com/gists', data).read())['html_url']
+response = urllib2.urlopen('https://api.github.com/gists', data.encode('UTF-8')).read()
+url = json.loads(response.decode('UTF-8'))['html_url']
 
 print("")
 print("=====================================")
@@ -66,7 +72,8 @@ print("")
 print("=====================================")
 print("")
 print("blueman: " + VERSION)
-print("BlueZ: " + subprocess.Popen(['/usr/sbin/bluetoothd', '-v'], stdout=subprocess.PIPE).stdout.read()[:-1])
+v = subprocess.Popen(['/usr/sbin/bluetoothd', '-v'], stdout=subprocess.PIPE).stdout.read().decode('UTF-8')[:-1]
+print("BlueZ: " + v)
 print("Distribution: ")
 print("Desktop: " + os.environ.get('XDG_CURRENT_DESKTOP'))
 print("")

--- a/apps/blueman-report
+++ b/apps/blueman-report
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+
+import json
+import os
+import signal
+import subprocess
+import time
+from threading import Thread, Lock
+import urllib2
+from blueman.Constants import VERSION
+from blueman.Functions import get_lockfile, get_pid, is_running
+
+for program in 'adapters', 'applet', 'manager', 'services':
+    name = 'blueman-' + program
+    lockfile = get_lockfile(name)
+
+    if os.path.exists(lockfile):
+        pid = get_pid(lockfile)
+        if pid and is_running(name, pid):
+            print('Terminating ' + name)
+            os.kill(pid, signal.SIGTERM)
+
+applet = subprocess.Popen(['blueman-applet'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+log = ''
+actions = []
+lines = 0
+lock = Lock()
+
+
+def copy_output():
+    global lines, log
+    for line in iter(applet.stdout.readline, b''):
+        lock.acquire()
+        lines += 1
+        log += line
+        lock.release()
+
+t = Thread(target=copy_output)
+t.daemon = True
+t.start()
+
+while True:
+    action = raw_input('Describe your next action (keep empty if done): ')
+    if not action:
+        break
+    lock.acquire()
+    lines += 1
+    log += "DEBUG ACTION: " + action + "\n"
+    lock.release()
+    actions.append((lines, action))
+    print('Perform the described action')
+    time.sleep(5)
+
+lock.acquire()
+
+data = json.dumps({'files': {'log': {'content': log}}})
+
+url = json.loads(urllib2.urlopen('https://api.github.com/gists', data).read())['html_url']
+
+print("")
+print("=====================================")
+print("")
+print("Use this data in your report:")
+print("")
+print("=====================================")
+print("")
+print("blueman: " + VERSION)
+print("BlueZ: " + subprocess.Popen(['/usr/sbin/bluetoothd', '-v'], stdout=subprocess.PIPE).stdout.read()[:-1])
+print("Distribution: ")
+print("Desktop: " + os.environ.get('XDG_CURRENT_DESKTOP'))
+print("")
+for line, action in actions:
+    print(url + '#file-log-L' + str(line) + " " + action)


### PR DESCRIPTION
As I always get to the same process and problems when trying to get behind reporters' issues, I've hacked together a small report script that

* starts a new blueman-applet,
* asks the user what actions he takes,
* uploads the log to GitHub,
* and provides a template with essential data for the bug report.

Sample output:

> Describe your next action (keep empty if done): Open manager window
> Perform the described action
> Describe your next action (keep empty if done): Close manager window
> Perform the described action
> Describe your next action (keep empty if done): 
> 
> =====================================
> 
> Use this data in your report:
> 
> =====================================
> 
> blueman: 1.99.alpha1
> BlueZ: 5.23
> Distribution: 
> Desktop: XFCE
> 
> https://gist.github.com/6c4fbdd2435520bb846f#file-log-L141 Open manager window
> https://gist.github.com/6c4fbdd2435520bb846f#file-log-L251 Close manager window

It currently only targets python 2 due to the use of urllib2 (vs. urllib.request) and raw_input (vs. input).