### PR TITLE
data: Do not translate polkit vendor

### DIFF
--- a/data/configs/org.blueman.policy.in
+++ b/data/configs/org.blueman.policy.in
@@ -3,7 +3,7 @@
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 <policyconfig>
-  <_vendor>The Blueman Project</_vendor>
+  <vendor>The Blueman Project</vendor>
   <vendor_url>https://github.com/blueman-project/blueman</vendor_url>
   <icon_name>blueman</icon_name>
   


### PR DESCRIPTION
polkit does not support this and outputs warnings about unrecognised
<vendor> elements in the .policy file.