### PR TITLE
Fix Audio modules import and Recent Connections labels

### DIFF
--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -308,7 +308,7 @@ class RecentConns(AppletPlugin, Gtk.Menu):
             mitem.props.sensitive = True
             mitem.props.tooltip_text = None
 
-        item["mitem"].props.label = (_("%(service)s on %(device)s") % {"service": item["name"], "device": item["alias"]})
+        item["mitem"].get_child().get_children()[1].set_markup_with_mnemonic( _("%(service)s on %(device)s") % {"service": name, "device": item["alias"]})
 
         if item["adapter"] not in self.Adapters.values():
             if item["device"] and item["gsignal"]:

--- a/blueman/plugins/manager/PulseAudioProfile.py
+++ b/blueman/plugins/manager/PulseAudioProfile.py
@@ -9,7 +9,7 @@ from blueman.gui.MessageArea import MessageArea
 from blueman.Functions import get_icon, create_menuitem
 
 from gi.repository import Gtk
-from blueman.services import Audio
+from blueman.services import AudioSink, AudioSource, Headset, Handsfree
 
 
 class PulseAudioProfile(ManagerPlugin):


### PR DESCRIPTION
After 0aa9344099f0031aef6eba0a059c9cd8fe9303d9 there's no sense in settings props.label.
There are more, I guess, to be fixed, but you guys seems to know more about that than I do.