### PR TITLE
Allow to reset alias to the device name

### DIFF
--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -346,6 +346,8 @@ class ManagerDeviceMenu(Gtk.Menu):
                 def on_response(dialog, response_id):
                     if response_id == Gtk.ResponseType.ACCEPT:
                         device.set('Alias', alias_entry.get_text())
+                    elif response_id == 1:
+                        device.set('Alias', '')
                     dialog.destroy()
 
                 builder = Gtk.Builder()

--- a/data/ui/rename-device.ui
+++ b/data/ui/rename-device.ui
@@ -29,6 +29,18 @@
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>
+              <object class="GtkButton" id="reset">
+                <property name="label">_Reset</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="reject">
                 <property name="label">_Cancel</property>
                 <property name="visible">True</property>
@@ -37,7 +49,7 @@
                 <property name="use_underline">True</property>
               </object>
               <packing>
-                <property name="position">0</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -51,7 +63,7 @@
                 <property name="use_underline">True</property>
               </object>
               <packing>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
@@ -64,6 +76,7 @@
       </object>
     </child>
     <action-widgets>
+      <action-widget response="1">reset</action-widget>
       <action-widget response="-2">reject</action-widget>
       <action-widget response="-3">accept</action-widget>
     </action-widgets>


### PR DESCRIPTION
After renaming the device there is no way to reset it back to it's default. I opted to add a reset button which sets the ``Alias`` to the ``Name`` of the device.

Another option is to have a button that sets ``device.Name`` in the ``GtkEntry`` text. Or something else you may prefer over either of these two.