### PR TITLE
Change agent capability to KeyboardDisplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [ui] Button to reset device alias
+* [bluez] Agent capability KeyboardDisplay (@kemnade-uni / Andreas Kemnade)
 
 ### Bugs fixed
 

--- a/blueman/plugins/applet/AuthAgent.py
+++ b/blueman/plugins/applet/AuthAgent.py
@@ -61,11 +61,11 @@ class AuthAgent(AppletPlugin):
             if self.legacy():
                 agent = BluezAgent.AdapterAgent(self.Applet.Plugins.StatusIcon, adapter, self.get_event_time)
                 agent.signal = agent.connect("released", self.on_released)
-                adapter.register_agent(agent, "DisplayYesNo")
+                adapter.register_agent(agent, "KeyboardDisplay")
                 self.agents.append(agent)
             elif not self.agents:
                 agent = BluezAgent.GlobalAgent(self.Applet.Plugins.StatusIcon, self.get_event_time)
-                self.agent_manager.register_agent(agent, "DisplayYesNo", default=True)
+                self.agent_manager.register_agent(agent, "KeyboardDisplay", default=True)
                 self.agents.append(agent)
 
         except Exception as e:

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -128,7 +128,7 @@ class DBusService(AppletPlugin):
             if pair:
                 agent_path = "/org/blueman/agent/temp/" + address.replace(":", "")
                 agent = TempAgent(self.Applet.Plugins.StatusIcon, agent_path, time)
-                adapter.create_paired_device(address, agent_path, "DisplayYesNo", error_handler=err,
+                adapter.create_paired_device(address, agent_path, "KeyboardDisplay", error_handler=err,
                                              reply_handler=ok, timeout=120)
 
             else:


### PR DESCRIPTION
@kemnade-uni discovered in [Debian #780776](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=780776#15) that agents get registered with capability DisplayYesNo while it should be KeyboardDisplay.

I wonder why we never had issues with any device reported before because of this and I'm unsure about the implications here, so a couple of testers would be nice. Just comment if pairing your devices behaves as before or if it changes with this and include your BlueZ major version (4 or 5 or both).