### PR TITLE
Add configuration option to force notification fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [ui] Button to reset device alias
 * [bluez] Agent capability KeyboardDisplay (@kemnade-uni / Andreas Kemnade)
+* New configuration option to disable the use of a notification daemon
 
 ### Bugs fixed
 

--- a/apps/blueman-applet
+++ b/apps/blueman-applet
@@ -45,7 +45,7 @@ class BluemanApplet(object):
     def __init__(self):
         setup_icon_path()
         if not Notify.init("Blueman"):
-            dprint("Error: Failed to init pynotify")
+            dprint("Error: Failed to initialize libnotify")
 
         check_single_instance("blueman-applet")
 

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -55,6 +55,11 @@
       <summary>List of devices we have netusage data stored.</summary>
       <description></description>
     </key>
+    <key type="b" name="notification-daemon">
+      <default>true</default>
+      <summary>Use notification daemon</summary>
+      <description>If this is set to false blueman always uses its internal fallback notification dialog and does not invoke a notification daemon. Otherwise the fallback dialog will only be used if actions need to be displayed and the notification daemon does not report to support them.</description>
+    </key>
   </schema>
   <schema id="org.blueman.gsmsettings" path="/org/blueman/gsmsettings/">
   </schema>


### PR DESCRIPTION
~~Using --disable-notification-daemon~~ the user can now choose not to use a notification-daemon at all. Previously the fallback GTK+ notifications were only used if we had to show actions, but the daemon did not report to support them.
Additional changes:

* Fix error message when libnotify cannot be initialized (it is no longer pynotify)
* ~~Fix blueman.Constants.POLKIT (was always false since 1954e2d3ffbc79a0cf696c7fe12bca431d34d368)~~
* Fix issue from GTK+ 3 transition in NotificationDialog (window vs. get_window())

Closes #245
Closes #246