### PR TITLE
Implement auto power-on for adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [sendto] Removed nautilus-sendto plugin (deprecated and broken)
 * [nm] Use API instead of GConf to create new connections
 * [nm] Enable IPv6 on created connections
+* [bluez] Auto power on adapters; can be disabled in PowerManager settings
 
 ### Bugs fixed
 

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -130,6 +130,13 @@
       <description></description>
     </key>
   </schema>
+  <schema id="org.blueman.plugins.powermanager" path="/org/blueman/plugins/powermanager/">
+    <key type="b" name="auto-power-on">
+        <default>true</default>
+        <summary>Automatically power on adapters</summary>
+        <description></description>
+    </key>
+  </schema>
   <schema id="org.blueman.plugins.recentconns" path="/org/blueman/plugins/recentconns/">
     <key type="i" name="max-items">
       <default>6</default>


### PR DESCRIPTION
In case adapters are not powered, we power them on automatically now. This can be disabled by a new PowerManager setting if not wanted.

Closes #249 