### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 script:
   - ./autogen.sh
-  - make check
   - make
+  - make check
   - cd po && intltool-update -m && [ ! -f missing ]
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+script:
+  - ./autogen.sh
+  - make check
+  - make
+
+env:
+  - PYTHON=python2.7
+  - PYTHON=python3.2
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq automake autoconf libglib2.0-dev libtool libgtk-3-dev libstartup-notification0-dev python-gi-dev libbluetooth-dev intltool python-dev python3-dev cython python-dbus python3-dbus dh-autoreconf

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ script:
   - ./autogen.sh
   - make check
   - make
+  - cd po && intltool-update -m && [ ! -f missing ]
 
 env:
   - PYTHON=python2.7

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ(2.69)
+AC_PREREQ(2.61)
 
 AC_INIT([blueman], [1.99.alpha2], [https://github.com/blueman-project/blueman/issues])
 AC_CONFIG_HEADERS(config.h)


### PR DESCRIPTION
I've set up a travis configuration for blueman. It currently basically just ensures that the build succeeds, but I want to add analysis as discussed in #251 and tests (#43; a very first step for testing would be to just start our apps and see if the keep running for a couple if seconds before killing them).

I did not manage to get Python 3.3 and 3.4 passing on travis yet. When setting the PYTHON variable it gives `checking whether python3.3 version >= 2.7... configure: error: too old` which I guess means the name python3.3 is not available (or just some dummy script). Using `language: python` and the python instead of the env matrix I couldn't get ./configure to find python-dbus, neither for Python 2, nor 3.