### PR TITLE
PulseAudio python3 support

### DIFF
--- a/blueman/main/PulseAudioUtils.py
+++ b/blueman/main/PulseAudioUtils.py
@@ -548,7 +548,7 @@ class PulseAudioUtils(GObject.GObject):
         self.__init_list_callback(pa_context_get_card_info_list,
                                   pa_card_info_cb_t, handler)
 
-    def GetCard(self, id, callback):
+    def GetCard(self, card, callback):
         self.check_connected()
 
         def handler(entry_info, end):
@@ -557,21 +557,21 @@ class PulseAudioUtils(GObject.GObject):
 
             callback(self.__card_info(entry_info))
 
-        if type(id) == str:
+        if type(card) == str:
             fn = pa_context_get_card_info_by_name
         else:
             fn = pa_context_get_card_info_by_index
 
         self.__init_list_callback(fn,
-                                  pa_card_info_cb_t, handler, id)
+                                  pa_card_info_cb_t, handler, card)
 
-    def SetCardProfile(self, card_id, profile, callback):
-        if type(card_id) == str:
+    def SetCardProfile(self, card, profile, callback):
+        if type(card) == str:
             fn = pa_context_set_card_profile_by_name
         else:
             fn = pa_context_set_card_profile_by_index
 
-        self.simple_callback(callback, fn, card_id, profile)
+        self.simple_callback(callback, fn, card, profile)
 
     #### Module API #######
     #from gi.repository import Gtk

--- a/blueman/plugins/manager/PulseAudioProfile.py
+++ b/blueman/plugins/manager/PulseAudioProfile.py
@@ -45,7 +45,11 @@ class PulseAudioProfile(ManagerPlugin):
         dprint(event, idx)
 
         def get_card_cb(card):
-            if card["driver"] == "module-bluetooth-device.c":
+            drivers = ("module-bluetooth-device.c",
+                       "module-bluez4-device.c",
+                       "module-bluez5-device.c")
+
+            if card["driver"] in drivers:
                 self.devices[card["proplist"]["device.string"]] = card
                 self.regenerate_with_device(card["proplist"]["device.string"])
 


### PR DESCRIPTION
I saw this was broken under python3 and made it work on par with current master. Except for the signal bars not showing under python3. But.... the ui has some problems in master __and__ my python3 branch with __both__ python versions.

What I see is that the menus get confused in that the ```active_profile``` in the menus do not correspond to the actual profile selected. The device menu works better than the right click one.

Work in progress still but my eyes can not handle more for today.