### PR TITLE
Gtk, GLib, Gio and Gthread are runtime only deps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [nm] Enable IPv6 on created connections
 * Use GAppInfo to launch applications
 * [bluez] Auto power on adapters; can be disabled in PowerManager settings
+* Remove Gtk+, GLib and Gio as build time dependancies.
 
 ### Bugs fixed
 

--- a/configure.ac
+++ b/configure.ac
@@ -156,11 +156,7 @@ if test "x$HAVE_GNOME_ICONS" = "xno" && test "x$HAVE_MATE_ICONS" = "xno" && test
 	AC_MSG_ERROR([Required icon themes not found.])
 fi
 
-PKG_CHECK_MODULES([PYGOBJECT],
-                  [pygobject-2.0 >= 2.12],
-                  [],
-                  [PKG_CHECK_MODULES([PYGOBJECT], [pygobject-3.0])]
-)
+PKG_CHECK_MODULES([PYGOBJECT],[pygobject-3.0])
 AC_SUBST([PYGOBJECT_CFLAGS])
 AC_SUBST([PYGOBJECT_LIBS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -138,12 +138,7 @@ if test "x$enable_runtime_deps_check" = "xyes"; then
 AM_CHECK_PYMOD([dbus],,,[AC_MSG_ERROR(Could not find Python module dbus)])
 fi
 
-PKG_CHECK_MODULES([BLUEZ],
-		  [bluez >= 4.61
-		  gtk+-3.0
-		  glib-2.0 >= 2.32
-		  gio-2.0 >= 2.32
-		  gthread-2.0 >= 2.32])
+PKG_CHECK_MODULES([BLUEZ], [bluez >= 4.61 gthread-2.0 >= 2.32])
 
 AC_SUBST([BLUEZ_CFLAGS])
 AC_SUBST([BLUEZ_LIBS])


### PR DESCRIPTION
The PR to start a quick discussion :smile:.

There is nothing in libblueman or _blueman.pyx that requires the above mentioned libs at build time and should only be available at runtime. And the runtime deps are the introspection (gir/typelib) files not the -dev packages with the pkg-config and header files.

We could print a nice warning at the end of configure to alert the maintainer to make sure the introspection files are added as build deps. Or something else?