### PR TITLE
Set a process title for the blueman apps

### DIFF
--- a/apps/blueman-adapters
+++ b/apps/blueman-adapters
@@ -19,7 +19,7 @@ if os.path.exists(os.path.join(_dirname, "CHANGELOG.md")):
 
 import blueman.bluez as Bluez
 from blueman.Constants import *
-from blueman.Functions import setup_icon_path, enable_rgba_colormap, check_single_instance, check_bluetooth_status
+from blueman.Functions import *
 from blueman.main.SignalTracker import SignalTracker
 
 enable_rgba_colormap()
@@ -231,6 +231,7 @@ class BluemanAdapters:
 
 
 if __name__ == '__main__':
+    set_proc_title()
     adapter_name = None
     if len(sys.argv) > 1:
         adapter_name = sys.argv[1]

--- a/apps/blueman-applet
+++ b/apps/blueman-applet
@@ -116,4 +116,5 @@ class BluemanApplet(object):
         self.Plugins.Run("on_adapter_removed", path)
 
 
+set_proc_title()
 BluemanApplet()

--- a/apps/blueman-assistant
+++ b/apps/blueman-assistant
@@ -307,4 +307,5 @@ class Assistant:
                                         reply_handler=success, error_handler=fail)
 
 
+set_proc_title()
 Assistant()

--- a/apps/blueman-browse
+++ b/apps/blueman-browse
@@ -83,4 +83,5 @@ class Browse:
             return None
 
 
+set_proc_title()
 Browse()

--- a/apps/blueman-manager
+++ b/apps/blueman-manager
@@ -275,4 +275,5 @@ class Blueman:
         applet.DisconnectDevice(device.get_object_path(), *args, **kwargs)
 
 
+set_proc_title()
 Blueman()

--- a/apps/blueman-mechanism
+++ b/apps/blueman-mechanism
@@ -28,6 +28,7 @@ loop = GObject.MainLoop()
 
 from blueman.Lib import set_probe_debug
 from blueman.Constants import POLKIT
+from blueman.Functions import set_proc_title
 
 import blueman.plugins.mechanism
 from blueman.plugins.MechanismPlugin import MechanismPlugin
@@ -161,6 +162,7 @@ class conf_service(DbusService):
             raise dbus.DBusException("Not authorized")
 
 
+set_proc_title()
 conf_service()
 loop.run()
 

--- a/apps/blueman-rfcomm-watcher
+++ b/apps/blueman-rfcomm-watcher
@@ -10,6 +10,7 @@ from gi.repository import GLib
 import os
 import sys
 
+from blueman.Functions import set_proc_title
 
 def on_file_changed(monitor, file, other_file, event_type):
     if event_type == Gio.FileMonitorEvent.DELETED:
@@ -20,5 +21,6 @@ mon.connect('changed', on_file_changed)
 
 fd = os.open(sys.argv[1], os.O_RDONLY | os.O_NONBLOCK)
 
+set_proc_title()
 loop = GLib.MainLoop()
 loop.run()

--- a/apps/blueman-sendto
+++ b/apps/blueman-sendto
@@ -388,4 +388,5 @@ class SendTo:
             return False
 
 
+set_proc_title()
 SendTo()

--- a/apps/blueman-services
+++ b/apps/blueman-services
@@ -165,4 +165,5 @@ class BluemanServices:
         self.set_page(id)
 
 
+set_proc_title()
 BluemanServices()

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -35,6 +35,7 @@ import os
 import signal
 import atexit
 import sys
+from ctypes import cdll, byref, create_string_buffer
 from subprocess import Popen
 from gi.repository import GObject
 import traceback
@@ -371,3 +372,19 @@ def mask_ip4_address(ip, subnet):
         masked_ip.append(x & y)
 
     return bytes(masked_ip)
+
+def set_proc_title(name=None):
+    '''Set the process title'''
+
+    if not name:
+        name = os.path.basename(sys.argv[0])
+
+    libc = cdll.LoadLibrary('libc.so.6')
+    buff = create_string_buffer(len(name)+1)
+    buff.value = name.encode("UTF-8")
+    ret = libc.prctl(15, byref(buff), 0, 0, 0)
+
+    if ret != 0:
+        dprint("Failed to set process title")
+
+    return ret


### PR DESCRIPTION
I was getting sick of trying to figure out which python process was blueman-manager, applet etc etc.

It makes use of the c module setproctitle but one could also use ctypes and call into libc directly. Although it uses a 3rd party module it made more sense to me than reinventing the wheel with libc+ctypes.

Opinions?