### PR TITLE
Add plugins button to View menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [bluez] Auto power on adapters; can be disabled in PowerManager settings
 * Remove Gtk+, GLib and Gio as build time dependencies
 * [obex] Migrate receiving files from obex-data-server to obexd
+* [ui] Plugins and local services items in manager's View menu
 
 ### Bugs fixed
 

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -84,6 +84,21 @@ class ManagerMenu:
         itemf.connect("activate", lambda x: self.blueman.Config.set_boolean("latest-last", not x.props.active))
         iteml.connect("activate", lambda x: self.blueman.Config.set_boolean("latest-last", x.props.active))
 
+        item = Gtk.SeparatorMenuItem()
+        view_menu.append(item)
+        item.show()
+
+        item = create_menuitem(_("Plugins"), get_icon('blueman-plugin', 16))
+        item.connect('activate', lambda *args: self.blueman.Applet.open_plugin_dialog())
+        view_menu.append(item)
+        item.show()
+
+        item = create_menuitem(_("_Local Services") + "...", get_icon("preferences-desktop", 16))
+        item.connect('activate',
+                     lambda *args: launch("blueman-services", None, False, "blueman", _("Service Preferences")))
+        view_menu.append(item)
+        item.show()
+
         self.item_adapter.show()
         self.item_view.show()
         self.item_help.show()

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -153,6 +153,10 @@ class DBusService(AppletPlugin):
         else:
             err()
 
+    @dbus.service.method('org.blueman.Applet')
+    def open_plugin_dialog(self):
+        self.Applet.Plugins.StandardItems.on_plugins(None)
+
     def rfcomm_connect_handler(self, service, reply_handler, error_handler):
         return False
 


### PR DESCRIPTION
Allows to open plugins dialog without using the applet.

Closes #264
Closes #282