### PR TITLE
resolve spacing issue in bluez/Manager

### DIFF
--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -23,7 +23,7 @@ class Manager(PropertiesBase):
 
         super(Manager, self).__init__('org.freedesktop.DBus.ObjectManager', '/')
         self._handle_signal(self._on_interfaces_added, 'InterfacesAdded')
-            self._handle_signal(self._on_interfaces_removed, 'InterfacesRemoved')
+        self._handle_signal(self._on_interfaces_removed, 'InterfacesRemoved')
 
     def _on_adapter_added(self, adapter_path):
         dprint(adapter_path)


### PR DESCRIPTION
This may just be a typo, but Python (3.4.3) is throwing an error at the extra indentation here