### PR TITLE
Fix non-standard icon names

### DIFF
--- a/blueman/services/Input.py
+++ b/blueman/services/Input.py
@@ -9,5 +9,5 @@ from blueman.Sdp import HID_SVCLASS_ID
 
 class Input(Service):
     __svclass_id__ = HID_SVCLASS_ID
-    __icon__ = "mouse"
+    __icon__ = "input-mouse"
     __priority__ = 1

--- a/data/ui/device-list-widget.ui
+++ b/data/ui/device-list-widget.ui
@@ -39,7 +39,7 @@
             <child>
               <object class="GtkImage" id="image1">
                 <property name="visible">True</property>
-                <property name="icon-name">gtk-find</property>
+                <property name="icon-name">edit-find</property>
                 <property name="icon-size">4</property>
               </object>
             </child>


### PR DESCRIPTION
This makes Blueman compatible with the Adwaita icon theme, which is the default theme in GTK+ 3.