### PR TITLE
Always set codeset for gettext to utf8

### DIFF
--- a/apps/blueman-adapters
+++ b/apps/blueman-adapters
@@ -11,6 +11,7 @@ from gi.repository import Pango
 import os.path
 import sys
 import signal
+from locale import bind_textdomain_codeset
 
 #support running uninstalled
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -40,6 +41,7 @@ class BluemanAdapters:
 
         builder = Gtk.Builder()
         builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         builder.add_from_file(UI_PATH + "/adapters.ui")
         self.dialog = builder.get_object("dialog")
 

--- a/apps/blueman-assistant
+++ b/apps/blueman-assistant
@@ -19,6 +19,7 @@ import os
 import sys
 import signal
 from optparse import OptionParser
+from locale import bind_textdomain_codeset
 
 #support running uninstalled
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -60,6 +61,7 @@ class Assistant:
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/assistant.ui")
         self.assistant = self.Builder.get_object("assistant")
         self.assistant.set_title(_("Bluetooth Assistant"))

--- a/apps/blueman-manager
+++ b/apps/blueman-manager
@@ -14,6 +14,7 @@ from blueman.Constants import *
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
+from locale import bind_textdomain_codeset
 
 #support running uninstalled
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -47,6 +48,7 @@ class Blueman:
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/manager-main.ui")
 
         self.window = self.Builder.get_object("window")

--- a/apps/blueman-sendto
+++ b/apps/blueman-sendto
@@ -17,6 +17,7 @@ from optparse import OptionParser
 import gettext
 import urllib
 import time
+from locale import bind_textdomain_codeset
 
 from blueman.Constants import *
 import gi
@@ -52,6 +53,7 @@ class Sender(GObject.GObject):
         GObject.GObject.__init__(self)
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/send-dialog.ui")
         self.window = self.Builder.get_object("window")
 

--- a/apps/blueman-services
+++ b/apps/blueman-services
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 import os
 import sys
+from locale import bind_textdomain_codeset
 #support running uninstalled
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if os.path.exists(os.path.join(_dirname, "CHANGELOG.md")):
@@ -35,6 +36,7 @@ class BluemanServices:
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/services.ui")
 
         self.Config = Config("org.blueman.general")

--- a/blueman/gui/GsmSettings.py
+++ b/blueman/gui/GsmSettings.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from locale import bind_textdomain_codeset
+
 from blueman.main.Config import Config
 from blueman.Functions import *
 from blueman.Constants import *
@@ -20,6 +22,7 @@ class GsmSettings(Gtk.Dialog):
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/gsm-settings.ui")
 
         vbox = self.Builder.get_object("vbox1")

--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from locale import bind_textdomain_codeset
+
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
@@ -105,6 +107,7 @@ class PluginDialog(Gtk.Dialog):
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/applet-plugins-widget.ui")
 
         self.set_title(_("Plugins"))

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from locale import bind_textdomain_codeset
 from operator import itemgetter
 from blueman.Sdp import uuid128_to_uuid16, SERIAL_PORT_SVCLASS_ID, OBEX_OBJPUSH_SVCLASS_ID, OBEX_FILETRANS_SVCLASS_ID
 from blueman.Functions import *
@@ -312,6 +313,7 @@ class ManagerDeviceMenu(Gtk.Menu):
 
             builder = Gtk.Builder()
             builder.set_translation_domain("blueman")
+            bind_textdomain_codeset("blueman", "UTF-8")
             builder.add_from_file(UI_PATH + "/rename-device.ui")
             dialog = builder.get_object("dialog")
             dialog.set_transient_for(self.Blueman.window)

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import dbus
 from dbus.mainloop.glib import DBusGMainLoop
 import dbus.service
+from locale import bind_textdomain_codeset
 from blueman.Functions import get_icon, dprint
 
 import gi
@@ -68,6 +69,7 @@ class BluezAgent(_GObjectAgent, Agent, GObject.GObject):
         builder = Gtk.Builder()
         builder.add_from_file(UI_PATH + "/applet-passkey.ui")
         builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         dialog = builder.get_object("dialog")
 
         dialog.props.icon_name = "blueman"

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -24,7 +24,7 @@ import dbus
 import time
 import datetime
 import gettext
-
+from locale import bind_textdomain_codeset
 
 class MonitorBase(GObject.GObject):
     __gsignals__ = {
@@ -135,6 +135,7 @@ class Dialog:
         builder = Gtk.Builder()
         builder.add_from_file(UI_PATH + "/net-usage.ui")
         builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
 
         self.dialog = builder.get_object("dialog")
         self.dialog.connect("response", self.on_response)

--- a/blueman/plugins/services/Network.py
+++ b/blueman/plugins/services/Network.py
@@ -18,6 +18,7 @@ from blueman.main.Mechanism import Mechanism
 from blueman.main.AppletService import AppletService
 from blueman.gui.Dialogs import NetworkErrorDialog
 from random import randint
+from locale import bind_textdomain_codeset
 
 
 class Network(ServicePlugin):
@@ -27,6 +28,7 @@ class Network(ServicePlugin):
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/services-network.ui")
         self.widget = self.Builder.get_object("network")
 

--- a/blueman/plugins/services/Transfer.py
+++ b/blueman/plugins/services/Transfer.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from locale import bind_textdomain_codeset
+
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
@@ -21,6 +23,7 @@ class Transfer(ServicePlugin):
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
+        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/services-transfer.ui")
         self.widget = self.Builder.get_object("transfer")
 


### PR DESCRIPTION
We had a [bug report](https://bugs.gentoo.org/show_bug.cgi?id=414871) that blueman crashes when non-utf8 locale is used on the system. It seems that setting codeset for gettext fixes that.