### PR TITLE
Fix TypeError in Gio.Settings.__init__()

### DIFF
--- a/apps/blueman-manager
+++ b/apps/blueman-manager
@@ -63,7 +63,7 @@ class Blueman:
         if self.window.get_has_resize_grip():
             statusbar = self.Builder.get_object("statusbar")
             margin_right = statusbar.get_margin_right()
-            statusbar.set_margin_right (margin_right +  10)
+            statusbar.set_margin_right (margin_right + 10)
 
         def do_present(time):
             if self.window.props.visible:

--- a/blueman/main/Config.py
+++ b/blueman/main/Config.py
@@ -6,8 +6,8 @@ from __future__ import unicode_literals
 from gi.repository import Gio
 
 class Config(Gio.Settings):
-    def __init__(self, schema_id, path=None):
-        Gio.Settings.__init__(self, schema_id=schema_id, path=path)
+    def __init__(self, schema_id, path=None, **kwargs):
+        Gio.Settings.__init__(self, schema=schema_id, path=path, **kwargs)
 
     def bind_to_widget(self, key, widget, prop, flags=Gio.SettingsBindFlags.DEFAULT):
         self.bind(key, widget, prop, flags)


### PR DESCRIPTION
Hi folks,
I have that error after e657a16d10,  when tried to start blueman-applet:
```
$ blueman-applet 
blueman-applet version 2.0 starting
Traceback (most recent call last):
  File "/usr/bin/blueman-applet", line 112, in <module>
    BluemanApplet()
  File "/usr/bin/blueman-applet", line 56, in __init__
    self.Plugins = PersistentPluginManager(AppletPlugin, blueman.plugins.applet, self)
  File "/usr/lib64/python2.7/site-packages/blueman/main/PluginManager.py", line 247, in __init__
    self.__config = Config("org.blueman.general")
  File "/usr/lib64/python2.7/site-packages/blueman/main/Config.py", line 10, in __init__
    Gio.Settings.__init__(self, schema_id=schema_id, path=path)
TypeError: __init__() takes at least 2 arguments (2 given)
```
If I'll fixed it, I now have an error, but that is:
```
Traceback (most recent call last):
  File "/usr/bin/blueman-manager", line 226, in <module>
    Blueman()
  File "/usr/bin/blueman-manager", line 65, in __init__
    top, bottom, left, right = align3.get_padding()
AttributeError: 'NoneType' object has no attribute 'get_padding'
```
Because data/ui/manager-main.ui does not explained the "alignment3" object, should get_has_resize_grip() be removed?