### PR TITLE
RfKill: open /dev/rfkill r+b to avoid creating

### DIFF
--- a/blueman/plugins/mechanism/RfKill.py
+++ b/blueman/plugins/mechanism/RfKill.py
@@ -12,6 +12,6 @@ from blueman.plugins.applet.KillSwitch import RFKILL_TYPE_BLUETOOTH, RFKILL_OP_C
 class RfKill(MechanismPlugin):
     @dbus.service.method('org.blueman.Mechanism', in_signature="b", out_signature="")
     def SetRfkillState(self, state):
-        f = open('/dev/rfkill', 'wb')
+        f = open('/dev/rfkill', 'r+b')
         f.write(struct.pack("IBBBB", 0, RFKILL_TYPE_BLUETOOTH, RFKILL_OP_CHANGE_ALL, (0 if state else 1), 0))
         f.close()


### PR DESCRIPTION
Open /dev/rfkill in r+b mode rather than wb since the latter creates the
file if it does not exist. And we certainly can not create /dev/rfkill
as a regular file since this is never going to work and is going to
break a lot of other programs that assume /dev/rfkill is a valid device
node.

Fixes: https://github.com/blueman-project/blueman/issues/333