### PR TITLE
Handle when rfkill subsystem is not available gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Codepoint issues when connecting to serial service
 * Infinite loop if RecentConns has only invalid items
 * Unblock rfkill in Python 3
+* Do not load RfKill plugins when device is not available.
 
 ## 2.0
 

--- a/apps/blueman-mechanism
+++ b/apps/blueman-mechanism
@@ -137,7 +137,7 @@ class conf_service(DbusService):
             try:
                 __import__("blueman.plugins.mechanism.%s" % plugin, None, None, [])
             except ImportError as e:
-                dprint("Skipping plugin %s\n%s" % (plugin, e))
+                dprint("Skipping plugin %s: %s" % (plugin, e))
 
         classes = MechanismPlugin.__subclasses__()
         for cls in classes:

--- a/blueman/plugins/mechanism/RfKill.py
+++ b/blueman/plugins/mechanism/RfKill.py
@@ -4,10 +4,13 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import dbus.service
+import os
 import struct
 from blueman.plugins.MechanismPlugin import MechanismPlugin
 from blueman.plugins.applet.KillSwitch import RFKILL_TYPE_BLUETOOTH, RFKILL_OP_CHANGE_ALL
 
+if not os.path.exists('/dev/rfkill'):
+    raise ImportError("Hardware kill switch not found")
 
 class RfKill(MechanismPlugin):
     @dbus.service.method('org.blueman.Mechanism', in_signature="b", out_signature="")


### PR DESCRIPTION
This fixes #333

One "drawback" of not loading the KillSwitch applet plugin is that is not shown any-more in the plugin dialogue. I can have it raise something else than ImportError and it should show up again, not sure which is better...

Concerns or suggestions?