### PR TITLE
TransferService: Fix UnicodeDecodeError in on_transfer_completed

### DIFF
--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -207,6 +207,10 @@ class TransferService(AppletPlugin):
 
         src = attributes['path']
         dest_dir = self._config["shared-path"]
+        # We get bytes from pygobject under python 2.7
+        if hasattr(dest_dir, 'upper') and hasattr(dest_dir, 'decode'):
+    	    dest_dir = dest_dir.decode('UTF-8')
+    	
         filename = os.path.basename(src)
 
         if os.path.exists(os.path.join(dest_dir, filename)):


### PR DESCRIPTION
Hi folks,
After 78ffdde2 I upgraded my system to Slackware-current, (is actual on Wed Aug 12 05:50:41 UTC  2015), according to [ChangeLog](http://mirror.yandex.ru/slackware/slackware64-current/ChangeLog.txt). Now, I have a errors listed [here](http://pastebin.com/1Se9GJk7), when I tried to receive a file from my phone. One of these errors is now UnicodeDecodeError, and I fixed it. 