### PR TITLE
Add generic names for blueman.desktop and blueman-manager.desktop

### DIFF
--- a/data/blueman-manager.desktop.in
+++ b/data/blueman-manager.desktop.in
@@ -1,6 +1,7 @@
 [Desktop Entry]
 _Name=Bluetooth Manager
 _Comment=Blueman Bluetooth Manager
+_GenericName=Bluetooth Manager
 Icon=blueman
 Exec=blueman-manager
 Terminal=false

--- a/data/blueman.desktop.in
+++ b/data/blueman.desktop.in
@@ -1,6 +1,7 @@
 [Desktop Entry]
 _Name=Blueman Applet
 _Comment=Blueman Bluetooth Manager
+_GenericName=Bluetooth Manager
 Icon=blueman
 Exec=blueman-applet
 Terminal=false


### PR DESCRIPTION
Right now, application menus will use "Blueman Bluetooth Manager" for the GenericName, which is wrong