### PR TITLE
Add systemd system and user service units for the D-Bus services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ Makefile
 /stamp-h1
 /blueman/Constants.py
 /blueman/plugins/mechanism/Rfcomm.py
+/data/configs/blueman-applet.service
+/data/configs/blueman-mechanism.service
 /data/configs/org.blueman.Applet.service
 /data/configs/org.blueman.Mechanism.service
 /module/.deps

--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,8 @@ data/icons/main_icon/Makefile
 data/icons/pixmaps/Makefile
 data/ui/Makefile
 data/man/Makefile
+data/configs/blueman-applet.service
+data/configs/blueman-mechanism.service
 data/configs/org.blueman.Applet.service
 data/configs/org.blueman.Mechanism.service
 module/Makefile

--- a/data/configs/Makefile.am
+++ b/data/configs/Makefile.am
@@ -7,6 +7,12 @@ dbus_services_DATA = org.blueman.Mechanism.service
 dbus_sessdir = $(datadir)/dbus-1/services
 dbus_sess_DATA = org.blueman.Applet.service
 
+systemd_systemdir = $(prefix)/lib/systemd/system
+systemd_system_DATA = blueman-mechanism.service
+
+systemd_userdir = $(prefix)/lib/systemd/user
+systemd_user_DATA = blueman-applet.service
+
 if HAVE_POLKIT
 @INTLTOOL_POLICY_RULE@ 
 policykitdir = $(datadir)/polkit-1/actions
@@ -14,12 +20,17 @@ policykit_in_files = org.blueman.policy.in
 policykit_DATA = $(policykit_in_files:.policy.in=.policy)
 endif
 
-EXTRA_DIST = org.blueman.Mechanism.conf		\
+EXTRA_DIST = \
+	blueman-applet.service.in		\
+	blueman-mechanism.service.in		\
+	org.blueman.Mechanism.conf		\
 	org.blueman.Applet.service.in		\
 	org.blueman.Mechanism.service.in	\
 	org.blueman.policy.in
 
 CLEANFILES =		\
+	blueman-applet.service		\
+	blueman-mechanism.service	\
 	org.blueman.Mechanism.service	\
 	org.blueman.policy		\
 	org.blueman.Applet.service		\

--- a/data/configs/blueman-applet.service.in
+++ b/data/configs/blueman-applet.service.in
@@ -1,0 +1,7 @@
+[Unit]
+Description=Bluetooth management applet
+
+[Service]
+Type=dbus
+BusName=org.blueman.Applet
+ExecStart=@BINDIR@/blueman-applet

--- a/data/configs/blueman-mechanism.service.in
+++ b/data/configs/blueman-mechanism.service.in
@@ -1,0 +1,7 @@
+[Unit]
+Description=Bluetooth management mechanism
+
+[Service]
+Type=dbus
+BusName=org.blueman.Mechanism
+ExecStart=@LIBEXECDIR@/blueman-mechanism

--- a/data/configs/org.blueman.Applet.service.in
+++ b/data/configs/org.blueman.Applet.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.blueman.Applet
 Exec=@BINDIR@/blueman-applet
+SystemdService=blueman-applet.service

--- a/data/configs/org.blueman.Mechanism.service.in
+++ b/data/configs/org.blueman.Mechanism.service.in
@@ -2,3 +2,4 @@
 Name=org.blueman.Mechanism
 Exec=@LIBEXECDIR@/blueman-mechanism
 User=root
+SystemdService=blueman-mechanism.service


### PR DESCRIPTION
The D-Bus system service (the mechanism) becomes a systemd system
service, and the D-Bus session service (the applet) becomes a systemd
user service.

In both cases, when systemd is used for service activation, this allows
placing the blueman-related process in its own cgroup (and applying
systemd resource control and life-cycle tracking), whereas without
these units the blueman processes would be part of the
dbus.service cgroup.

dbus running under systemd has provided system service activation via
systemd for some time. User service activation via systemd is a
recent addition (D-Bus 1.10) and not always enabled, but installing
the necessary metadata is harmless in any case.