### PR TITLE
Migrate MessageArea from EventBox to InfoBar

### DIFF
--- a/blueman/gui/GtkAnimation.py
+++ b/blueman/gui/GtkAnimation.py
@@ -123,7 +123,7 @@ class TreeRowFade(AnimBase):
         super(TreeRowFade, self).__init__(1.0)
         self.tw = tw
 
-        self.sig = self.tw.connect_after("draw", self.on_expose)
+        self.sig = self.tw.connect_after("draw", self.on_draw)
 
         self.row = Gtk.TreeRowReference.new(tw.props.model, path)
         self.stylecontext = tw.get_style_context()
@@ -137,7 +137,7 @@ class TreeRowFade(AnimBase):
     def get_iter(self):
         return self.tw.props.model.get_iter(self.row.get_path())
 
-    def on_expose(self, widget, cr):
+    def on_draw(self, widget, cr):
         if self.frozen:
             return
 
@@ -178,7 +178,7 @@ class TreeRowColorFade(TreeRowFade):
     def do_animation_finished(self):
         self.unref()
 
-    def on_expose(self, widget, cr):
+    def on_draw(self, widget, cr):
         if self.frozen:
             return
 
@@ -209,7 +209,7 @@ class CellFade(AnimBase):
         self.tw = tw
 
         self.frozen = False
-        self.sig = tw.connect_after("draw", self.on_expose)
+        self.sig = tw.connect_after("draw", self.on_draw)
         self.row = Gtk.TreeRowReference.new(tw.props.model, path)
         self.selection = tw.get_selection()
         self.columns = []
@@ -224,7 +224,7 @@ class CellFade(AnimBase):
     def get_iter(self):
         return self.tw.props.model.get_iter(self.row.get_path())
 
-    def on_expose(self, widget, cr):
+    def on_draw(self, widget, cr):
         if self.frozen:
             return
 
@@ -273,9 +273,9 @@ class WidgetFade(AnimBase):
         self.widget = widget
         self.color = color
 
-        self.sig = widget.connect_after("draw", self.on_expose)
+        self.sig = widget.connect_after("draw", self.on_draw)
 
-    def on_expose(self, window, cr):
+    def on_draw(self, widget, cr):
         if not self.frozen:
             rect = self.widget.get_allocation()
             cr.rectangle(rect.x, rect.y, rect.width, rect.height)

--- a/blueman/gui/GtkAnimation.py
+++ b/blueman/gui/GtkAnimation.py
@@ -277,9 +277,6 @@ class WidgetFade(AnimBase):
 
     def on_draw(self, widget, cr):
         if not self.frozen:
-            rect = self.widget.get_allocation()
-            cr.rectangle(rect.x, rect.y, rect.width, rect.height)
-            cr.clip()
             cr.set_source_rgba(self.color.red, self.color.green, self.color.blue, self.color.alpha - self.get_state())
             cr.set_operator(cairo.OPERATOR_OVER)
             cr.paint()

--- a/blueman/gui/MessageArea.py
+++ b/blueman/gui/MessageArea.py
@@ -8,6 +8,22 @@ from gi.repository import Pango
 from blueman.gui.GtkAnimation import WidgetFade
 
 
+CSS = b'''
+#MessageArea.error {
+  background: #BF2121;
+  color: #D6D6D6;
+  border-color: #BF2121;
+}
+
+#MessageArea button {
+  background-image: none;
+  background: none;
+  background-color: #BF2121;
+  color: #BF2121;
+}
+'''
+
+
 class MessageArea(Gtk.InfoBar):
     _inst_ = None
 
@@ -22,9 +38,14 @@ class MessageArea(Gtk.InfoBar):
 
         self.set_name("MessageArea")
 
+        self.style_context = self.get_style_context()
+        cssprovider = Gtk.CssProvider()
+        cssprovider.load_from_data(CSS)
+        self.style_context.add_provider(cssprovider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
+
         self.text = ""
 
-        self.anim = WidgetFade(self, self.get_style_context().get_background_color(Gtk.StateFlags.NORMAL))
+        self.anim = WidgetFade(self, self.style_context.get_background_color(Gtk.StateFlags.NORMAL))
         self.hl_anim = WidgetFade(self, Gdk.RGBA(1, 0, 0, 1))
 
         self.bt = None

--- a/blueman/gui/MessageArea.py
+++ b/blueman/gui/MessageArea.py
@@ -8,7 +8,7 @@ from gi.repository import Pango
 from blueman.gui.GtkAnimation import WidgetFade
 
 
-class MessageArea(Gtk.EventBox):
+class MessageArea(Gtk.InfoBar):
     _inst_ = None
 
     def __new__(cls):
@@ -18,97 +18,54 @@ class MessageArea(Gtk.EventBox):
         return MessageArea._inst_
 
     def __init__(self):
-        super(MessageArea, self).__init__()
+        super(MessageArea, self).__init__(show_close_button=True)
 
         self.set_name("MessageArea")
-        self.hbox = Gtk.Box(spacing=4, border_width=2, orientation=Gtk.Orientation.HORIZONTAL, visible=True)
 
         self.text = ""
 
-        self.set_app_paintable(True)
+        self.anim = WidgetFade(self, self.get_style_context().get_background_color(Gtk.StateFlags.NORMAL))
+        self.hl_anim = WidgetFade(self, Gdk.RGBA(1, 0, 0, 1))
 
-        self.anim = WidgetFade(self.hbox, self.hbox.get_style_context().get_background_color(Gtk.StateFlags.NORMAL))
-        self.hl_anim = WidgetFade(self.hbox, Gdk.RGBA(1, 0, 0, 1))
-
-        self.setting_style = False
+        self.bt = None
 
         self.icon = Gtk.Image(pixel_size=16, visible=True)
         self.label = Gtk.Label(xalign=0, ellipsize=Pango.EllipsizeMode.END, single_line_mode=True,
                                selectable=True, visible=True)
 
         im = Gtk.Image(icon_name="dialog-information", pixel_size=16, visible=True)
-        self.b_more = Gtk.Button(label=_("More"), relief=Gtk.ReliefStyle.NONE, visible=True, image=im)
+        self.b_more = self.add_button(_("More"), 0)
+        self.b_more.set_image(im)
+        self.b_more.props.relief = Gtk.ReliefStyle.NONE
 
-        im = Gtk.Image(icon_name="window-close", pixel_size=16, visible=True)
-        self.b_close = Gtk.Button(label=_("Close"), relief=Gtk.ReliefStyle.NONE, tooltip_text=_("Close"),
-                                  visible=True, image=im)
+        self.content_area = self.get_content_area()
+        self.content_area.add(self.icon)
+        self.content_area.add(self.label)
 
-        self.hbox.pack_start(self.icon, False, False, 4)
-        self.hbox.pack_start(self.label, True, False, 0)
-        self.hbox.pack_start(self.b_more, False, False, 0)
-        self.hbox.pack_start(self.b_close, False, False, 0)
+        self.connect("response", self.on_response)
 
-        self.add(self.hbox)
-
-        self.b_close.connect("clicked", self.on_close)
-        self.b_more.connect("clicked", self.on_more)
-
-        self.hbox.connect("draw", self.draw)
-        self.b_close.connect("style-set", self.style_set)
-
-    def on_more(self, button):
-        d = Gtk.MessageDialog(parent=self.get_toplevel(), flags=0, type=Gtk.MessageType.INFO,
-                              buttons=Gtk.ButtonsType.CLOSE, text='\n'.join((self.text, self.bt)))
-        d.run()
-        d.destroy()
-
-    def style_set(self, widget, prev_style):
-        # FIXME needs porting to GtkStyleContext
-        if self.setting_style:
-            return
-
-        # This is a hack needed to use the tooltip background color
-        window = Gtk.Window(type=Gtk.WindowType.POPUP, name="gtk-tooltip")
-        window.ensure_style()
-        style = window.get_style()
-        window.destroy()
-
-        self.setting_style = True
-
-        #recursively set style
-        def _set_style(wg):
-            if isinstance(wg, Gtk.Container):
-                for w in wg:
-                    if not isinstance(w, Gtk.Button):
-                        _set_style(w)
-
-            wg.set_style(style)
-
-        _set_style(self)
-        self.anim.color = self.hbox.get_style_context().get_background_color(Gtk.StateFlags.NORMAL)
-        self.queue_draw()
-
-        self.setting_style = False
-
-    def on_close(self, button):
-        def on_finished(anim):
-            anim.disconnect(sig)
-            self.props.visible = False
-            anim.freeze()
-
-        sig = self.anim.connect("animation-finished", on_finished)
-        self.anim.thaw()
-        self.anim.animate(start=1.0, end=0.0, duration=500)
+    def on_response(self, info_bar, response_id):
+        if response_id == 0:
+            d = Gtk.MessageDialog(parent=self.get_toplevel(), flags=0, type=Gtk.MessageType.INFO,
+                                  buttons=Gtk.ButtonsType.CLOSE, text='\n'.join((self.text, self.bt)))
+            d.run()
+            d.destroy()
+        elif response_id == Gtk.ResponseType.CLOSE:
+            info_bar.props.visible = False
 
     @staticmethod
     def close():
-        MessageArea._inst_.on_close(None)
+        MessageArea._inst_.response(1)
 
     @staticmethod
     def show_message(*args):
         MessageArea._inst_._show_message(*args)
 
     def _show_message(self, text, bt=None, icon="dialog-warning"):
+        def on_finished(anim):
+            anim.disconnect(sig)
+            anim.freeze()
+
         self.text = text
         self.bt = bt
 
@@ -116,19 +73,15 @@ class MessageArea(Gtk.EventBox):
         self.icon.props.icon_name = icon
 
         if icon == "dialog-warning":
+            self.set_message_type(Gtk.MessageType.ERROR)
             self.hl_anim.color = Gdk.RGBA(1, 0, 0, 1)
         else:
+            self.set_message_type(Gtk.MessageType.INFO)
             self.hl_anim.color = Gdk.RGBA(0, 0, 1, 1)
-
-        def on_finished(anim):
-            anim.disconnect(sig)
-            anim.freeze()
 
         if not self.props.visible:
             sig = self.anim.connect("animation-finished", on_finished)
-
             self.anim.thaw()
-
             self.show()
             self.anim.animate(start=0.0, end=1.0, duration=500)
         else:
@@ -142,20 +95,4 @@ class MessageArea(Gtk.EventBox):
         else:
             self.label.props.label = self.text
             self.b_more.props.visible = False
-
-    def draw(self, window, cr):
-        rect = window.get_allocation()
-        Gtk.paint_box(window.get_style(), cr,
-                      Gtk.StateType.NORMAL, Gtk.ShadowType.IN,
-                      window, "tooltip",
-                      rect.x, rect.y, rect.width, rect.height)
-
-    def expose_event(self, window, event):
-        rect = window.get_allocation()
-        window.style.paint_box(window.window,
-                               Gtk.StateType.NORMAL, Gtk.ShadowType.IN,
-                               None, window, "tooltip",
-                               rect.x, rect.y, rect.width, rect.height)
-
-        return False
 

--- a/blueman/gui/MessageArea.py
+++ b/blueman/gui/MessageArea.py
@@ -96,3 +96,6 @@ class MessageArea(Gtk.InfoBar):
             self.label.props.label = self.text
             self.b_more.props.visible = False
 
+        # Queue a resize to workaround negative height problem, see issue #369
+        # TODO revisit this in later Gtk versions to see if the problem persists
+        self.queue_resize()


### PR DESCRIPTION
Looking at this now and we need to discuss this, so opening a PR :smile:. This is based on a slightly modified version of what is on the main git repo.

> We are losing the color animation with this.

How important is this?

> Actually colors do not seem to work at although set_message_type should change them. :/

This highly depends on the theme, for some themes the error is red others use something differently. For the MATE traditional themes it is red but on Adwaita it is blue. We can force by using a StyleProvider if it has to be a specific color.

ps: With the StyleProvider we can force other styling, like background colors, transition effects etc.
