### PR TITLE
Remove enable_rgba_colormap which does nothing

### DIFF
--- a/apps/blueman-adapters
+++ b/apps/blueman-adapters
@@ -22,8 +22,6 @@ import blueman.bluez as Bluez
 from blueman.Constants import *
 from blueman.Functions import *
 
-enable_rgba_colormap()
-
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk

--- a/apps/blueman-manager
+++ b/apps/blueman-manager
@@ -40,8 +40,6 @@ DBusGMainLoop(set_as_default=True)
 # Workaround introspection bug, gnome bug 622084
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-enable_rgba_colormap()
-
 
 class Blueman(Gtk.Window):
     def __init__(self):

--- a/apps/blueman-sendto
+++ b/apps/blueman-sendto
@@ -42,8 +42,6 @@ DBusGMainLoop(set_as_default=True)
 # Workaround introspection bug, gnome bug 622084
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-enable_rgba_colormap()
-
 
 class Sender(Gtk.Dialog):
     __gsignals__ = {

--- a/apps/blueman-services
+++ b/apps/blueman-services
@@ -27,7 +27,6 @@ import blueman.plugins.services
 from blueman.plugins.ServicePlugin import ServicePlugin
 from blueman.main.Config import Config
 
-enable_rgba_colormap()
 setup_icon_path()
 
 

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -131,15 +131,6 @@ def wait_for_adapter(bluez_adapter, callback, timeout=1000):
     sig = bluez_adapter.connect_signal('property-changed', on_prop_changed)
 
 
-def enable_rgba_colormap():
-    #screen = Gdk.Display.get_default().get_default_screen()
-    #colormap = screen.get_rgba_colormap()
-    #if colormap == None:
-    #	colormap = screen.get_rgb_colormap()
-    #Gtk.widget_set_default_colormap(colormap)
-    pass
-
-
 def launch(cmd, paths=None, system=False, icon_name=None, sn=True, name="blueman"):
     '''Launch a gui app with starup notification'''
     display = Gdk.Display.get_default()

--- a/configure.ac
+++ b/configure.ac
@@ -184,6 +184,15 @@ AC_ARG_ENABLE([appindicator],
 
 AM_CONDITIONAL([HAVE_APPINDICATOR], [test "x$use_appindicator" = "xyes"])
 
+AC_ARG_WITH([systemdunitdir],
+  AS_HELP_STRING([--with-systemdunitdir=PATH],
+    [Directory for systemd unit files]
+    [[default=${prefix}/lib/systemd]]),
+  [systemd_unit_dir="$withval"],
+  [systemd_unit_dir='${prefix}/lib/systemd'])
+AC_SUBST([systemd_unit_dir])
+AM_CONDITIONAL([SYSTEMD_UNIT_DIR], [test "x$systemd_unit_dir" != "xno"])
+
 # GSettings related settings
 GLIB_GSETTINGS
 
@@ -268,4 +277,5 @@ echo Settings menu integration enabled: $have_settings
 echo Dhcpd 3 configuration file: $dhconfig
 echo PulseAudio support: $use_pulseaudio
 echo AppIndicator support: $use_appindicator
+echo Systemd unit dir: ${systemd_unit_dir}
 echo

--- a/data/configs/Makefile.am
+++ b/data/configs/Makefile.am
@@ -7,11 +7,13 @@ dbus_services_DATA = org.blueman.Mechanism.service
 dbus_sessdir = $(datadir)/dbus-1/services
 dbus_sess_DATA = org.blueman.Applet.service
 
-systemd_systemdir = $(prefix)/lib/systemd/system
+if SYSTEMD_UNIT_DIR
+systemd_systemdir = $(systemd_unit_dir)/system
 systemd_system_DATA = blueman-mechanism.service
 
-systemd_userdir = $(prefix)/lib/systemd/user
+systemd_userdir = $(sytemd_unit_dir)/user
 systemd_user_DATA = blueman-applet.service
+endif
 
 if HAVE_POLKIT
 @INTLTOOL_POLICY_RULE@ 


### PR DESCRIPTION
AFAICS there is nothing in blueman that needs to update the GdkVisual (Gtk3's colormap replacement).

commit message:
```
If we need to handle compositing changes we can connect to the
composited-changed signal on GtkWidget and update with the new
GdkVisual.
```