### PR TITLE
Add dict like functionality to PropertiesBase

### DIFF
--- a/apps/blueman-adapters
+++ b/apps/blueman-adapters
@@ -81,15 +81,14 @@ class BluemanAdapters(Gtk.Dialog):
         self.show_all()
 
     def on_dialog_response(self, dialog, response_id):
-        for hci, settings in self.tabs.items():
-            if settings['changed']:
-                settings['adapter'].set_name(settings['name'])
         Gtk.main_quit()
 
     def on_property_changed(self, adapter, name, value, path):
+        hci_dev = os.path.basename(path)
         if name == "Discoverable" and value == 0:
-            hci_dev = os.path.basename(path)
             self.tabs[hci_dev]["hidden_radio"].set_active(True)
+        elif name == "Alias":
+            self.tabs[hci_dev]["label"].set_text(value)
 
     def on_adapter_added(self, _manager, adapter_path):
         adapter = Bluez.Adapter(adapter_path)
@@ -107,35 +106,30 @@ class BluemanAdapters(Gtk.Dialog):
         #fixme: show error dialog and exit
 
     def build_adapter_tab(self, adapter):
-        adapter_settings = {}
-
         def on_hidden_toggle(radio):
             if not radio.props.active:
                 return
-            adapter.set('DiscoverableTimeout', 0)
-            adapter_settings['discoverable'] = False
-            adapter.set('Discoverable', False)
+            adapter['DiscoverableTimeout'] = 0
+            adapter['Discoverable'] = False
             hscale.set_sensitive(False)
 
         def on_always_toggle(radio):
             if not radio.props.active:
                 return
-            adapter.set('DiscoverableTimeout', 0)
-            adapter_settings['discoverable'] = True
-            adapter.set('Discoverable', True)
+            adapter['DiscoverableTimeout'] = 0
+            adapter['Discoverable'] = True
             hscale.set_sensitive(False)
 
         def on_temporary_toggle(radio):
             if not radio.props.active:
                 return
-            adapter_settings['discoverable'] = True
-            adapter.set('Discoverable', True)
+            adapter['Discoverable'] = True
             hscale.set_sensitive(True)
             hscale.set_value(3)
 
         def on_scale_format_value(scale, value):
             if value == 0:
-                if adapter_settings['discoverable']:
+                if adapter['Discoverable']:
                     return _("Always")
                 else:
                     return _("Hidden")
@@ -145,29 +139,21 @@ class BluemanAdapters(Gtk.Dialog):
         def on_scale_value_changed(scale):
             val = scale.get_value()
             print('value: '+str(val))
-            if val == 0 and adapter_settings['discoverable']:
+            if val == 0 and adapter['Discoverable']:
                 always_radio.props.active = True
             timeout = int(val * 60)
-            adapter.set('DiscoverableTimeout', timeout)
+            adapter['DiscoverableTimeout'] = timeout
 
         def on_name_changed(entry):
-            adapter_settings['name'] = entry.get_text()
-            adapter_settings['changed'] = True
+            adapter['Alias'] = entry.get_text()
 
-        props = adapter.get_properties()
-        adapter_settings['adapter'] = adapter
-        adapter_settings['adapter'].connect_signal('property-changed', self.on_property_changed)
-        adapter_settings['address'] = props['Address']
-        adapter_settings['name'] = adapter.get_name()
-        adapter_settings['discoverable'] = props['Discoverable']
-        #we use count timeout in minutes
-        adapter_settings['discoverable_timeout'] = props['DiscoverableTimeout'] / 60
-        adapter_settings['changed'] = False
+        ui = {}
+
+        adapter.connect_signal('property-changed', self.on_property_changed)
 
         builder = Gtk.Builder()
         builder.set_translation_domain("blueman")
         builder.add_from_file(UI_PATH + "/adapters-tab.ui")
-        adapter_settings['grid'] = builder.get_object("grid")
 
         hscale = builder.get_object("hscale")
         hscale.connect("format-value", on_scale_format_value)
@@ -179,27 +165,29 @@ class BluemanAdapters(Gtk.Dialog):
         always_radio = builder.get_object("always")
         temporary_radio = builder.get_object("temporary")
 
-        if adapter_settings['discoverable'] and adapter_settings['discoverable_timeout'] > 0:
+        if adapter['Discoverable'] and adapter['DiscoverableTimeout'] > 0:
             temporary_radio.set_active(True)
-            hscale.set_value(adapter_settings['discoverable_timeout'])
+            hscale.set_value(adapter['DiscoverableTimeout'])
             hscale.set_sensitive(True)
-        elif adapter_settings['discoverable'] and adapter_settings['discoverable_timeout'] == 0:
+        elif adapter['Discoverable'] and adapter['DiscoverableTimeout'] == 0:
             always_radio.set_active(True)
         else:
             hidden_radio.set_active(True)
 
         name_entry = builder.get_object("name_entry")
-        name_entry.set_text(adapter_settings['name'])
+        name_entry.set_text(adapter.get_name())
 
         hidden_radio.connect("toggled", on_hidden_toggle)
         always_radio.connect("toggled", on_always_toggle)
         temporary_radio.connect("toggled", on_temporary_toggle)
         name_entry.connect("changed", on_name_changed)
 
-        adapter_settings["hidden_radio"] = hidden_radio
-        adapter_settings["always_radio"] = always_radio
-        adapter_settings["temparary_radio"] = temporary_radio
-        return adapter_settings
+        ui['adapter'] = adapter
+        ui['grid'] = builder.get_object("grid")
+        ui["hidden_radio"] = hidden_radio
+        ui["always_radio"] = always_radio
+        ui["temparary_radio"] = temporary_radio
+        return ui
 
     def add_to_notebook(self, adapter):
         hci_dev = os.path.basename(adapter.get_object_path())
@@ -211,16 +199,17 @@ class BluemanAdapters(Gtk.Dialog):
             if self.tabs[hci_dev]['visible']:
                 return
             #might need to update settings at this point
-        settings = self.tabs[hci_dev]
-        settings['visible'] = True
-        name = settings['name']
+        ui = self.tabs[hci_dev]
+        ui['visible'] = True
+        name = adapter.get_name()
         if name == '':
             name = _('Adapter') + ' %d' % (hci_dev_num + 1)
         label = Gtk.Label(label=name)
+        ui['label'] = label
         label.set_max_width_chars(20)
         label.props.hexpand = True
         label.set_ellipsize(Pango.EllipsizeMode.END)
-        self.notebook.insert_page(settings['grid'], label, hci_dev_num)
+        self.notebook.insert_page(ui['grid'], label, hci_dev_num)
 
     def remove_from_notebook(self, adapter):
         hci_dev = os.path.basename(adapter.get_object_path())

--- a/apps/blueman-adapters
+++ b/apps/blueman-adapters
@@ -50,6 +50,7 @@ class BluemanAdapters(Gtk.Dialog):
         self.notebook = Gtk.Notebook()
         self.content_area.add(self.notebook)
         self.tabs = {}
+        self._adapters = {}
 
         setup_icon_path()
         self.bus = dbus.SystemBus()
@@ -61,15 +62,18 @@ class BluemanAdapters(Gtk.Dialog):
 
         try:
             self.manager = Bluez.Manager()
-            self.manager.connect_signal('adapter-added', self.on_adapter_added)
-            self.manager.connect_signal('adapter-removed', self.on_adapter_removed)
-            adapters = self.manager.list_adapters()
-            for adapter in adapters:
-                self.add_to_notebook(adapter)
         except Exception as e:
             print(e)
             self.manager = None
         #fixme: show error dialog and exit
+
+        self.manager.connect_signal('adapter-added', self.on_adapter_added)
+        self.manager.connect_signal('adapter-removed', self.on_adapter_removed)
+        for adapter in self.manager.list_adapters():
+            path = adapter.get_object_path()
+            hci_dev = os.path.basename(path)
+            self._adapters[hci_dev] = adapter
+            self.on_adapter_added(self.manager, path)
 
         #activate a particular tab according to command line option
         if selected_hci_dev is not None:
@@ -91,13 +95,16 @@ class BluemanAdapters(Gtk.Dialog):
             self.tabs[hci_dev]["label"].set_text(value)
 
     def on_adapter_added(self, _manager, adapter_path):
-        adapter = Bluez.Adapter(adapter_path)
-        self.add_to_notebook(adapter)
+        hci_dev = os.path.basename(adapter_path)
+        if not hci_dev in self._adapters:
+            self._adapters[hci_dev] = Bluez.Adapter(adapter_path)
+
+        self._adapters[hci_dev].connect_signal("property-changed", self.on_property_changed)
+        self.add_to_notebook(self._adapters[hci_dev])
 
     def on_adapter_removed(self, _manager, adapter_path):
         hci_dev = os.path.basename(adapter_path)
-        adapter = self.tabs[hci_dev]["adapter"]
-        self.remove_from_notebook(adapter)
+        self.remove_from_notebook(self._adapters[hci_dev])
 
     def on_dbus_name_owner_change(self, owner):
         print('org.bluez owner changed to '+owner)
@@ -149,8 +156,6 @@ class BluemanAdapters(Gtk.Dialog):
 
         ui = {}
 
-        adapter.connect_signal('property-changed', self.on_property_changed)
-
         builder = Gtk.Builder()
         builder.set_translation_domain("blueman")
         builder.add_from_file(UI_PATH + "/adapters-tab.ui")
@@ -182,7 +187,6 @@ class BluemanAdapters(Gtk.Dialog):
         temporary_radio.connect("toggled", on_temporary_toggle)
         name_entry.connect("changed", on_name_changed)
 
-        ui['adapter'] = adapter
         ui['grid'] = builder.get_object("grid")
         ui["hidden_radio"] = hidden_radio
         ui["always_radio"] = always_radio

--- a/blueman/bluez/PropertiesBase.py
+++ b/blueman/bluez/PropertiesBase.py
@@ -37,6 +37,10 @@ class PropertiesBase(Base):
                 self._on_property_changed(name, value, path)
 
     @raise_dbus_error
+    def get(self, name):
+        return self.__properties_interface.Get(self._interface_name, name)
+
+    @raise_dbus_error
     def set(self, name, value):
         if type(value) is int:
             value = dbus.UInt32(value)
@@ -45,3 +49,12 @@ class PropertiesBase(Base):
     @raise_dbus_error
     def get_properties(self):
         return self.__properties_interface.GetAll(self._interface_name)
+
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def __setitem__(self, key, value):
+        self.set(key, value)
+
+    def __contains__(self, key):
+        return key in self.get_properties()


### PR DESCRIPTION
While working on ``blueman-adapters`` I found it strange that we were storing the adapter properties in a separate dict instead of retrieving them when needed. The first commits allows ``PropertiesBase`` to be used as a dictionary. The second commit implements the new functionality in ``blueman-adapters`` getting rid of all the duplicate storage of the properties.

We can also rename the ``get_properties`` to ``items`` which matches the python dictionary terminology better. Which requires changes across all of blueman so I left this out for now.

The new dict like functionality of-course applies to all classes that derive from ``PropertiesBase``.