### PR TITLE
build: Fix typo in systemd path variable

### DIFF
--- a/data/configs/Makefile.am
+++ b/data/configs/Makefile.am
@@ -11,7 +11,7 @@ if SYSTEMD_UNIT_DIR
 systemd_systemdir = $(systemd_unit_dir)/system
 systemd_system_DATA = blueman-mechanism.service
 
-systemd_userdir = $(sytemd_unit_dir)/user
+systemd_userdir = $(systemd_unit_dir)/user
 systemd_user_DATA = blueman-applet.service
 endif
 


### PR DESCRIPTION
Right now unit files are installed in `/user` which is not a very good idea ;-P.