### PR TITLE
Fix missed r_randp -> r_pair in 61a9657452332e278f907d4a2f7149

### DIFF
--- a/apps/blueman-assistant
+++ b/apps/blueman-assistant
@@ -101,7 +101,7 @@ class Assistant:
         self.svc_vbox = self.Builder.get_object("svcs")
 
         self.Builder.get_object("r_dontp").connect("toggled", self.on_pairing_method_changed, False)
-        self.Builder.get_object("r_randp").connect("toggled", self.on_pairing_method_changed, True)
+        self.Builder.get_object("r_pair").connect("toggled", self.on_pairing_method_changed, True)
 
         self.dev_widget = DeviceSelectorWidget()
         self.dev_widget.List.connect("device-selected", self.on_device_selected)


### PR DESCRIPTION
Oops.

Signed-off-by: Robby Workman <rworkman@slackware.com>