### PR TITLE
Fix building on musl libc

### DIFF
--- a/blueman/main/PPPConnection.py
+++ b/blueman/main/PPPConnection.py
@@ -131,7 +131,7 @@ class PPPConnection(GObject.GObject):
         attrs[0] &= ~(termios.IGNCR | termios.ICRNL | termios.IUCLC | termios.INPCK | termios.IXON | termios.IXANY |
                       termios.IGNPAR)
         attrs[1] &= ~(termios.OPOST | termios.OLCUC | termios.OCRNL | termios.ONLCR | termios.ONLRET)
-        attrs[3] &= ~(termios.ICANON | termios.XCASE | termios.ECHO | termios.ECHOE | termios.ECHONL)
+        attrs[3] &= ~(termios.ICANON | getattr(termios, 'XCASE', 4) | termios.ECHO | termios.ECHOE | termios.ECHONL)
         attrs[3] &= ~(termios.ECHO | termios.ECHOE)
         attrs[6][termios.VMIN] = 1
         attrs[6][termios.VTIME] = 0

--- a/module/libblueman.c
+++ b/module/libblueman.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 #include <linux/sockios.h>
 #include <linux/if.h>

--- a/module/modem-prober.c
+++ b/module/modem-prober.c
@@ -34,6 +34,10 @@
 
 #include "modem-prober.h"
 
+#ifndef XCASE
+#define XCASE 0000004
+#endif
+
 #if PY_MAJOR_VERSION >= 3
 #define PyString_FromString PyUnicode_FromString
 #endif


### PR DESCRIPTION
\__GLIBC\__ is defined if not defined in order to make the kernel headers work with userspace headers better. musl does not define \__GLIBC\__.

Other distributions usually work around the kernel headers issue by patching kernel headers.

In addition, XCASE must be defined since it is normally provided by glibc's termios.h.