### PR TITLE
RFC: Replace the main Device with the bluez Device object

### DIFF
--- a/blueman/main/Device.py
+++ b/blueman/main/Device.py
@@ -8,7 +8,6 @@ import inspect
 from blueman.Functions import dprint
 from blueman.Sdp import uuid128_to_uuid16
 from blueman.bluez import Manager
-from blueman.bluez.Device import Device as BluezDevice
 import blueman.services
 import blueman.services.meta
 import weakref
@@ -26,10 +25,7 @@ class Device(GObject.GObject):
         self.Properties = {}
         self.Temp = False
 
-        if hasattr(instance, "format") and hasattr(instance, "upper"):
-            self.Device = BluezDevice(instance)
-        else:
-            self.Device = instance
+        self.Device = instance
 
         #set fallback icon, fixes lp:#327718
         self.Device.Icon = "blueman"

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -8,6 +8,7 @@ from blueman.main.PluginManager import StopException
 from blueman.plugins.AppletPlugin import AppletPlugin
 
 from blueman.main.Device import Device
+from blueman.bluez.Device import Device as BluezDevice
 
 from gi.repository import GLib
 import dbus
@@ -36,7 +37,7 @@ class DBusService(AppletPlugin):
 
     @dbus.service.method('org.blueman.Applet', in_signature="o", out_signature="", async_callbacks=("ok", "err"))
     def DisconnectDevice(self, obj_path, ok, err):
-        dev = Device(obj_path)
+        dev = Device(BluezDevice(obj_path))
 
         self.Applet.Plugins.Run("on_device_disconnect", dev)
 
@@ -58,7 +59,7 @@ class DBusService(AppletPlugin):
 
     @dbus.service.method('org.blueman.Applet', in_signature="os", async_callbacks=("ok", "err"))
     def connect_service(self, object_path, uuid, ok, err):
-        service = Device(object_path).get_service(uuid)
+        service = Device(BluezDevice(object_path)).get_service(uuid)
 
         try:
             self.Applet.Plugins.RecentConns
@@ -89,7 +90,7 @@ class DBusService(AppletPlugin):
 
     @dbus.service.method('org.blueman.Applet', in_signature="osd", async_callbacks=("ok", "err"))
     def disconnect_service(self, object_path, uuid, port, ok, err):
-        service = Device(object_path).get_service(uuid)
+        service = Device(BluezDevice(object_path)).get_service(uuid)
 
         if service.group == 'serial':
             service.disconnect(port)

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -8,7 +8,6 @@ from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.gui.Notification import Notification
 from blueman.Sdp import uuid128_to_uuid16, uuid16_to_name, SERIAL_PORT_SVCLASS_ID
 from _blueman import rfcomm_list
-from blueman.main.Device import Device
 from subprocess import Popen
 import atexit
 
@@ -57,7 +56,7 @@ class SerialManager(AppletPlugin):
 
     def _on_device_property_changed(self, _device, key, value, path):
         if key == "Connected" and not value:
-            self.terminate_all_scripts(Device(path).Address)
+            self.terminate_all_scripts(Bluez.Device(path)["Address"])
 
     def on_rfcomm_connected(self, service, port):
         device = service.device

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -12,7 +12,6 @@ import shutil
 from blueman.bluez import obex
 from blueman.Functions import dprint, get_icon, launch
 from blueman.gui.Notification import Notification
-from blueman.main.Device import Device
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.main.Config import Config
 
@@ -76,9 +75,9 @@ class _Agent:
             size = transfer.size
 
         try:
-            device = Device(self._applet.Manager.get_adapter().find_device(address))
-            name = device.Alias
-            trusted = device.Trusted
+            device = self._applet.Manager.get_adapter().find_device(address)
+            name = device["Alias"]
+            trusted = device["Trusted"]
         except Exception as e:
             dprint(e)
             name = address


### PR DESCRIPTION
I see ``Device`` class in ``blueman.main.Device`` doing the the following things:

 1.  caches the properties
 2. Handles optional properties missing [see lp bug 327718](https://bugs.launchpad.net/blueman/+bug/327718).
 3. Translates uuid to something meaningful
 4. Add an invalidated signal that wraps the device removed signal from the manager.

Now for the questions :smile:.

Regarding 1, why is this done? If you do not know why not instead handle this in the PropertiesBase or (bluez) Device class?
Regarding 2, We could move this to bluez Device class and handle properties that are optional. Or fix this in RecentConns where the icon is used and what the lp bug is about.
Regarding 3, Move this into the bluez Device class?
Regarding 4, While this is useful why not connect the manager singnal in the right places to handle device removals?