### PR TITLE
RFC: Proof of concept use of GObject properties

### DIFF
--- a/blueman/bluez/Device.py
+++ b/blueman/bluez/Device.py
@@ -8,6 +8,19 @@ from blueman.bluez.errors import raise_dbus_error, parse_dbus_error
 
 
 class Device(PropertiesBase):
+    __gproperties__ = {
+        str('Alias'): (GObject.TYPE_STRING,
+                       'BlueZ Device Alias',
+                       None,
+                       None,
+                       GObject.PARAM_READWRITE)
+
+    def do_get_property(self, prop):
+        return self.get(prop.name)
+
+    def do_set_property(self, prop, value):
+        return self.set(prop.name, value)
+
     @raise_dbus_error
     def __init__(self, obj_path=None):
         super(Device, self).__init__('org.bluez.Device1', obj_path)


### PR DESCRIPTION
This allows us to use Device.props and interact with it. While it does not add a whole lot it does give a cleaner way of accessing properties instead of using get/set.

Feel free to shoot this down :wink: .
