### PR TITLE
Bug fixes for the script handling in SerialManager plugin

### DIFF
--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -154,8 +154,9 @@ class SerialManager(AppletPlugin):
             try:
                 dprint("Disconnecting", name)
                 serial_services[0].disconnect(port)
-            except:
+            except Exception as e:
                 dprint("Failed to disconnect", name)
+                dprint(e)
 
 
 @atexit.register

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -103,7 +103,7 @@ class SerialManager(AppletPlugin):
         if c and c != "":
             args = c.split(" ")
             try:
-                args += [address, name, sv_name, ",".join(map(lambda x: hex(x), uuid16)), node]
+                args += [address, name, sv_name, "%s" % hex(uuid16), node]
                 dprint(args)
                 p = Popen(args, preexec_fn=lambda: os.setpgid(0, 0))
 


### PR DESCRIPTION
This requires at least one more fix to fix the below. I don't understand this last one so any hints would be helpful :smile:.

```
on_device_disconnect (/usr/lib64/python3.4/site-packages/blueman/plugins/applet/SerialManager.py:132)
Disconnecting /dev/rfcomm14 
ERROR:dbus.connection:Unable to set arguments ('/dev/rfcomm14',) according to signature 'd': <class 'TypeError'>: a float is required
```