### PR TITLE
PropertiesBase: Merge the two property changed functions

### DIFF
--- a/blueman/bluez/PropertiesBase.py
+++ b/blueman/bluez/PropertiesBase.py
@@ -27,14 +27,11 @@ class PropertiesBase(Base):
         self._handle_signal(self._on_properties_changed, 'PropertiesChanged', 'org.freedesktop.DBus.Properties',
                             path_keyword='path')
 
-    def _on_property_changed(self, key, value, path):
-        dprint(path, key, value)
-        self.emit('property-changed', key, value, path)
-
     def _on_properties_changed(self, interface_name, changed_properties, _invalidated_properties, path):
         if interface_name == self._interface_name:
             for name, value in changed_properties.items():
-                self._on_property_changed(name, value, path)
+                dprint(path, name, value)
+                self.emit('property-changed', name, value, path)
 
     @raise_dbus_error
     def get(self, name):


### PR DESCRIPTION
>_on_property_changed does nothing but emit a signal which we can just
as well do from _on_properties_changed.

So the only reason I can think of to have two functions is the name printed on the console. Other than that I find it pretty useless, any objection to merge the two?