### PR TITLE
Make DiscvManager handle it's own signals

### DIFF
--- a/apps/blueman-applet
+++ b/apps/blueman-applet
@@ -61,9 +61,6 @@ class BluemanApplet(object):
         self.bus = dbus.SystemBus()
         self.bus.watch_name_owner("org.bluez", self.on_dbus_name_owner_change)
 
-        self._any_adapter = Bluez.Adapter()
-        self._any_adapter.connect_signal('property-changed', self._on_adapter_property_changed)
-
         Gtk.main()
 
     def manager_init(self):
@@ -89,9 +86,6 @@ class BluemanApplet(object):
             self.manager_deinit()
         elif self.Manager is None:
             self.manager_init()
-
-    def _on_adapter_property_changed(self, _adapter, key, value, path):
-        self.Plugins.Run("on_adapter_property_changed", path, key, value)
 
     def on_adapter_added(self, _manager, path):
         dprint("Adapter added ", path)

--- a/blueman/plugins/applet/DiscvManager.py
+++ b/blueman/plugins/applet/DiscvManager.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from blueman.bluez.errors import DBusNoSuchAdapterError
 from blueman.Functions import *
 from blueman.plugins.AppletPlugin import AppletPlugin
 from gi.repository import GLib
@@ -73,7 +74,7 @@ class DiscvManager(AppletPlugin):
     def init_adapter(self):
         try:
             self.adapter = self.Applet.Manager.get_adapter()
-        except:
+        except DBusNoSuchAdapterError:
             self.adapter = None
 
     def on_adapter_removed(self, path):
@@ -112,7 +113,7 @@ class DiscvManager(AppletPlugin):
     def update_menuitems(self):
         try:
             props = self.adapter.get_properties()
-        except Exception as e:
+        except AttributeError as e:
             dprint("warning: Adapter is None")
             self.item.props.visible = False
         else:


### PR DESCRIPTION
While this works I am not sure we are doing the right thing here now. I am contemplating to make the GDBus port handle this by subscribing to the bus anyway but only for the case we want to get all signals for all adapters and devices. I'll experiment a bit with proxies and see if this can be done without interacting directly with the bus.

So this PR is just for quick review and discussion on the validity of doing it like this.