### PR TITLE
GDBus migration part one

### DIFF
--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -6,8 +6,6 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import dbus
-from dbus.mainloop.glib import DBusGMainLoop
 import os.path
 import os
 import sys
@@ -28,8 +26,6 @@ gi.require_version("Gtk", "3.0")
 gi.require_version("Pango", "1.0")
 from gi.repository import Gtk
 from gi.repository import Pango
-
-DBusGMainLoop(set_as_default=True)
 
 # Workaround introspection bug, gnome bug 622084
 signal.signal(signal.SIGINT, signal.SIG_DFL)
@@ -57,8 +53,7 @@ class BluemanAdapters(Gtk.Dialog):
         self._adapters = {}
 
         setup_icon_path()
-        self.bus = dbus.SystemBus()
-        self.bus.watch_name_owner('org.bluez', self.on_dbus_name_owner_change)
+        Bluez.Manager.watch_name_owner(self._on_dbus_name_appeared, self._on_dbus_name_vanished)
 
         check_single_instance("blueman-adapters", lambda time: self.present_with_time(time))
 
@@ -110,11 +105,13 @@ class BluemanAdapters(Gtk.Dialog):
         hci_dev = os.path.basename(adapter_path)
         self.remove_from_notebook(self._adapters[hci_dev])
 
-    def on_dbus_name_owner_change(self, owner):
-        print('org.bluez owner changed to '+owner)
-        if owner == '':
-            self.manager = None
-        #fixme: show error dialog and exit
+    def _on_dbus_name_appeared(self, _connection, _name, owner):
+        dprint(owner)
+
+    def _on_dbus_name_vanished(self, _connection, _name, _owner):
+        dprint()
+        self.manager = None
+        # FIXME: show error dialog and exit
 
     def build_adapter_tab(self, adapter):
         def on_hidden_toggle(radio):

--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -105,11 +105,11 @@ class BluemanAdapters(Gtk.Dialog):
         hci_dev = os.path.basename(adapter_path)
         self.remove_from_notebook(self._adapters[hci_dev])
 
-    def _on_dbus_name_appeared(self, _connection, _name, owner):
-        dprint(owner)
+    def _on_dbus_name_appeared(self, _connection, name, owner):
+        dprint(name, owner)
 
-    def _on_dbus_name_vanished(self, _connection, _name, _owner):
-        dprint()
+    def _on_dbus_name_vanished(self, _connection, _name):
+        dprint(name)
         self.manager = None
         # FIXME: show error dialog and exit
 

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -65,10 +65,10 @@ class BluemanApplet(object):
         self.bus = dbus.SystemBus()
         self.bus.watch_name_owner("org.bluez", self.on_dbus_name_owner_change)
 
-        self._any_adapter = Bluez.Adapter()
+        self._any_adapter = Bluez.AnyAdapter()
         self._any_adapter.connect_signal('property-changed', self._on_adapter_property_changed)
 
-        self._any_device = Bluez.Device()
+        self._any_device = Bluez.AnyDevice()
         self._any_device.connect_signal('property-changed', self._on_device_property_changed)
 
         Gtk.main()

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -10,8 +10,6 @@ import sys
 import os.path
 import os
 import signal
-import dbus
-from dbus.mainloop.glib import DBusGMainLoop
 from blueman.Constants import *
 import gi
 gi.require_version("Gtk", "3.0")
@@ -19,8 +17,6 @@ gi.require_version('Notify', '0.7')
 from gi.repository import Notify
 try: import __builtin__ as builtins
 except ImportError: import builtins
-
-DBusGMainLoop(set_as_default=True)
 
 #support running uninstalled
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -62,8 +58,7 @@ class BluemanApplet(object):
 
         self.Plugins.Run("on_plugins_loaded")
 
-        self.bus = dbus.SystemBus()
-        self.bus.watch_name_owner("org.bluez", self.on_dbus_name_owner_change)
+        Bluez.Manager.watch_name_owner(self._on_dbus_name_appeared, self._on_dbus_name_vanished)
 
         self._any_adapter = Bluez.AnyAdapter()
         self._any_adapter.connect_signal('property-changed', self._on_adapter_property_changed)
@@ -96,12 +91,17 @@ class BluemanApplet(object):
         self.Manager = None
         self.Plugins.Run("on_manager_state_changed", False)
 
-    def on_dbus_name_owner_change(self, owner):
-        dprint("org.bluez owner changed to", owner)
-        if owner == "":
-            self.manager_deinit()
-        elif self.Manager is None:
+    def _on_dbus_name_appeared(self, _connection, _name, owner):
+        dprint(owner)
+        if self.Manager is None:
             self.manager_init()
+
+    def _on_dbus_name_vanished(self, _connection, _name, _owner):
+        dprint()
+        self.manager_deinit()
+
+    def _on_adapter_property_changed(self, adapter, key, value):
+        self.Plugins.Run("on_adapter_property_changed", adapter.get_object_path(), key, value)
 
     def _on_adapter_property_changed(self, _adapter, key, value, path):
         self.Plugins.Run("on_adapter_property_changed", path, key, value)

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -83,7 +83,8 @@ class BluemanApplet(object):
             self._signals.append(self.Manager.connect_signal('device-created', self.on_device_created))
             self._signals.append(self.Manager.connect_signal('device-removed', self.on_device_removed))
 
-        except dbus.exceptions.DBusException as e:
+        # FIXME catch specific error(s)
+        except Exception as e:
             dprint(e)
             self.manager_deinit()
             dprint("Bluez DBus API not available. Listening for DBus name ownership changes")

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -91,13 +91,13 @@ class BluemanApplet(object):
         self.Manager = None
         self.Plugins.Run("on_manager_state_changed", False)
 
-    def _on_dbus_name_appeared(self, _connection, _name, owner):
-        dprint(owner)
+    def _on_dbus_name_appeared(self, _connection, name, owner):
+        dprint(name, owner)
         if self.Manager is None:
             self.manager_init()
 
-    def _on_dbus_name_vanished(self, _connection, _name, _owner):
-        dprint()
+    def _on_dbus_name_vanished(self, _connection, name):
+        dprint(name)
         self.manager_deinit()
 
     def _on_adapter_property_changed(self, adapter, key, value):

--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -86,8 +86,8 @@ class Blueman(Gtk.Window):
             else:
                 self.show()
 
-        def on_dbus_name_vanished(_connection, _name, _owner):
-            dprint()
+        def on_dbus_name_vanished(_connection, _name):
+            dprint(name)
             self.hide()
             d = Gtk.MessageDialog(self, type=Gtk.MessageType.ERROR, buttons=Gtk.ButtonsType.CLOSE)
             d.props.icon_name = "blueman"
@@ -103,8 +103,8 @@ class Blueman(Gtk.Window):
             except:
                 Gtk.main_quit()
 
-        def on_dbus_name_appeared(_connection, _name, owner):
-            dprint(owner)
+        def on_dbus_name_appeared(_connection, name, owner):
+            dprint(name, owner)
             setup_icon_path()
 
             self.Config = Config("org.blueman.general")

--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -10,8 +10,6 @@ import os.path
 import os
 import sys
 import signal
-import dbus
-from dbus.mainloop.glib import DBusGMainLoop
 from blueman.Constants import *
 import gi
 gi.require_version("Gtk", "3.0")
@@ -30,6 +28,7 @@ from blueman.gui.manager.ManagerMenu import ManagerMenu
 from blueman.gui.manager.ManagerStats import ManagerStats
 from blueman.gui.manager.ManagerProgressbar import ManagerProgressbar
 from blueman.main.Config import Config
+import blueman.bluez as bluez
 
 from blueman.gui.MessageArea import MessageArea
 from blueman.gui.Notification import Notification
@@ -37,8 +36,6 @@ from blueman.gui.Notification import Notification
 from blueman.main.PluginManager import PluginManager
 import blueman.plugins.manager
 from blueman.plugins.ManagerPlugin import ManagerPlugin
-
-DBusGMainLoop(set_as_default=True)
 
 # Workaround introspection bug, gnome bug 622084
 signal.signal(signal.SIGINT, signal.SIG_DFL)
@@ -89,77 +86,77 @@ class Blueman(Gtk.Window):
             else:
                 self.show()
 
-        def on_bluez_name_owner_changed(owner):
-            dprint('org.bluez owner changed to ', owner)
-            if owner == '':
-                self.hide()
-                d = Gtk.MessageDialog(self, type=Gtk.MessageType.ERROR, buttons=Gtk.ButtonsType.CLOSE)
-                d.props.icon_name = "blueman"
-                d.props.text = _("Connection to BlueZ failed")
+        def on_dbus_name_vanished(_connection, _name, _owner):
+            dprint()
+            self.hide()
+            d = Gtk.MessageDialog(self, type=Gtk.MessageType.ERROR, buttons=Gtk.ButtonsType.CLOSE)
+            d.props.icon_name = "blueman"
+            d.props.text = _("Connection to BlueZ failed")
 
-                d.props.secondary_text = _(
-                    "Bluez daemon is not running, blueman-manager cannot continue.\nThis probably means that there were no Bluetooth adapters detected or Bluetooth daemon was not started.")
+            d.props.secondary_text = _(
+                "Bluez daemon is not running, blueman-manager cannot continue.\nThis probably means that there were no Bluetooth adapters detected or Bluetooth daemon was not started.")
 
-                d.run()
-                d.destroy()
-                try:
-                    exit(1)
-                except:
-                    Gtk.main_quit()
-            else:
+            d.run()
+            d.destroy()
+            try:
+                exit(1)
+            except:
+                Gtk.main_quit()
 
-                setup_icon_path()
+        def on_dbus_name_appeared(_connection, _name, owner):
+            dprint(owner)
+            setup_icon_path()
 
-                self.Config = Config("org.blueman.general")
+            self.Config = Config("org.blueman.general")
 
-                try:
-                    self.Applet = AppletService()
-                except:
-                    print("Blueman applet needs to be running")
-                    exit()
-                try:
-                    if not self.Applet.GetBluetoothStatus():
-                        on_bt_status_changed(False)
-                except:
-                    pass
-                self.Applet.bus.add_signal_receiver(on_bt_status_changed, "BluetoothStatusChanged",
-                                                    self.Applet.dbus_interface, path=self.Applet.object_path)
+            try:
+                self.Applet = AppletService()
+            except:
+                print("Blueman applet needs to be running")
+                exit()
+            try:
+                if not self.Applet.GetBluetoothStatus():
+                    on_bt_status_changed(False)
+            except:
+                pass
+            self.Applet.bus.add_signal_receiver(on_bt_status_changed, "BluetoothStatusChanged",
+                                                self.Applet.dbus_interface, path=self.Applet.object_path)
 
-                self.connect("delete-event", on_window_delete)
-                self.props.icon_name = "blueman"
+            self.connect("delete-event", on_window_delete)
+            self.props.icon_name = "blueman"
 
-                w, h, x, y = self.Config["window-properties"]
-                if w and h: self.resize(w, h)
-                if x and y: self.move(x, y)
+            w, h, x, y = self.Config["window-properties"]
+            if w and h: self.resize(w, h)
+            if x and y: self.move(x, y)
 
-                sw = self.Builder.get_object("scrollview")
-                # Disable overlay scrolling
-                if Gtk.get_minor_version() >= 16:
-                    sw.props.overlay_scrolling = False
+            sw = self.Builder.get_object("scrollview")
+            # Disable overlay scrolling
+            if Gtk.get_minor_version() >= 16:
+                sw.props.overlay_scrolling = False
 
-                self.List = ManagerDeviceList(adapter=self.Config["last-adapter"], inst=self)
+            self.List = ManagerDeviceList(adapter=self.Config["last-adapter"], inst=self)
 
-                self.List.show()
-                sw.add(self.List)
+            self.List.show()
+            sw.add(self.List)
 
-                self.Toolbar = ManagerToolbar(self)
-                self.Menu = ManagerMenu(self)
-                self.Stats = ManagerStats(self)
+            self.Toolbar = ManagerToolbar(self)
+            self.Menu = ManagerMenu(self)
+            self.Stats = ManagerStats(self)
 
-                if self.List.IsValidAdapter():
-                    self.List.DisplayKnownDevices(autoselect=True)
+            if self.List.IsValidAdapter():
+                self.List.DisplayKnownDevices(autoselect=True)
 
-                self.List.connect("adapter-changed", self.on_adapter_changed)
+            self.List.connect("adapter-changed", self.on_adapter_changed)
 
-                toolbar = self.Builder.get_object("toolbar")
-                statusbar = self.Builder.get_object("statusbar")
+            toolbar = self.Builder.get_object("toolbar")
+            statusbar = self.Builder.get_object("statusbar")
 
-                self.Config.bind_to_widget("show-toolbar", toolbar, "visible")
-                self.Config.bind_to_widget("show-statusbar", statusbar, "visible")
+            self.Config.bind_to_widget("show-toolbar", toolbar, "visible")
+            self.Config.bind_to_widget("show-statusbar", statusbar, "visible")
 
-                self.show()
+            self.show()
 
-        dbus.SystemBus().watch_name_owner('org.bluez', on_bluez_name_owner_changed)
+        bluez.Manager.watch_name_owner(on_dbus_name_appeared, on_dbus_name_vanished)
 
     def on_adapter_changed(self, lst, adapter):
         if adapter is not None:

--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -12,7 +12,6 @@ _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
 
-from dbus.mainloop.glib import DBusGMainLoop
 from optparse import OptionParser
 import gettext
 import urllib
@@ -37,8 +36,6 @@ from blueman.gui.DeviceSelectorDialog import DeviceSelectorDialog
 from blueman.main.SpeedCalc import SpeedCalc
 
 from blueman.bluez import obex
-
-DBusGMainLoop(set_as_default=True)
 
 # Workaround introspection bug, gnome bug 622084
 signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/blueman/DeviceClass.py
+++ b/blueman/DeviceClass.py
@@ -200,7 +200,7 @@ def get_minor_class(klass, i18n=False):
             return ""
     elif i == 2:
         minor_index = (klass >> 2) & 0x3F
-        if (minor_index < len(phone_minor_cls)):
+        if minor_index < len(phone_minor_cls):
             if i18n:
                 return phone_minor_cls_i18n[minor_index]
             else:
@@ -208,13 +208,13 @@ def get_minor_class(klass, i18n=False):
         return ""
     elif i == 3:
         minor_index = (klass >> 5) & 0x07
-        if (minor_index < len(access_point_minor_cls)):
+        if minor_index < len(access_point_minor_cls):
             return access_point_minor_cls[minor_index]
         else:
             return ""
     elif i == 4:
         minor_index = (klass >> 2) & 0x3F
-        if (minor_index < len(audio_video_minor_cls)):
+        if minor_index < len(audio_video_minor_cls):
             if i18n:
                 return audio_video_minor_cls_i18n[minor_index]
             else:
@@ -223,7 +223,7 @@ def get_minor_class(klass, i18n=False):
             return ""
     elif i == 5:
         minor_index = (klass >> 6) & 0x03
-        if (minor_index < len(peripheral_minor_cls)):
+        if minor_index < len(peripheral_minor_cls):
             if i18n:
                 return peripheral_minor_cls_i18n[minor_index]
             else:
@@ -235,13 +235,13 @@ def get_minor_class(klass, i18n=False):
 
     elif i == 7:
         minor_index = (klass >> 2) & 0x3F
-        if (minor_index < len(wearable_minor_cls)):
+        if minor_index < len(wearable_minor_cls):
             return wearable_minor_cls[minor_index]
         else:
             return ""
     elif i == 8:
         minor_index = (klass >> 2) & 0x3F
-        if (minor_index < len(toy_minor_cls)):
+        if minor_index < len(toy_minor_cls):
             return toy_minor_cls[minor_index]
         else:
             return ""

--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -8,8 +8,8 @@ from gi.repository import GObject
 from blueman.Functions import dprint
 from blueman.bluez.PropertiesBase import PropertiesBase
 from blueman.bluez.Device import Device
+from blueman.bluez.AnyBase import AnyBase
 import dbus
-
 
 class Adapter(PropertiesBase):
     _interface_name = 'org.bluez.Adapter1'
@@ -56,3 +56,7 @@ class Adapter(PropertiesBase):
             return self.set('Alias', name)
         except dbus.exceptions.DBusException:
             return self.set('Name', name)
+
+class AnyAdapter(AnyBase):
+    def __init__(self):
+        super(AnyAdapter, self).__init__('org.bluez.Adapter1')

--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -4,35 +4,38 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from gi.repository import GObject
+from gi.repository import GObject, Gio, GLib
 from blueman.Functions import dprint
 from blueman.bluez.PropertiesBase import PropertiesBase
 from blueman.bluez.Device import Device
 from blueman.bluez.AnyBase import AnyBase
-import dbus
 
 class Adapter(PropertiesBase):
     _interface_name = 'org.bluez.Adapter1'
 
     def _init(self, obj_path=None):
-        super(Adapter, self)._init(interface_name=self._interface_name, obj_path=obj_path)
-        proxy = dbus.SystemBus().get_object('org.bluez', '/', follow_name_owner_changes=True)
-        self.manager_interface = dbus.Interface(proxy, 'org.freedesktop.DBus.ObjectManager')
+        super(Adapter, self)._init(self._interface_name, obj_path=obj_path)
+
+        self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
+            Gio.BusType.SYSTEM, Gio.DBusObjectManagerClientFlags.NONE,
+            'org.bluez', '/', None, None, None)
 
     def find_device(self, address):
-        devices = self.list_devices()
-        for device in devices:
-            if device.get_properties()['Address'] == address:
+        for device in self.list_devices():
+            if device['Address'] == address:
                 return device
 
     def list_devices(self):
-        objects = self._call('GetManagedObjects', interface=self.manager_interface)
-        devices = []
-        for path, interfaces in objects.items():
-            if 'org.bluez.Device1' in interfaces:
-                if path.startswith(self.get_object_path()):
-                    devices.append(path)
-        return [Device(device) for device in devices]
+        paths = []
+        for obj_proxy in self._object_manager.get_objects():
+            proxy = obj_proxy.get_interface('org.bluez.Device1')
+
+            if proxy:
+                object_path = proxy.get_object_path()
+                if object_path.startswith(self.get_object_path()):
+                    paths.append(object_path)
+
+        return [Device(path) for path in paths]
 
     def start_discovery(self):
         self._call('StartDiscovery')
@@ -41,20 +44,20 @@ class Adapter(PropertiesBase):
         self._call('StopDiscovery')
 
     def remove_device(self, device):
-        self._call('RemoveDevice', device.get_object_path())
+        param = GLib.Variant('(o)', (device.get_object_path(),))
+        self._call('RemoveDevice', param)
 
     # FIXME in BlueZ 5.31 getting and setting Alias appears to never fail
     def get_name(self):
-        props = self.get_properties()
-        try:
-            return props['Alias']
-        except KeyError:
-            return props['Name']
+        if 'Alias' in self:
+            return self['Alias']
+        else:
+            return self['Name']
 
     def set_name(self, name):
         try:
             return self.set('Alias', name)
-        except dbus.exceptions.DBusException:
+        except GLib.Error:
             return self.set('Name', name)
 
 class AnyAdapter(AnyBase):

--- a/blueman/bluez/Agent.py
+++ b/blueman/bluez/Agent.py
@@ -46,7 +46,8 @@ introspection_xml = \
 '''
 
 class Agent(object):
-    __bus = Gio.bus_get_sync(Gio.BusType.SYSTEM)
+    __bus_type = Gio.BusType.SYSTEM
+    __bus = Gio.bus_get_sync(__bus_type)
 
     def __init__(self, agent_path, handle_method_call):
         node_info = Gio.DBusNodeInfo.new_for_xml(introspection_xml)
@@ -61,7 +62,7 @@ class Agent(object):
         if regid:
             self.__regid = regid
         else:
-            raise GLib.Error('Failed to register object with path: %s', agent_path)
+            raise GLib.Error('Failed to register object with path: %s' % agent_path)
 
     def __del__(self):
         self._unregister_object()

--- a/blueman/bluez/AgentManager.py
+++ b/blueman/bluez/AgentManager.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.bluez.Base import Base
-
+from gi.repository import GLib
 
 class AgentManager(Base):
     _interface_name = 'org.bluez.AgentManager1'
@@ -14,9 +14,12 @@ class AgentManager(Base):
         super(AgentManager, self)._init(interface_name=self._interface_name, obj_path='/org/bluez')
 
     def register_agent(self, agent_path, capability='', default=False):
-        self._call('RegisterAgent', agent_path, capability)
+        param = GLib.Variant('(os)', (agent_path, capability))
+        self._call('RegisterAgent', param)
         if default:
-            self._call('RequestDefaultAgent', agent_path)
+            default_param = GLib.Variant('(o)', (agent_path,))
+            self._call('RequestDefaultAgent', default_param)
 
     def unregister_agent(self, agent_path):
-        self._call('UnregisterAgent', agent_path)
+        param = GLib.Variant('(o)', (agent_path,))
+        self._call('UnregisterAgent', param)

--- a/blueman/bluez/AnyBase.py
+++ b/blueman/bluez/AnyBase.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from gi.repository import GObject
+from gi.repository import Gio
+
+
+class AnyBase(GObject.GObject):
+    __gsignals__ = {
+        str('property-changed'): (GObject.SignalFlags.NO_HOOKS, None,
+                                  (GObject.TYPE_PYOBJECT,
+                                   GObject.TYPE_PYOBJECT,
+                                   GObject.TYPE_PYOBJECT))
+    }
+
+    connect_signal = GObject.GObject.connect
+    disconnect_signal = GObject.GObject.disconnect
+
+    __bus = Gio.bus_get_sync(Gio.BusType.SYSTEM)
+    __bus_name = 'org.bluez'
+    __bus_interface_name = 'org.freedesktop.DBus.Properties'
+
+    def __init__(self, interface_name):
+        super(AnyBase, self).__init__()
+
+        self.__interface_name = interface_name
+        self.__signals = []
+
+        def on_signal(_connection, _sender_name, object_path, _interface_name,
+                      _signal_name, param):
+            self._on_properties_changed(object_path, *param.unpack())
+
+        sig = self.__bus.signal_subscribe(self.__bus_name, self.__bus_interface_name,
+            'PropertiesChanged', None, None, Gio.DBusSignalFlags.NONE, on_signal)
+
+        self.__signals.append(sig)
+
+    def _on_properties_changed(self, object_path, interface_name, changed_properties, invalidated):
+        if self.__interface_name == interface_name:
+            for name, value in changed_properties.items():
+                self.emit('property-changed', name, value, object_path)
+
+    def __del__(self):
+        for signal in self.__signals:
+            self.__bus.signal_unsubscribe(signal)

--- a/blueman/bluez/Device.py
+++ b/blueman/bluez/Device.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.bluez.PropertiesBase import PropertiesBase
+from blueman.bluez.AnyBase import AnyBase
 
 
 class Device(PropertiesBase):
@@ -21,3 +22,8 @@ class Device(PropertiesBase):
 
     def disconnect(self, reply_handler=None, error_handler=None):
         self._call('Disconnect', reply_handler=reply_handler, error_handler=error_handler)
+
+
+class AnyDevice(AnyBase):
+    def __init__(self):
+        super(AnyDevice, self).__init__('org.bluez.Device1')

--- a/blueman/bluez/Makefile.am
+++ b/blueman/bluez/Makefile.am
@@ -11,6 +11,7 @@ blueman_PYTHON =				\
 	Device.py					\
 	errors.py					\
 	Manager.py					\
+	ManagerBase.py					\
 	PropertiesBase.py				\
 	Network.py					\
 	NetworkServer.py

--- a/blueman/bluez/Makefile.am
+++ b/blueman/bluez/Makefile.am
@@ -6,6 +6,7 @@ blueman_PYTHON =				\
 	Adapter.py					\
 	Agent.py					\
 	AgentManager.py				\
+	AnyBase.py					\
 	Base.py						\
 	Device.py					\
 	errors.py					\

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -91,3 +91,8 @@ class Manager(GObject.GObject):
         # If the given - or any - adapter does not exist, raise the NoSuchAdapter
         # error BlueZ 4's DefaultAdapter and FindAdapter methods trigger
         raise DBusNoSuchAdapterError('No such adapter')
+
+    @classmethod
+    def watch_name_owner(cls, appeared_handler, vanished_handler):
+        Gio.bus_watch_name(Gio.BusType.SYSTEM, cls.__bus_name, Gio.BusNameWatcherFlags.AUTO_START,
+                           appeared_handler, vanished_handler)

--- a/blueman/bluez/ManagerBase.py
+++ b/blueman/bluez/ManagerBase.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from gi.repository import GObject, Gio
+from blueman.Functions import dprint
+
+from blueman.bluez.Adapter import Adapter
+from blueman.bluez.PropertiesBase import PropertiesBase
+from blueman.bluez.errors import DBusNoSuchAdapterError
+
+
+class ManagerBase(GObject.GObject):
+    connect_signal = GObject.GObject.connect
+    disconnect_signal = GObject.GObject.disconnect
+
+    __bus_name = 'org.bluez'
+    __bus_type = Gio.BusType.SYSTEM
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(ManagerBase, cls).__new__(cls)
+            cls._instance._init(*args, **kwargs)
+        return cls._instance
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __del__(self):
+        for sig in self.__signals:
+            self._object_manager.disconnect(sig)
+
+    def _init(self):
+        super(ManagerBase, self).__init__()
+        self.__signals = []
+
+        self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
+            self.__bus_type, Gio.DBusObjectManagerClientFlags.NONE,
+            self.__bus_name, '/', None, None, None)
+
+        self.__signals.append(self._object_manager.connect('object-added', self._on_object_added))
+        self.__signals.append(self._object_manager.connect('object-removed', self._on_object_removed))
+
+    def _on_object_added(self, object_manager, dbus_object):
+        # Override in subclass
+        pass
+
+    def _on_object_removed(self, object_manager, dbus_object):
+        # Override in subclass
+        pass
+
+    @classmethod
+    def watch_name_owner(cls, appeared_handler, vanished_handler):
+        Gio.bus_watch_name(cls.__bus_type, cls.__bus_name, Gio.BusNameWatcherFlags.AUTO_START,
+                           appeared_handler, vanished_handler)

--- a/blueman/bluez/Network.py
+++ b/blueman/bluez/Network.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.bluez.PropertiesBase import PropertiesBase
+from blueman.bluez.AnyBase import AnyBase
+from gi.repository import GLib
 
 
 class Network(PropertiesBase):
@@ -18,3 +20,7 @@ class Network(PropertiesBase):
 
     def disconnect(self, reply_handler=None, error_handler=None):
         self._call('Disconnect', reply_handler=reply_handler, error_handler=error_handler)
+
+class AnyNetwork(AnyBase):
+    def __init__(self):
+        super(AnyNetwork, self).__init__('org.bluez.Network1')

--- a/blueman/bluez/Network.py
+++ b/blueman/bluez/Network.py
@@ -16,7 +16,8 @@ class Network(PropertiesBase):
         super(Network, self)._init(interface_name=self._interface_name, obj_path=obj_path)
 
     def connect(self, uuid, reply_handler=None, error_handler=None):
-        self._call('Connect', uuid, reply_handler=reply_handler, error_handler=error_handler)
+        param = GLib.Variant('(s)', (uuid,))
+        self._call('Connect', param, reply_handler=reply_handler, error_handler=error_handler)
 
     def disconnect(self, reply_handler=None, error_handler=None):
         self._call('Disconnect', reply_handler=reply_handler, error_handler=error_handler)

--- a/blueman/bluez/NetworkServer.py
+++ b/blueman/bluez/NetworkServer.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.bluez.PropertiesBase import PropertiesBase
-
+from gi.repository import GLib
 
 class NetworkServer(PropertiesBase):
     _interface_name = 'org.bluez.NetworkServer1'
@@ -14,7 +14,9 @@ class NetworkServer(PropertiesBase):
         super(NetworkServer, self)._init(interface_name=self._interface_name, obj_path=obj_path)
 
     def register(self, uuid, bridge):
-        self._call('Register', uuid, bridge)
+        param = GLib.Variant('(ss)', (uuid, bridge))
+        self._call('Register', param)
 
     def unregister(self, uuid):
-        self._call('Unregister', uuid)
+        param = GLib.Variant('(s)', (uuid,))
+        self._call('Unregister', param)

--- a/blueman/bluez/__init__.py
+++ b/blueman/bluez/__init__.py
@@ -4,9 +4,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from blueman.bluez.Adapter import Adapter
+from blueman.bluez.Adapter import Adapter, AnyAdapter
 from blueman.bluez.AgentManager import AgentManager
-from blueman.bluez.Device import Device
+from blueman.bluez.Device import Device, AnyDevice
 from blueman.bluez.Manager import Manager
 
 import blueman.bluez.errors

--- a/blueman/bluez/errors.py
+++ b/blueman/bluez/errors.py
@@ -4,8 +4,6 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import dbus
-
 
 class BluezDBusException(Exception):
     def __init__(self, reason):
@@ -107,35 +105,34 @@ class BluezUnavailableAgentMethodError(BluezDBusException):
     pass
 
 
-__DICT_ERROR__ = {'org.bluez.Error.Failed:': DBusFailedError,
-                  'org.bluez.Error.InvalidArguments:': DBusInvalidArgumentsError,
-                  'org.bluez.Error.NotAuthorized:': DBusNotAuthorizedError,
-                  'org.bluez.Error.OutOfMemory:': DBusOutOfMemoryError,
-                  'org.bluez.Error.NoSuchAdapter:': DBusNoSuchAdapterError,
-                  'org.bluez.Error.NotReady:': DBusNotReadyError,
-                  'org.bluez.Error.NotAvailable:': DBusNotAvailableError,
-                  'org.bluez.Error.NotConnected:': DBusNotConnectedError,
-                  'org.bluez.serial.Error.ConnectionAttemptFailed:': DBusConnectionAttemptFailedError,
-                  'org.bluez.Error.AlreadyExists:': DBusAlreadyExistsError,
-                  'org.bluez.Error.DoesNotExist:': DBusDoesNotExistError,
-                  'org.bluez.Error.InProgress:': DBusInProgressError,
-                  'org.bluez.Error.NoReply:': DBusNoReplyError,
-                  'org.bluez.Error.NotSupported:': DBusNotSupportedError,
-                  'org.bluez.Error.AuthenticationFailed:': DBusAuthenticationFailedError,
-                  'org.bluez.Error.AuthenticationTimeout:': DBusAuthenticationTimeoutError,
-                  'org.bluez.Error.AuthenticationRejected:': DBusAuthenticationRejectedError,
-                  'org.bluez.Error.AuthenticationCanceled:': DBusAuthenticationCanceledError,
-                  'org.bluez.serial.Error.NotSupported:': DBusNotSupportedError,
-                  'org.bluez.Error.UnsupportedMajorClass:': DBusUnsupportedMajorClassError,
-                  'org.freedesktop.DBus.Error.ServiceUnknown:': DBusServiceUnknownError}
+__DICT_ERROR__ = {'org.bluez.Error.Failed': DBusFailedError,
+                  'org.bluez.Error.InvalidArguments': DBusInvalidArgumentsError,
+                  'org.bluez.Error.NotAuthorized': DBusNotAuthorizedError,
+                  'org.bluez.Error.OutOfMemory': DBusOutOfMemoryError,
+                  'org.bluez.Error.NoSuchAdapter': DBusNoSuchAdapterError,
+                  'org.bluez.Error.NotReady': DBusNotReadyError,
+                  'org.bluez.Error.NotAvailable': DBusNotAvailableError,
+                  'org.bluez.Error.NotConnected': DBusNotConnectedError,
+                  'org.bluez.serial.Error.ConnectionAttemptFailed': DBusConnectionAttemptFailedError,
+                  'org.bluez.Error.AlreadyExists': DBusAlreadyExistsError,
+                  'org.bluez.Error.DoesNotExist': DBusDoesNotExistError,
+                  'org.bluez.Error.InProgress': DBusInProgressError,
+                  'org.bluez.Error.NoReply': DBusNoReplyError,
+                  'org.bluez.Error.NotSupported': DBusNotSupportedError,
+                  'org.bluez.Error.AuthenticationFailed': DBusAuthenticationFailedError,
+                  'org.bluez.Error.AuthenticationTimeout': DBusAuthenticationTimeoutError,
+                  'org.bluez.Error.AuthenticationRejected': DBusAuthenticationRejectedError,
+                  'org.bluez.Error.AuthenticationCanceled': DBusAuthenticationCanceledError,
+                  'org.bluez.serial.Error.NotSupported': DBusNotSupportedError,
+                  'org.bluez.Error.UnsupportedMajorClass': DBusUnsupportedMajorClassError,
+                  'org.freedesktop.DBus.Error.ServiceUnknown': DBusServiceUnknownError}
 
 
 def parse_dbus_error(exception):
     global __DICT_ERROR__
 
-    aux = "%s" % exception
-    aux_splt = aux.split(None, 1)
+    gerror, dbus_error, message = exception.message.split(':')
     try:
-        return __DICT_ERROR__[aux_splt[0]](aux_splt[1])
+        return __DICT_ERROR__[dbus_error](message)
     except KeyError:
-        return exception
+        return BluezDBusException(dbus_error + message)

--- a/blueman/bluez/errors.py
+++ b/blueman/bluez/errors.py
@@ -131,7 +131,7 @@ __DICT_ERROR__ = {'org.bluez.Error.Failed': DBusFailedError,
 def parse_dbus_error(exception):
     global __DICT_ERROR__
 
-    gerror, dbus_error, message = exception.message.split(':')
+    gerror, dbus_error, message = exception.message.split(':', 2)
     try:
         return __DICT_ERROR__[dbus_error](message)
     except KeyError:

--- a/blueman/bluez/obex/Agent.py
+++ b/blueman/bluez/obex/Agent.py
@@ -4,58 +4,42 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import dbus
-import dbus.service
-from gi.repository import GObject
-from gi.types import GObjectMeta
-from inspect import isclass
-from blueman.Functions import dprint
-from blueman.bluez.obex.Error import Error
+from gi.repository import Gio, GLib
 
+introspection_xml = \
+'''
+<node name='/org/blueman/obex_agent'>
+  <interface name='org.bluez.obex.Agent1'>
+    <method name='Release'/>
+    <method name='Cancel'/>
+    <method name ='AuthorizePush'>
+      <arg type='o' name='transfer' direction='in'/>
+      <arg type='s' name='path' direction='out'/>
+    </method>
+  </interface>
+</node>
+'''
 
-class _GDbusObjectType(dbus.service.InterfaceType, GObjectMeta):
-    pass
+class Agent(object):
+    __bus = Gio.bus_get_sync(Gio.BusType.SESSION)
 
-_GDBusObject = _GDbusObjectType(str('_GDBusObject'), (dbus.service.Object, GObject.GObject), {})
+    def __init__(self, agent_path, handle_method_call):
+        node_info = Gio.DBusNodeInfo.new_for_xml(introspection_xml)
 
+        regid = self.__bus.register_object(
+            agent_path,
+            node_info.interfaces[0],
+            handle_method_call,
+            None,
+            None)
 
-# noinspection PyPep8Naming
-class Agent(_GDBusObject, dbus.service.Object, GObject.GObject):
-    __gsignals__ = {
-        str('release'): (GObject.SignalFlags.NO_HOOKS, None, ()),
-        str('authorize'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
-        str('cancel'): (GObject.SignalFlags.NO_HOOKS, None, ()),
-    }
-
-    def __init__(self, agent_path):
-        self._agent_path = agent_path
-        dbus.service.Object.__init__(self, dbus.SessionBus(), agent_path)
-        GObject.GObject.__init__(self)
-        self._reply_handler = None
-        self._error_handler = None
-
-    @dbus.service.method('org.bluez.obex.Agent1')
-    def Release(self):
-        dprint(self._agent_path)
-        self.emit('release')
-
-    @dbus.service.method('org.bluez.obex.Agent1', async_callbacks=('reply_handler', 'error_handler'))
-    def AuthorizePush(self, transfer_path, reply_handler, error_handler):
-        dprint(self._agent_path, transfer_path)
-        self._reply_handler = reply_handler
-        self._error_handler = error_handler
-        self.emit('authorize', transfer_path)
-
-    @dbus.service.method('org.bluez.obex.Agent1')
-    def Cancel(self):
-        dprint(self._agent_path)
-        self.emit('cancel')
-
-    def reply(self, reply):
-        dprint(self._agent_path, reply)
-        if isclass(reply) and issubclass(reply, Error):
-            self._error_handler(dbus.DBusException(name=('org.bluez.obex.Error.%s' % reply.__name__)))
+        if regid:
+            self.__regid = regid
         else:
-            self._reply_handler(reply)
-        self._reply_handler = None
-        self._error_handler = None
+            raise GLib.Error('Failed to register object with path: %s', agent_path)
+
+    def __del__(self):
+        self._unregister_object()
+
+    def _unregister_object(self):
+        self.__bus.unregister_object(self.__regid)

--- a/blueman/bluez/obex/Agent.py
+++ b/blueman/bluez/obex/Agent.py
@@ -4,7 +4,8 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from gi.repository import Gio, GLib
+from gi.repository import Gio
+from blueman.bluez.Agent import Agent as AgentBase
 
 introspection_xml = \
 '''
@@ -20,26 +21,6 @@ introspection_xml = \
 </node>
 '''
 
-class Agent(object):
-    __bus = Gio.bus_get_sync(Gio.BusType.SESSION)
 
-    def __init__(self, agent_path, handle_method_call):
-        node_info = Gio.DBusNodeInfo.new_for_xml(introspection_xml)
-
-        regid = self.__bus.register_object(
-            agent_path,
-            node_info.interfaces[0],
-            handle_method_call,
-            None,
-            None)
-
-        if regid:
-            self.__regid = regid
-        else:
-            raise GLib.Error('Failed to register object with path: %s', agent_path)
-
-    def __del__(self):
-        self._unregister_object()
-
-    def _unregister_object(self):
-        self.__bus.unregister_object(self.__regid)
+class Agent(AgentBase):
+    __bus_type = Gio.BusType.SESSION

--- a/blueman/bluez/obex/AgentManager.py
+++ b/blueman/bluez/obex/AgentManager.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 from blueman.Functions import dprint
 from blueman.bluez.obex.Base import Base
-
+from gi.repository import GLib
 
 class AgentManager(Base):
     _interface_name = 'org.bluez.obex.AgentManager1'
@@ -21,7 +21,8 @@ class AgentManager(Base):
         def on_register_failed(error):
             dprint(agent_path, error)
 
-        self._call('RegisterAgent', agent_path, reply_handler=on_registered, error_handler=on_register_failed)
+        param = GLib.Variant('(o)', (agent_path,))
+        self._call('RegisterAgent', param, reply_handler=on_registered, error_handler=on_register_failed)
 
     def unregister_agent(self, agent_path):
         def on_unregistered():
@@ -30,4 +31,5 @@ class AgentManager(Base):
         def on_unregister_failed(error):
             dprint(agent_path, error)
 
-        self._call('UnregisterAgent', agent_path, reply_handler=on_unregistered, error_handler=on_unregister_failed)
+        param = GLib.Variant('(o)', (agent_path,))
+        self._call('UnregisterAgent', param, reply_handler=on_unregistered, error_handler=on_unregister_failed)

--- a/blueman/bluez/obex/Base.py
+++ b/blueman/bluez/obex/Base.py
@@ -4,10 +4,10 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import dbus
 from blueman.bluez.Base import Base as BlueZBase
+from gi.repository import Gio
 
 
 class Base(BlueZBase):
-    __bus = dbus.SessionBus()
+    __bus = Gio.bus_get_sync(Gio.BusType.SESSION)
     __bus_name = 'org.bluez.obex'

--- a/blueman/bluez/obex/Client.py
+++ b/blueman/bluez/obex/Client.py
@@ -4,10 +4,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import dbus
 from blueman.Functions import dprint
 from blueman.bluez.obex.Base import Base
-from gi.repository import GObject
+from gi.repository import GObject, GLib, Gio
 
 
 class ObexdNotFoundError(Exception):
@@ -24,8 +23,13 @@ class Client(Base):
     _interface_name = 'org.bluez.obex.Client1'
 
     def _init(self):
-        obj = dbus.SessionBus().get_object('org.bluez.obex', '/')
-        introspection = dbus.Interface(obj, 'org.freedesktop.DBus.Introspectable').Introspect()
+        proxy = Gio.DBusProxy.new_for_bus_sync(
+            Gio.BusType.SESSION, Gio.DBusProxyFlags.NONE, None, 'org.bluez.obex', '/',
+            'org.freedesktop.DBus.Introspectable')
+
+        introspection = proxy.call_sync('Introspect', None, Gio.DBusCallFlags.NONE,
+            -1, None).unpack()[0]
+
         if 'org.freedesktop.DBus.ObjectManager' not in introspection:
             raise ObexdNotFoundError('Could not find any compatible version of obexd')
 
@@ -40,8 +44,10 @@ class Client(Base):
             dprint(dest_addr, source_addr, pattern, error)
             self.emit("session-failed", error)
 
-        self._call('CreateSession', dest_addr, {"Source": source_addr, "Target": pattern},
-                   reply_handler=on_session_created, error_handler=on_session_failed)
+        v_source_addr = GLib.Variant('s', source_addr)
+        v_pattern = GLib.Variant('s', pattern)
+        param = GLib.Variant('(sa{sv})', (dest_addr, {"Source": v_source_addr, "Target": v_pattern}))
+        self._call('CreateSession', param, reply_handler=on_session_created, error_handler=on_session_failed)
 
     def remove_session(self, session_path):
         def on_session_removed():
@@ -51,5 +57,6 @@ class Client(Base):
         def on_session_remove_failed(error):
             dprint(session_path, error)
 
-        self._call('RemoveSession', session_path, reply_handler=on_session_removed,
+        param = GLib.Variant('(o)', (session_path,))
+        self._call('RemoveSession', param, reply_handler=on_session_removed,
                    error_handler=on_session_remove_failed)

--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -6,46 +6,24 @@ from __future__ import unicode_literals
 
 from blueman.Functions import dprint
 from blueman.bluez.obex.Transfer import Transfer
+from blueman.bluez.ManagerBase import ManagerBase
 from gi.repository import GObject, Gio
 
 
-class Manager(GObject.GObject):
+class Manager(ManagerBase):
     __gsignals__ = {
         str('session-removed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
         str('transfer-started'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
         str('transfer-completed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT, GObject.TYPE_PYOBJECT)),
     }
 
-    connect_signal = GObject.GObject.connect
-    disconnect_signal = GObject.GObject.disconnect
-
     __bus_name = 'org.bluez.obex'
-    _instance = None
-
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            cls._instance = super(Manager, cls).__new__(cls)
-            cls._instance._init(*args, **kwargs)
-        return cls._instance
-
-    def __init__(self, *args, **kwargs):
-        pass
+    __bus_type = Gio.BusType.SESSION
 
     def _init(self):
-        super(Manager, self).__init__()
+        super(Manager, self)._init()
         self.__transfers = {}
         self.__signals = []
-
-        self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
-            Gio.BusType.SYSTEM, Gio.DBusObjectManagerClientFlags.NONE,
-            self.__bus_name, '/', None, None, None)
-
-        self.__signals.append(self._object_manager.connect('object-added', self._on_object_added))
-        self.__signals.append(self._object_manager.connect('object-removed', self._on_object_removed))
-
-    def __del__(self):
-        for sig in self.__signals:
-            self._object_manager.disconnect(sig)
 
     def _on_object_added(self, object_manager, dbus_object):
         transfer_proxy = dbus_object.get_interface('org.bluez.obex.Transfer1')
@@ -76,8 +54,3 @@ class Manager(GObject.GObject):
 
         dprint(transfer_path, success)
         self.emit('transfer-completed', transfer_path, success)
-
-    @classmethod
-    def watch_name_owner(cls, appeared_handler, vanished_handler):
-        Gio.bus_watch_name(Gio.BusType.SESSION, cls.__bus_name, Gio.BusNameWatcherFlags.AUTO_START,
-                           appeared_handler, vanished_handler)

--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -6,53 +6,73 @@ from __future__ import unicode_literals
 
 from blueman.Functions import dprint
 from blueman.bluez.obex.Transfer import Transfer
-from blueman.bluez.obex.Base import Base
-from gi.repository import GObject
+from gi.repository import GObject, Gio
 
 
-class Manager(Base):
+class Manager(GObject.GObject):
     __gsignals__ = {
         str('session-removed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
         str('transfer-started'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
         str('transfer-completed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT, GObject.TYPE_PYOBJECT)),
     }
 
-    _interface_name = 'org.freedesktop.DBus.ObjectManager'
+    connect_signal = GObject.GObject.connect
+    disconnect_signal = GObject.GObject.disconnect
+
+    __bus_name = 'org.bluez.obex'
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(Manager, cls).__new__(cls)
+            cls._instance._init(*args, **kwargs)
+        return cls._instance
+
+    def __init__(self, *args, **kwargs):
+        pass
 
     def _init(self):
-        super(Manager, self)._init(interface_name=self._interface_name, obj_path='/')
+        super(Manager, self).__init__()
+        self.__transfers = {}
+        self.__signals = []
 
-        self._transfers = {}
+        self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
+            Gio.BusType.SYSTEM, Gio.DBusObjectManagerClientFlags.NONE,
+            self.__bus_name, '/', None, None, None)
 
-        def on_interfaces_added(object_path, interfaces):
-            if 'org.bluez.obex.Transfer1' in interfaces:
-                def on_tranfer_completed(_transfer):
-                    self._on_transfer_completed(object_path, True)
+        self.__signals.append(self._object_manager.connect('object-added', self._on_object_added))
+        self.__signals.append(self._object_manager.connect('object-removed', self._on_object_removed))
 
-                def on_tranfer_error(_transfer):
-                    self._on_transfer_completed(object_path, False)
+    def __del__(self):
+        for sig in self.__signals:
+            self._object_manager.disconnect(sig)
 
-                self._transfers[object_path] = Transfer(object_path)
-                self._transfers[object_path].connect('completed', on_tranfer_completed)
-                self._transfers[object_path].connect('error', on_tranfer_error)
-                self._on_transfer_started(object_path)
+    def _on_object_added(self, object_manager, dbus_object):
+        transfer_proxy = dbus_object.get_interface('org.bluez.obex.Transfer1')
 
-        self._handle_signal(on_interfaces_added, 'InterfacesAdded')
+        if transfer_proxy:
+            transfer_path = transfer_proxy.get_object_path()
+            transfer = Transfer(transfer_path)
+            completed_sig = transfer.connect_signal('completed', self._on_transfer_completed, True)
+            error_sig = transfer.connect_signal('error', self._on_transfer_completed, False)
+            self.__signals[transfer_path] = (completed_sig, error_sig)
 
-        def on_interfaces_removed(object_path, interfaces):
-            if 'org.bluez.obex.Session1' in interfaces:
-                self._on_session_removed(object_path)
+            dprint(transfer_path)
+            self.emit('transfer-started', transfer_path)
 
-        self._handle_signal(on_interfaces_removed, 'InterfacesRemoved')
+    def _on_object_removed(self, object_manager, dbus_object):
+        session_proxy = dbus_object.get_interface('org.bluez.obex.Session1')
 
-    def _on_session_removed(self, session_path):
-        dprint(session_path)
-        self.emit('session-removed', session_path)
+        if session_proxy:
+            session_path = session_proxy.get_object_path()
+            dprint(session_path)
+            self.emit('session-removed', session_path)
 
-    def _on_transfer_started(self, transfer_path):
-        dprint(transfer_path)
-        self.emit('transfer-started', transfer_path)
+    def _on_transfer_completed(self, transfer, success):
+        transfer_path = transfer.get_object_path()
+        signals = self.__transfers.pop(transfer_path)
+        for sig in signals:
+            transfer.disconnect_signal(sig)
 
-    def _on_transfer_completed(self, transfer_path, success):
         dprint(transfer_path, success)
         self.emit('transfer-completed', transfer_path, success)

--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -76,3 +76,8 @@ class Manager(GObject.GObject):
 
         dprint(transfer_path, success)
         self.emit('transfer-completed', transfer_path, success)
+
+    @classmethod
+    def watch_name_owner(cls, appeared_handler, vanished_handler):
+        Gio.bus_watch_name(Gio.BusType.SYSTEM, cls.__bus_name, Gio.BusNameWatcherFlags.AUTO_START,
+                           appeared_handler, vanished_handler)

--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -79,5 +79,5 @@ class Manager(GObject.GObject):
 
     @classmethod
     def watch_name_owner(cls, appeared_handler, vanished_handler):
-        Gio.bus_watch_name(Gio.BusType.SYSTEM, cls.__bus_name, Gio.BusNameWatcherFlags.AUTO_START,
+        Gio.bus_watch_name(Gio.BusType.SESSION, cls.__bus_name, Gio.BusNameWatcherFlags.AUTO_START,
                            appeared_handler, vanished_handler)

--- a/blueman/bluez/obex/ObjectPush.py
+++ b/blueman/bluez/obex/ObjectPush.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 from blueman.Functions import dprint
 from blueman.bluez.obex.Base import Base
-from gi.repository import GObject
+from gi.repository import GObject, GLib
 
 
 class ObjectPush(Base):
@@ -29,7 +29,8 @@ class ObjectPush(Base):
             dprint(file_path, error)
             self.emit('transfer-failed', error)
 
-        self._call('SendFile', file_path, reply_handler=on_transfer_started, error_handler=on_transfer_error)
+        param = GLib.Variant('(s)', (file_path,))
+        self._call('SendFile', param, reply_handler=on_transfer_started, error_handler=on_transfer_error)
 
     def get_session_path(self):
         return self.get_object_path()

--- a/blueman/bluez/obex/Session.py
+++ b/blueman/bluez/obex/Session.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from blueman.bluez.obex.Base import Base
+from gi.repository import GLib
 
 
 class Session(Base):
@@ -10,8 +11,10 @@ class Session(Base):
 
     @property
     def address(self):
-        return self._call('Get', 'org.bluez.obex.Session1', 'Destination')
+        param = GLib.Variant('(ss)', ('org.bluez.obex.Session1', 'Destination'))
+        return self._call('Get', param)
 
     @property
     def root(self):
-        return self._call('Get', 'org.bluez.obex.Session1', 'Root')
+        param = GLib.Variant('(ss)', ('org.bluez.obex.Session1', 'Root'))
+        return self._call('Get', param)

--- a/blueman/bluez/obex/Transfer.py
+++ b/blueman/bluez/obex/Transfer.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 from blueman.Functions import dprint
 from blueman.bluez.obex.Base import Base
-from gi.repository import GObject
+from gi.repository import GObject, GLib
 
 
 class Transfer(Base):
@@ -16,22 +16,29 @@ class Transfer(Base):
         str('error'): (GObject.SignalFlags.NO_HOOKS, None, ())
     }
 
-    _interface_name = 'org.freedesktop.DBus.Properties'
+    _interface_name = 'org.bluez.obex.Transfer1'
 
     def _init(self, transfer_path):
-        super(Transfer, self)._init(interface_name=self._interface_name, obj_path=transfer_path)
-        self._handle_signal(self._on_properties_changed, 'PropertiesChanged')
+        super(Transfer, self)._init(interface_name=self._interface_name,
+                                    obj_path=transfer_path,
+                                    properties_interface=True)
+
+        self.__signals = []
+        sig = self._dbus_proxy.connect('g-properties-changed', self._on_properties_changed)
+        self.__signals.append(sig)
+
+    def get(self, name):
+        param = GLib.Variant('(ss)', (self._interface_name, name))
+        prop = self._call('Get', param, True)[0]
+        return prop
 
     def __getattr__(self, name):
         if name in ('filename', 'name', 'session', 'size'):
-            return self._call('Get', 'org.bluez.obex.Transfer1', name.capitalize())
+            return self.get(name.capitalize())
 
-    def _on_properties_changed(self, interface_name, changed_properties, _invalidated_properties):
-        if interface_name != 'org.bluez.obex.Transfer1':
-            return
-
-        for name, value in changed_properties.items():
-            dprint(self.get_object_path(), name, value)
+    def _on_properties_changed(self, proxy, changed_properties, _invalidated_properties):
+        for name, value in changed_properties.unpack().items():
+            dprint(proxy.get_object_path(), name, value)
             if name == 'Transferred':
                 self.emit('progress', value)
             elif name == 'Status':

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -199,7 +199,7 @@ class ManagerDeviceList(DeviceList):
 
             fader.disconnect(signal)
             fader.freeze()
-            DeviceList.device_remove_event(self, device, tree_iter)
+            super(ManagerDeviceList, self).device_remove_event(device, tree_iter)
 
         signal = row_fader.connect("animation-finished", on_finished)
         row_fader.thaw()

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -8,8 +8,8 @@ from locale import bind_textdomain_codeset
 from operator import itemgetter
 from blueman.Sdp import uuid128_to_uuid16, SERIAL_PORT_SVCLASS_ID, OBEX_OBJPUSH_SVCLASS_ID, OBEX_FILETRANS_SVCLASS_ID
 from blueman.Functions import *
-from blueman.bluez.Network import Network
-from blueman.bluez.Device import Device
+from blueman.bluez.Network import AnyNetwork
+from blueman.bluez.Device import AnyDevice
 from blueman.gui.manager.ManagerProgressbar import ManagerProgressbar
 from blueman.main.AppletService import AppletService
 from blueman.gui.MessageArea import MessageArea
@@ -48,10 +48,10 @@ class ManagerDeviceMenu(Gtk.Menu):
 
         ManagerDeviceMenu.__instances__.append(self)
 
-        self._any_network = Network()
+        self._any_network = AnyNetwork()
         self._any_network.connect_signal('property-changed', self._on_service_property_changed)
 
-        self._any_device = Device()
+        self._any_device = AnyDevice()
         self._any_device.connect_signal('property-changed', self._on_service_property_changed)
 
         self.Generate()

--- a/blueman/plugins/applet/AuthAgent.py
+++ b/blueman/plugins/applet/AuthAgent.py
@@ -36,5 +36,5 @@ class AuthAgent(AppletPlugin):
 
     def _remove_agent(self):
         if self._agent:
-            self._agent.Release()
+            self._agent._on_release()
             del self._agent

--- a/blueman/plugins/applet/DhcpClient.py
+++ b/blueman/plugins/applet/DhcpClient.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import dbus.service
-from blueman.bluez.Network import Network
+from blueman.bluez.Network import AnyNetwork
 from blueman.gui.Notification import Notification
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.main.Mechanism import Mechanism
@@ -20,7 +20,7 @@ class DhcpClient(AppletPlugin):
     _any_network = None
 
     def on_load(self, applet):
-        self._any_network = Network()
+        self._any_network = AnyNetwork()
         self._any_network.connect_signal('property-changed', self._on_network_prop_changed)
 
         self.quering = []

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -9,7 +9,7 @@ from blueman.Constants import *
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.main.Config import Config
 from blueman.bluez.Device import Device
-from blueman.bluez.Network import Network
+from blueman.bluez.Network import AnyNetwork
 from _blueman import rfcomm_list
 from gi.repository import GObject
 from gi.repository import GLib
@@ -334,7 +334,7 @@ class NetUsage(AppletPlugin, GObject.GObject):
 
         self.bus = dbus.SystemBus()
 
-        self._any_network = Network()
+        self._any_network = AnyNetwork()
         self._any_network.connect_signal('property-changed', self._on_network_property_changed)
 
         item = create_menuitem(_("Network _Usage"), get_icon("network-wireless", 16))

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -16,52 +16,65 @@ from blueman.gui.Notification import Notification
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.main.Config import Config
 
-class _Agent:
+class Agent(obex.Agent):
+    __agent_path = '/org/bluez/obex/agent/blueman'
+
     def __init__(self, applet):
+        super(Agent, self).__init__(self.__agent_path, self._handle_method_call)
+
         self._applet = applet
         self._config = Config("org.blueman.transfer")
-
-        self._agent_path = '/org/blueman/obex_agent'
-
-        self._agent = obex.Agent(self._agent_path)
-        self._agent.connect('release', self._on_release)
-        self._agent.connect('authorize', self._on_authorize)
-        self._agent.connect('cancel', self._on_cancel)
 
         self._allowed_devices = []
         self._notification = None
         self._pending_transfer = None
         self.transfers = {}
 
+    def _handle_method_call(self, connection, sender, agent_path, interface_name, method_name, parameters, invocation):
+        if method_name == 'Release':
+            dprint(agent_path)
+            self._on_release()
+        elif method_name == 'AuthorizePush':
+            dprint(agent_path)
+            self._on_authorize(parameters, invocation)
+        elif method_name == 'Cancel':
+            dprint(agent_path)
+            self._on_cancel(parameters, invocation)
+
     def register(self):
-        obex.AgentManager().register_agent(self._agent_path)
+        obex.AgentManager().register_agent(self.__agent_path)
 
     def unregister(self):
-        obex.AgentManager().unregister_agent(self._agent_path)
+        obex.AgentManager().unregister_agent(self.__agent_path)
 
-    def _on_release(self, _agent):
-        raise Exception(self._agent_path + " was released unexpectedly")
+    def _on_release(self):
+        raise Exception(self.__agent_path + " was released unexpectedly")
 
-    def _on_action(self, _notification, action):
-        dprint(action)
+    def _on_authorize(self, parameters, invocation):
+        def on_action(_notification, action):
+            dprint(action)
 
-        if action == "accept":
-            self.transfers[self._pending_transfer['transfer_path']] = {
-                'path': self._pending_transfer['root'] + '/' + os.path.basename(self._pending_transfer['filename']),
-                'size': self._pending_transfer['size'],
-                'name': self._pending_transfer['name']
-            }
-            self._agent.reply(self.transfers[self._pending_transfer['transfer_path']]['path'])
-            self._allowed_devices.append(self._pending_transfer['address'])
-            GLib.timeout_add(60000, self._allowed_devices.remove, self._pending_transfer['address'])
-        else:
-            self._agent.reply(obex.Error.Rejected)
+            if action == "accept":
+                self.transfers[self._pending_transfer['transfer_path']] = {
+                    'path': self._pending_transfer['root'] + '/' + os.path.basename(self._pending_transfer['filename']),
+                    'size': self._pending_transfer['size'],
+                    'name': self._pending_transfer['name']
+                }
 
-    def _on_authorize(self, _agent, transfer_path):
+                param = GLib.Variant('(s)', (self.transfers[self._pending_transfer['transfer_path']]['path'],))
+                invocation.return_value(param)
+
+                self._allowed_devices.append(self._pending_transfer['address'])
+                GLib.timeout_add(60000, self._allowed_devices.remove, self._pending_transfer['address'])
+            else:
+                invocation.return_dbus_error('org.bluez.obex.Error.Rejected', 'Rejected')
+
+        transfer_path = parameters.unpack()[0]
+
         transfer = obex.Transfer(transfer_path)
         session = obex.Session(transfer.session)
-        root = session.root
-        address = session.address
+        root = session.root[0]
+        address = session.address[0]
         filename = transfer.name
         size = transfer.size
 
@@ -87,7 +100,7 @@ class _Agent:
             self._notification = Notification(_("Incoming file over Bluetooth"),
                 _("Incoming file %(0)s from %(1)s") % {"0": "<b>" + filename + "</b>",
                                                        "1": "<b>" + name + "</b>"},
-                30000, [["accept", _("Accept"), "help-about"], ["reject", _("Reject"), "help-about"]], self._on_action,
+                30000, [["accept", _("Accept"), "help-about"], ["reject", _("Reject"), "help-about"]], on_action,
                 pixbuf=get_icon("blueman", 48), status_icon=status_icon)
         # Device is trusted or was already allowed, larger file -> display a notification, but auto-accept
         elif size > 350000:
@@ -95,14 +108,15 @@ class _Agent:
                 _("Receiving file %(0)s from %(1)s") % {"0": "<b>" + filename + "</b>",
                                                         "1": "<b>" + name + "</b>"},
                 pixbuf=get_icon("blueman", 48), status_icon=status_icon)
-            self._on_action(self._notification, 'accept')
+            on_action(self._notification, 'accept')
         # Device is trusted or was already allowed. very small file -> auto-accept and transfer silently
         else:
             self._notification = None
-            self._on_action(self._notification, "accept")
+            on_action(self._notification, "accept")
 
-    def _on_cancel(self, agent):
+    def _on_cancel(self, parameters, invocation):
         self._notification.close()
+        invocation.return_dbus_error('org.bluez.obex.Error.Canceled', 'Canceled')
         agent.reply(obex.Error.Canceled)
 
 
@@ -157,7 +171,7 @@ class TransferService(AppletPlugin):
 
     def _register_agent(self):
         if not self.__class__._agent:
-            self.__class__._agent = _Agent(self._applet)
+            self.__class__._agent = Agent(self._applet)
         self._agent.register()
 
     @classmethod

--- a/blueman/plugins/manager/Info.py
+++ b/blueman/plugins/manager/Info.py
@@ -1,8 +1,8 @@
-import dbus
 from gi.repository import Gtk
 
 from blueman.Functions import create_menuitem, get_icon
 from blueman.Sdp import uuid128_to_uuid16, uuid16_to_name
+from blueman.bluez.errors import BluezDBusException
 
 from blueman.plugins.ManagerPlugin import ManagerPlugin
 
@@ -59,7 +59,7 @@ def show_info(device, parent):
                 store.append((prop[0], prop[1](device.get(prop[0]))))
             else:
                 store.append((prop, device.get(prop)))
-        except dbus.exceptions.DBusException:
+        except BluezDBusException:
             pass
     dialog.run()
     dialog.destroy()

--- a/blueman/plugins/mechanism/Rfcomm.py.in
+++ b/blueman/plugins/mechanism/Rfcomm.py.in
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import

--- a/blueman/services/Functions.py
+++ b/blueman/services/Functions.py
@@ -5,8 +5,8 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from blueman.Sdp import uuid128_to_uuid16
+from blueman.bluez.errors import BluezDBusException
 import blueman.services
-import dbus
 import inspect
 
 
@@ -20,6 +20,6 @@ def get_services(device):
     try:
         services = (get_service(device, uuid) for uuid in device['UUIDs'])
         return [service for service in services if service]
-    except dbus.exceptions.DBusException as e:
+    except BluezDBusException as e:
         dprint(e)
         return []

--- a/blueman/services/__init__.py
+++ b/blueman/services/__init__.py
@@ -12,4 +12,4 @@ from blueman.services.HandsfreeGateway import HandsfreeGateway
 from blueman.services.Input import Input
 from blueman.services.NetworkAccessPoint import NetworkAccessPoint
 from blueman.services.SerialPort import SerialPort
-from blueman.services.Functions import *
+from blueman.services.Functions import get_service, get_services

--- a/blueman/services/meta/NetworkService.py
+++ b/blueman/services/meta/NetworkService.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.Functions import dprint
-from dbus import DBusException
+from blueman.bluez.errors import BluezDBusException
 from blueman.Service import Service
 from blueman.bluez.Network import Network
 
@@ -19,7 +19,7 @@ class NetworkService(Service):
     def connected(self):
         try:
             return self._service.get_properties()['Connected']
-        except DBusException as e:
+        except BluezDBusException as e:
             dprint('Could not get properties of network service: %s' % e)
             return False
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -60,6 +60,7 @@ blueman/plugins/mechanism/RfKill.py
 blueman/plugins/mechanism/Network.py
 blueman/plugins/mechanism/Ppp.py
 blueman/plugins/mechanism/__init__.py
+blueman/plugins/manager/Info.py
 blueman/plugins/manager/PulseAudioProfile.py
 blueman/plugins/manager/__init__.py
 blueman/plugins/manager/Services.py


### PR DESCRIPTION
This is a partial rewrite from the gdbus branch. Here are the differences:

 * It uses the signals provided by the GDBusProxy objects and does not interact with dbus directly for this any-more.
 * It does not ``prepare_arguments`` and leaves it up to the caller. The main reason is clarity and simplicity, the caller knows what parameters to provide and what it expects back. ``Base._call`` just gets out of the way and let the caller handle things.
 * Both Managers now subclass from GObject instead of PropertiesBase. The reason is simple, Gio's DBusObjectManager handles everything and we do not need to subscribe the bus directly for signals any-more. They only shares a single identical function right now but at some point when this increases we should probably think of having a ManagerBase class.
 * It does not use the get/set_cached_property functions. These only ever interact with the __cached__ properties so when we set a property it only updates the cache not the actual dbus object.
 * It has new Any* clases if there is a need to catch all signals for a adapter, device and network objects. This does not include the changes suggested, not forgotten and looking at the plugin design a bit.

It works ok for me but there are probably small bugs here and there lurking. I would propose we use this as a basis and replace the current gdbus branch with this.

edit: It looks like my phone has file transfer problems so this needs more testing,