### PR TITLE
blueman-manager: Fix authentication failed handling

### DIFF
--- a/apps/blueman-manager
+++ b/apps/blueman-manager
@@ -31,6 +31,7 @@ from blueman.gui.manager.ManagerProgressbar import ManagerProgressbar
 from blueman.main.Config import Config
 
 from blueman.gui.MessageArea import MessageArea
+from blueman.gui.Notification import Notification
 
 from blueman.main.PluginManager import PluginManager
 import blueman.plugins.manager
@@ -197,7 +198,12 @@ class Blueman(Gtk.Window):
         launch(command, None, False, "blueman", _("Bluetooth Assistant"))
 
     def bond(self, device):
-        self.List.Adapter.find_device(device['Address']).pair()
+        def error_handler(e):
+            dprint(e)
+            message = 'Pairing failed for:\n%s (%s)' % (device['Alias'], device['Address'])
+            Notification('Bluetooth', message, pixbuf=get_icon("blueman", 48))
+
+        device.pair(error_handler=error_handler)
 
     def adapter_properties(self):
         adapter = self.List.Adapter

--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -6,47 +6,39 @@ from __future__ import unicode_literals
 from gi.repository import GObject
 from blueman.Functions import dprint
 from blueman.bluez.PropertiesBase import PropertiesBase
-from blueman.bluez.errors import raise_dbus_error
 from blueman.bluez.Device import Device
 import dbus
 
 
 class Adapter(PropertiesBase):
-    @raise_dbus_error
     def __init__(self, obj_path=None):
         super(Adapter, self).__init__('org.bluez.Adapter1', obj_path)
         proxy = dbus.SystemBus().get_object('org.bluez', '/', follow_name_owner_changes=True)
         self.manager_interface = dbus.Interface(proxy, 'org.freedesktop.DBus.ObjectManager')
 
-    @raise_dbus_error
     def find_device(self, address):
         devices = self.list_devices()
         for device in devices:
             if device.get_properties()['Address'] == address:
                 return device
 
-    @raise_dbus_error
     def list_devices(self):
-        objects = self.manager_interface.GetManagedObjects()
+        objects = self._call('GetManagedObjects', interface=self.manager_interface)
         devices = []
         for path, interfaces in objects.items():
             if 'org.bluez.Device1' in interfaces:
                 devices.append(path)
         return [Device(device) for device in devices]
 
-    @raise_dbus_error
     def start_discovery(self):
-        self._interface.StartDiscovery()
+        self._call('StartDiscovery')
 
-    @raise_dbus_error
     def stop_discovery(self):
-        self._interface.StopDiscovery()
+        self._call('StopDiscovery')
 
-    @raise_dbus_error
     def remove_device(self, device):
-        self._interface.RemoveDevice(device.get_object_path())
+        self._call('RemoveDevice', device.get_object_path())
 
-    @raise_dbus_error
     def get_name(self):
         props = self.get_properties()
         try:
@@ -54,7 +46,6 @@ class Adapter(PropertiesBase):
         except KeyError:
             return props['Name']
 
-    @raise_dbus_error
     def set_name(self, name):
         try:
             return self.set('Alias', name)

--- a/blueman/bluez/AgentManager.py
+++ b/blueman/bluez/AgentManager.py
@@ -4,22 +4,17 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.bluez.Base import Base
-from blueman.bluez.errors import raise_dbus_error
-import dbus
 
 
 class AgentManager(Base):
-    @raise_dbus_error
     def __init__(self):
         interface = 'org.bluez.AgentManager1'
         super(AgentManager, self).__init__(interface, '/org/bluez')
 
-    @raise_dbus_error
     def register_agent(self, agent_path, capability='', default=False):
-        self._interface.RegisterAgent(agent_path, capability)
+        self._call('RegisterAgent', agent_path, capability)
         if default:
-            self._interface.RequestDefaultAgent(agent_path)
+            self._call('RequestDefaultAgent', agent_path)
 
-    @raise_dbus_error
     def unregister_agent(self, agent_path):
-        self._interface.UnregisterAgent(agent_path)
+        self._call('UnregisterAgent', agent_path)

--- a/blueman/bluez/Device.py
+++ b/blueman/bluez/Device.py
@@ -4,15 +4,13 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.bluez.PropertiesBase import PropertiesBase
-from blueman.bluez.errors import raise_dbus_error, parse_dbus_error
+from blueman.bluez.errors import parse_dbus_error
 
 
 class Device(PropertiesBase):
-    @raise_dbus_error
     def __init__(self, obj_path=None):
         super(Device, self).__init__('org.bluez.Device1', obj_path)
 
-    @raise_dbus_error
     def pair(self, reply_handler=None, error_handler=None):
         def ok():
             if callable(reply_handler):
@@ -25,9 +23,8 @@ class Device(PropertiesBase):
             else:
                 raise exception
 
-        self._interface.Pair(reply_handler=ok, error_handler=err)
+        self._call('Pair', reply_handler=ok, error_handler=err)
 
-    @raise_dbus_error
     def connect(self, reply_handler=None, error_handler=None):
         def ok():
             if callable(reply_handler):
@@ -40,9 +37,8 @@ class Device(PropertiesBase):
             else:
                 raise exception
 
-        self._interface.Connect(reply_handler=ok, error_handler=err)
+        self._call('Connect', reply_handler=ok, error_handler=err)
 
-    @raise_dbus_error
     def disconnect(self, reply_handler=None, error_handler=None):
         def ok():
             if callable(reply_handler):
@@ -55,4 +51,4 @@ class Device(PropertiesBase):
             else:
                 raise exception
 
-        self._interface.Disconnect(reply_handler=ok, error_handler=err)
+        self._call('Disconnect', reply_handler=ok, error_handler=err)

--- a/blueman/bluez/Device.py
+++ b/blueman/bluez/Device.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.bluez.PropertiesBase import PropertiesBase
-from blueman.bluez.errors import parse_dbus_error
 
 
 class Device(PropertiesBase):
@@ -12,43 +11,10 @@ class Device(PropertiesBase):
         super(Device, self).__init__('org.bluez.Device1', obj_path)
 
     def pair(self, reply_handler=None, error_handler=None):
-        def ok():
-            if callable(reply_handler):
-                reply_handler()
-
-        def err(e):
-            exception = parse_dbus_error(e)
-            if callable(error_handler):
-                error_handler(exception)
-            else:
-                raise exception
-
-        self._call('Pair', reply_handler=ok, error_handler=err)
+        self._call('Pair', reply_handler=reply_handler, error_handler=error_handler)
 
     def connect(self, reply_handler=None, error_handler=None):
-        def ok():
-            if callable(reply_handler):
-                reply_handler()
-
-        def err(e):
-            exception = parse_dbus_error(e)
-            if callable(error_handler):
-                error_handler(exception)
-            else:
-                raise exception
-
-        self._call('Connect', reply_handler=ok, error_handler=err)
+        self._call('Connect', reply_handler=reply_handler, error_handler=error_handler)
 
     def disconnect(self, reply_handler=None, error_handler=None):
-        def ok():
-            if callable(reply_handler):
-                reply_handler()
-
-        def err(e):
-            exception = parse_dbus_error(e)
-            if callable(error_handler):
-                error_handler(exception)
-            else:
-                raise exception
-
-        self._call('Disconnect', reply_handler=ok, error_handler=err)
+        self._call('Disconnect', reply_handler=reply_handler, error_handler=error_handler)

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -7,7 +7,7 @@ from blueman.Functions import dprint
 
 from blueman.bluez.Adapter import Adapter
 from blueman.bluez.PropertiesBase import PropertiesBase
-from blueman.bluez.errors import raise_dbus_error, DBusNoSuchAdapterError
+from blueman.bluez.errors import DBusNoSuchAdapterError
 from dbus.mainloop.glib import DBusGMainLoop
 
 
@@ -19,7 +19,6 @@ class Manager(PropertiesBase):
         str('device-removed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
     }
 
-    @raise_dbus_error
     def __init__(self):
         DBusGMainLoop(set_as_default=True)
 
@@ -51,16 +50,14 @@ class Manager(PropertiesBase):
             dprint(object_path)
             self.emit('device-removed', object_path)
 
-    @raise_dbus_error
     def list_adapters(self):
-        objects = self._interface.GetManagedObjects()
+        objects = self._call('GetManagedObjects')
         adapters = []
         for path, interfaces in objects.items():
             if 'org.bluez.Adapter1' in interfaces:
                 adapters.append(path)
         return [Adapter(adapter) for adapter in adapters]
 
-    @raise_dbus_error
     def get_adapter(self, pattern=None):
         adapters = self.list_adapters()
         if pattern is None:

--- a/blueman/bluez/Network.py
+++ b/blueman/bluez/Network.py
@@ -4,18 +4,14 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.bluez.PropertiesBase import PropertiesBase
-from blueman.bluez.errors import raise_dbus_error
 
 
 class Network(PropertiesBase):
-    @raise_dbus_error
     def __init__(self, obj_path=None):
         super(Network, self).__init__('org.bluez.Network1', obj_path)
 
-    @raise_dbus_error
     def connect(self, uuid, reply_handler=None, error_handler=None):
-        self._interface.Connect(uuid, reply_handler=reply_handler, error_handler=error_handler)
+        self._call('Connect', uuid, reply_handler=reply_handler, error_handler=error_handler)
 
-    @raise_dbus_error
     def disconnect(self, reply_handler=None, error_handler=None):
-        self._interface.Disconnect(reply_handler=reply_handler, error_handler=error_handler)
+        self._call('Disconnect', reply_handler=reply_handler, error_handler=error_handler)

--- a/blueman/bluez/NetworkServer.py
+++ b/blueman/bluez/NetworkServer.py
@@ -4,18 +4,14 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from blueman.bluez.PropertiesBase import PropertiesBase
-from blueman.bluez.errors import raise_dbus_error
 
 
 class NetworkServer(PropertiesBase):
-    @raise_dbus_error
     def __init__(self, obj_path):
         super(NetworkServer, self).__init__('org.bluez.NetworkServer1', obj_path)
 
-    @raise_dbus_error
     def register(self, uuid, bridge):
-        self._interface.Register(uuid, bridge)
+        self._call('Register', uuid, bridge)
 
-    @raise_dbus_error
     def unregister(self, uuid):
-        self._interface.Unregister(uuid)
+        self._call('Unregister', uuid)

--- a/blueman/bluez/PropertiesBase.py
+++ b/blueman/bluez/PropertiesBase.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from gi.repository import GObject
 from blueman.Functions import dprint
 from blueman.bluez.Base import Base
-from blueman.bluez.errors import raise_dbus_error
 import dbus
 
 
@@ -34,7 +33,6 @@ class PropertiesBase(Base):
                 dprint(path, name, value)
                 self.emit('property-changed', name, value, path)
 
-    @raise_dbus_error
     def get(self, name):
         try:
             prop = self.__properties_interface.Get(self._interface_name, name)
@@ -45,15 +43,13 @@ class PropertiesBase(Base):
                 raise e
         return prop
 
-    @raise_dbus_error
     def set(self, name, value):
         if type(value) is int:
             value = dbus.UInt32(value)
-        return self.__properties_interface.Set(self._interface_name, name, value)
+        return self._call('Set', self._interface_name, name, value, interface=self.__properties_interface)
 
-    @raise_dbus_error
     def get_properties(self):
-        props = self.__properties_interface.GetAll(self._interface_name)
+        props = self._call('GetAll', self._interface_name, interface=self.__properties_interface)
         if props:
             for k, v in self.__fallback.items():
                 if k in props: continue

--- a/blueman/bluez/errors.py
+++ b/blueman/bluez/errors.py
@@ -138,17 +138,3 @@ def parse_dbus_error(exception):
         return __DICT_ERROR__[aux_splt[0]](aux_splt[1])
     except KeyError:
         return exception
-
-
-def raise_dbus_error(func):
-    def warp(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except dbus.DBusException as exception:
-            raise parse_dbus_error(exception)
-    return warp
-
-
-def raise_type_error(instance, cls):
-    if not isinstance(instance, cls):
-        raise TypeError('Expecting an instance of ' + cls.__name__ + ', not ' + type(instance).__name__)

--- a/blueman/bluez/obex/AgentManager.py
+++ b/blueman/bluez/obex/AgentManager.py
@@ -18,7 +18,7 @@ class AgentManager(Base):
         def on_register_failed(error):
             dprint(agent_path, error)
 
-        self._interface.RegisterAgent(agent_path, reply_handler=on_registered, error_handler=on_register_failed)
+        self._call('RegisterAgent', agent_path, reply_handler=on_registered, error_handler=on_register_failed)
 
     def unregister_agent(self, agent_path):
         def on_unregistered():
@@ -27,4 +27,4 @@ class AgentManager(Base):
         def on_unregister_failed(error):
             dprint(agent_path, error)
 
-        self._interface.UnregisterAgent(agent_path, reply_handler=on_unregistered, error_handler=on_unregister_failed)
+        self._call('UnregisterAgent', agent_path, reply_handler=on_unregistered, error_handler=on_unregister_failed)

--- a/blueman/bluez/obex/Client.py
+++ b/blueman/bluez/obex/Client.py
@@ -37,8 +37,8 @@ class Client(Base):
             dprint(dest_addr, source_addr, pattern, error)
             self.emit("session-failed", error)
 
-        self._interface.CreateSession(dest_addr, {"Source": source_addr, "Target": pattern},
-                                      reply_handler=on_session_created, error_handler=on_session_failed)
+        self._call('CreateSession', dest_addr, {"Source": source_addr, "Target": pattern},
+                   reply_handler=on_session_created, error_handler=on_session_failed)
 
     def remove_session(self, session_path):
         def on_session_removed():
@@ -48,5 +48,5 @@ class Client(Base):
         def on_session_remove_failed(error):
             dprint(session_path, error)
 
-        self._interface.RemoveSession(session_path, reply_handler=on_session_removed,
-                                      error_handler=on_session_remove_failed)
+        self._call('RemoveSession', session_path, reply_handler=on_session_removed,
+                   error_handler=on_session_remove_failed)

--- a/blueman/bluez/obex/ObjectPush.py
+++ b/blueman/bluez/obex/ObjectPush.py
@@ -26,7 +26,7 @@ class ObjectPush(Base):
             dprint(file_path, error)
             self.emit('transfer-failed', error)
 
-        self._interface.SendFile(file_path, reply_handler=on_transfer_started, error_handler=on_transfer_error)
+        self._call('SendFile', file_path, reply_handler=on_transfer_started, error_handler=on_transfer_error)
 
     def get_session_path(self):
         return self.get_object_path()

--- a/blueman/bluez/obex/Session.py
+++ b/blueman/bluez/obex/Session.py
@@ -7,8 +7,8 @@ class Session(Base):
 
     @property
     def address(self):
-        return self._interface.Get('org.bluez.obex.Session1', 'Destination')
+        return self._call('Get', 'org.bluez.obex.Session1', 'Destination')
 
     @property
     def root(self):
-        return self._interface.Get('org.bluez.obex.Session1', 'Root')
+        return self._call('Get', 'org.bluez.obex.Session1', 'Root')

--- a/blueman/bluez/obex/Transfer.py
+++ b/blueman/bluez/obex/Transfer.py
@@ -21,7 +21,7 @@ class Transfer(Base):
 
     def __getattr__(self, name):
         if name in ('filename', 'name', 'session', 'size'):
-            return self._interface.Get('org.bluez.obex.Transfer1', name.capitalize())
+            return self._call('Get', 'org.bluez.obex.Transfer1', name.capitalize())
 
     def _on_properties_changed(self, interface_name, changed_properties, _invalidated_properties):
         if interface_name != 'org.bluez.obex.Transfer1':


### PR DESCRIPTION
This picks a commit that changes the handling of bluez methods from the gdbus migration. It is useful as it allows for more things to be pushed down into ``blueman.bluez.Base`` and simplify things.

Just like in my gdbus branch we now check if we either have an error or reply handler and make the call asynchronous.

Then we show a notification when we fail to pair in blueman-manager. Please let me know if we need to specify what error we got in the notification.

This fixes #453