### PR TITLE
Extend the function we have the PluginManager run

### DIFF
--- a/apps/blueman-applet
+++ b/apps/blueman-applet
@@ -50,6 +50,8 @@ class BluemanApplet(object):
 
         check_single_instance("blueman-applet")
 
+        self._signals = []
+
         self.Manager = None
         self.DbusSvc = DbusService("org.blueman.Applet", "/")
 
@@ -71,8 +73,8 @@ class BluemanApplet(object):
             self.Manager = Bluez.Manager()
             self.Plugins.Run("on_manager_state_changed", True)
 
-            self.Manager.connect_signal('adapter-added', self.on_adapter_added)
-            self.Manager.connect_signal('adapter-removed', self.on_adapter_removed)
+            self._signals.append(self.Manager.connect_signal('adapter-added', self.on_adapter_added))
+            self._signals.append(self.Manager.connect_signal('adapter-removed', self.on_adapter_removed))
 
         except dbus.exceptions.DBusException as e:
             dprint(e)
@@ -80,6 +82,9 @@ class BluemanApplet(object):
             dprint("Bluez DBus API not available. Listening for DBus name ownership changes")
 
     def manager_deinit(self):
+        for sig in self._signals:
+            self.Manager.disconnect_signal(sig)
+
         self.Manager = None
         self.Plugins.Run("on_manager_state_changed", False)
 

--- a/apps/blueman-applet
+++ b/apps/blueman-applet
@@ -75,6 +75,8 @@ class BluemanApplet(object):
 
             self._signals.append(self.Manager.connect_signal('adapter-added', self.on_adapter_added))
             self._signals.append(self.Manager.connect_signal('adapter-removed', self.on_adapter_removed))
+            self._signals.append(self.Manager.connect_signal('device-created', self.on_device_created))
+            self._signals.append(self.Manager.connect_signal('device-removed', self.on_device_removed))
 
         except dbus.exceptions.DBusException as e:
             dprint(e)
@@ -112,6 +114,14 @@ class BluemanApplet(object):
         dprint("Adapter removed ", path)
         self.Plugins.Run("on_adapter_removed", path)
 
+
+    def on_device_created(self, _manager, path):
+        dprint("Device created ", path)
+        self.Plugins.Run("on_device_created", path)
+
+    def on_device_removed(self, _manager, path):
+        dprint("Device removed ", path)
+        self.Plugins.Run("on_device_removed", path)
 
 set_proc_title()
 BluemanApplet()

--- a/apps/blueman-applet
+++ b/apps/blueman-applet
@@ -66,6 +66,9 @@ class BluemanApplet(object):
         self._any_adapter = Bluez.Adapter()
         self._any_adapter.connect_signal('property-changed', self._on_adapter_property_changed)
 
+        self._any_device = Bluez.Device()
+        self._any_device.connect_signal('property-changed', self._on_device_property_changed)
+
         Gtk.main()
 
     def manager_init(self):
@@ -99,6 +102,9 @@ class BluemanApplet(object):
 
     def _on_adapter_property_changed(self, _adapter, key, value, path):
         self.Plugins.Run("on_adapter_property_changed", path, key, value)
+
+    def _on_device_property_changed(self, _device, key, value, path):
+        self.Plugins.Run("on_device_property_changed", path, key, value)
 
     def on_adapter_added(self, _manager, path):
         dprint("Adapter added ", path)

--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -76,6 +76,9 @@ class AppletPlugin(ConfigurablePlugin):
     def on_adapter_property_changed(self, path, key, value):
         pass
 
+    def on_device_property_changed(self, path, key, value):
+        pass
+
     #notify when all plugins finished loading
     def on_plugins_loaded(self):
         pass

--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -67,6 +67,12 @@ class AppletPlugin(ConfigurablePlugin):
     def on_adapter_removed(self, adapter):
         pass
 
+    def on_device_created(self, device):
+        pass
+
+    def on_device_removed(self, device):
+        pass
+
     def on_adapter_property_changed(self, path, key, value):
         pass
 

--- a/blueman/plugins/applet/GameControllerWakelock.py
+++ b/blueman/plugins/applet/GameControllerWakelock.py
@@ -26,16 +26,13 @@ class GameControllerWakelock(AppletPlugin):
         self.wake_lock = 0
         self.root_window_id = "0x%x" % Gdk.Screen.get_default().get_root_window().get_xid()
 
-        self._any_device = bluez.Device()
-        self._any_device.connect_signal('property-changed', self._on_device_property_changed)
-
     def on_unload(self):
         if self.wake_lock:
             self.wake_lock = 1
             self.xdg_screensaver("resume")
         del self._any_device
 
-    def _on_device_property_changed(self, _device, key, value, path):
+    def on_device_property_changed(self, path, key, value):
         if key == "Connected":
             klass = bluez.Device(path).get_properties()["Class"] & 0x1fff
 

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -31,8 +31,6 @@ class PowerManager(AppletPlugin):
         }
     }
 
-    _any_signal = None
-
     def on_load(self, applet):
         AppletPlugin.add_method(self.on_power_state_query)
         AppletPlugin.add_method(self.on_power_state_change_requested)
@@ -44,9 +42,6 @@ class PowerManager(AppletPlugin):
         self.item.get_child().get_children()[1].set_markup_with_mnemonic(_("<b>Turn Bluetooth _Off</b>"))
 
         self.item.props.tooltip_text = _("Turn off all adapters")
-
-        self._any_adapter = Bluez.Adapter()
-        self._any_adapter.connect_signal('property-changed', self._on_adapter_property_changed)
 
         self.item.connect("activate", lambda x: self.on_bluetooth_toggled())
 
@@ -211,7 +206,7 @@ class PowerManager(AppletPlugin):
     def GetBluetoothStatus(self):
         return self.CurrentState
 
-    def _on_adapter_property_changed(self, _adapter, key, value, _path):
+    def on_adapter_property_changed(self, _path, key, value):
         if key == "Powered":
             if value and not self.CurrentState:
                 dprint("adapter powered on while in off state, turning bluetooth on")

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -80,10 +80,6 @@ class RecentConns(AppletPlugin, Gtk.Menu):
         self.deferred = False
         RecentConns.inst = weakref.proxy(self)
 
-        self._manager = Manager()
-        self._manager_signal = self._manager.connect_signal(
-            'device-removed', self.on_device_removed)
-
     def store_state(self):
         items = []
 
@@ -196,7 +192,7 @@ class RecentConns(AppletPlugin, Gtk.Menu):
 
         self.change_sensitivity(state)
 
-    def on_device_removed(self, _manager, path):
+    def on_device_removed(self, path):
         for item in reversed(RecentConns.items):
             if item['device'] == path:
                 RecentConns.items.remove(item)

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -45,17 +45,13 @@ class SerialManager(AppletPlugin):
     _any_device = None
 
     def on_load(self, applet):
-        self._any_device = Bluez.Device()
-        self._any_device.connect_signal('property-changed', self._on_device_property_changed)
-
         self.scripts = {}
 
     def on_unload(self):
-        del self._any_device
         for k in self.scripts.keys():
             self.terminate_all_scripts(k)
 
-    def _on_device_property_changed(self, _device, key, value, path):
+    def on_device_property_changed(self, path, key, value):
         if key == "Connected" and not value:
             self.terminate_all_scripts(Bluez.Device(path)["Address"])
 

--- a/blueman/plugins/applet/ShowConnected.py
+++ b/blueman/plugins/applet/ShowConnected.py
@@ -28,9 +28,6 @@ class ShowConnected(AppletPlugin):
         self.active = False
         self.initialized = False
 
-        self._any_device = bluez.Device()
-        self._any_device.connect_signal('property-changed', self._on_device_property_changed)
-
     def on_unload(self):
         del self._any_device
         self.Applet.Plugins.StatusIcon.SetTextLine(1, None)
@@ -101,7 +98,7 @@ class ShowConnected(AppletPlugin):
             self.num_connections = 0
             self.update_statusicon()
 
-    def _on_device_property_changed(self, _device, key, value, _path):
+    def on_device_property_changed(self, _path, key, value):
         if key == "Connected":
             if value:
                 self.num_connections += 1


### PR DESCRIPTION
Applet plugin no longer need to connect their own signals for Adapter and Devices. This is how the plugin system was for the adapter already, we now extend this to the devices too.

See  #440 

There is also a couple of small cleanups in here (first two).