### PR TITLE
RFC: Store if device has object push capability in GtkListStore

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -41,6 +41,7 @@ class ManagerDeviceList(DeviceList):
             # trusted/bonded icons
             # ["tb_icons", 'PyObject', CellRendererPixbufTable(), {"pixbuffs":5}, None],
 
+            ["alias", str], # used for quick access instead of device.GetProperties
             ["connected", bool], # used for quick access instead of device.GetProperties
             ["bonded", bool], # used for quick access instead of device.GetProperties
             ["trusted", bool], # used for quick access instead of device.GetProperties
@@ -235,7 +236,7 @@ class ManagerDeviceList(DeviceList):
         caption = self.make_caption(name, klass, address)
 
         # caption = "<span size='x-large'>%(0)s</span>\n<span size='small'>%(1)s</span>\n<i>%(2)s</i>" % {"0":name, "1":klass.capitalize(), "2":address}
-        self.set(tree_iter, caption=caption, orig_icon=icon)
+        self.set(tree_iter, caption=caption, orig_icon=icon, alias=name)
 
         try:
             self.row_update_event(tree_iter, "Trusted", device['Trusted'])
@@ -294,7 +295,7 @@ class ManagerDeviceList(DeviceList):
         elif key == "Alias":
             device = self.get(tree_iter, "device")["device"]
             c = self.make_caption(value, self.get_device_class(device), device['Address'])
-            self.set(tree_iter, caption=c)
+            self.set(tree_iter, caption=c, alias=value)
 
         elif key == "UUIDs":
             device = self.get(tree_iter, "device")["device"]

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -263,11 +263,10 @@ class ManagerDeviceMenu(Gtk.Menu):
         self.append(send_item)
         send_item.show()
 
-        for uuid in device['UUIDs']:
-            uuid16 = uuid128_to_uuid16(uuid)
-            if uuid16 == OBEX_OBJPUSH_SVCLASS_ID:
-                send_item.connect("activate", lambda x: self.Blueman.send(device))
-                send_item.props.sensitive = True
+        has_objpush = self.Blueman.List.get(selected, "objpush")["objpush"]
+        if has_objpush:
+            send_item.connect("activate", lambda x: self.Blueman.send(device))
+            send_item.props.sensitive = True
 
         item = Gtk.SeparatorMenuItem()
         item.show()

--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 from blueman.Constants import *
 from blueman.Functions import dprint
-from blueman.Sdp import *
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -76,7 +75,7 @@ class ManagerToolbar:
         dprint("toolbar adapter", adapter_path)
         if adapter_path is None:
             self.b_search.props.sensitive = False
-            self.update_send(None)
+            self.b_send.props.sensitive = False
         else:
             self.b_search.props.sensitive = True
 
@@ -87,7 +86,7 @@ class ManagerToolbar:
             self.b_trust.props.sensitive = False
             self.b_setup.props.sensitive = False
         else:
-            row = dev_list.get(tree_iter, "bonded", "trusted", "fake")
+            row = dev_list.get(tree_iter, "bonded", "trusted", "fake", "objpush")
             self.b_setup.props.sensitive = True
             if row["bonded"]:
                 self.b_bond.props.sensitive = False
@@ -111,21 +110,13 @@ class ManagerToolbar:
             else:
                 self.b_remove.props.sensitive = True
 
-        self.update_send(device)
-
-    def update_send(self, device):
-        self.b_send.props.sensitive = False
-        if device:
-            for uuid in device['UUIDs']:
-                uuid16 = uuid128_to_uuid16(uuid)
-                if uuid16 == OBEX_OBJPUSH_SVCLASS_ID:
-                    self.b_send.props.sensitive = True
+            if row["objpush"]:
+                self.b_send.props.sensitive = True
+            else:
+                self.b_send.props.sensitive = False
 
     def on_device_propery_changed(self, dev_list, device, tree_iter, key_value):
         key, value = key_value
         if dev_list.compare(tree_iter, dev_list.selected()):
-            if key == "Trusted" or key == "Paired":
+            if key == "Trusted" or key == "Paired" or key == "UUIDs":
                 self.on_device_selected(dev_list, device, tree_iter)
-
-            elif key == "UUIDs":
-                self.update_send(device)

--- a/blueman/services/Functions.py
+++ b/blueman/services/Functions.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 from blueman.Sdp import uuid128_to_uuid16
 import blueman.services
+import dbus
 import inspect
 
 
@@ -16,5 +17,9 @@ def get_service(device, uuid):
 
 
 def get_services(device):
-    services = (get_service(device, uuid) for uuid in device['UUIDs'])
-    return [service for service in services if service]
+    try:
+        services = (get_service(device, uuid) for uuid in device['UUIDs'])
+        return [service for service in services if service]
+    except dbus.exceptions.DBusException as e:
+        dprint(e)
+        return []


### PR DESCRIPTION
This relates to issue comnment https://github.com/blueman-project/blueman/issues/460#issuecomment-184472046.

This does not solve all the errors we get trying to get properties from a removed device though and we need to do the same thing for the audio service. We could also store all the uuids and work of them instead of reading them over and over.

This is a proof of concept to store values in the GtkTreeStore for use in the UI.

Opinions, objection or suggestions (especially on my naming skills :smile:).