### PR TITLE
Big cleanup and rework of Adapter menu in ManagerMenu class

### DIFF
--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -41,6 +41,7 @@ class Adapter(PropertiesBase):
     def remove_device(self, device):
         self._call('RemoveDevice', device.get_object_path())
 
+    # FIXME in BlueZ 5.31 getting and setting Alias appears to never fail
     def get_name(self):
         props = self.get_properties()
         try:

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -32,67 +32,69 @@ class ManagerMenu:
         self.item_help.set_submenu(help_menu)
         help_menu.show()
 
-        item = create_menuitem(_("_Report a Problem"), get_icon("dialog-warning", 16))
-        item.connect("activate", lambda x: launch("xdg-open %s/issues" % WEBSITE, None, True))
-        help_menu.append(item)
-        item.show()
+        report_item = create_menuitem(_("_Report a Problem"), get_icon("dialog-warning", 16))
+        report_item.show()
+        help_menu.append(report_item)
+        report_item.connect("activate", lambda x: launch("xdg-open %s/issues" % WEBSITE, None, True))
 
-        item = Gtk.SeparatorMenuItem()
-        help_menu.append(item)
-        item.show()
+        sep = Gtk.SeparatorMenuItem()
+        sep.show()
+        help_menu.append(sep)
 
-        item = create_menuitem("_Help", get_icon("help-about"))
-        item.connect("activate", lambda x: show_about_dialog('Blueman ' + _('Device Manager')))
-        help_menu.append(item)
-        item.show()
+        help_item = create_menuitem("_Help", get_icon("help-about"))
+        help_item.show()
+        help_menu.append(help_item)
+        help_item.connect("activate", lambda x: show_about_dialog('Blueman ' + _('Device Manager')))
 
         view_menu = Gtk.Menu()
         self.item_view.set_submenu(view_menu)
         view_menu.show()
 
-        item = Gtk.CheckMenuItem.new_with_mnemonic(_("Show _Toolbar"))
-        self.blueman.Config.bind_to_widget("show-toolbar", item, "active")
-        view_menu.append(item)
-        item.show()
+        item_toolbar = Gtk.CheckMenuItem.new_with_mnemonic(_("Show _Toolbar"))
+        item_toolbar.show()
+        view_menu.append(item_toolbar)
+        self.blueman.Config.bind_to_widget("show-toolbar", item_toolbar, "active")
 
-        item = Gtk.CheckMenuItem.new_with_mnemonic(_("Show _Statusbar"))
-        self.blueman.Config.bind_to_widget("show-statusbar", item, "active")
-        view_menu.append(item)
-        item.show()
+        item_statusbar = Gtk.CheckMenuItem.new_with_mnemonic(_("Show _Statusbar"))
+        item_statusbar.show()
+        view_menu.append(item_statusbar)
+        self.blueman.Config.bind_to_widget("show-statusbar", item_statusbar, "active")
 
-        item = Gtk.SeparatorMenuItem()
-        view_menu.append(item)
-        item.show()
+        item_services = Gtk.SeparatorMenuItem()
+        view_menu.append(item_services)
+        item_services.show()
 
         group = []
 
         itemf = Gtk.RadioMenuItem.new_with_mnemonic(group, _("Latest Device _First"))
+        itemf.show()
         group = itemf.get_group()
         view_menu.append(itemf)
-        itemf.show()
 
         iteml = Gtk.RadioMenuItem.new_with_mnemonic(group, _("Latest Device _Last"))
+        iteml.show()
         group = iteml.get_group()
         view_menu.append(iteml)
-        iteml.show()
 
         itemf.connect("activate", lambda x: self.blueman.Config.set_boolean("latest-last", not x.props.active))
         iteml.connect("activate", lambda x: self.blueman.Config.set_boolean("latest-last", x.props.active))
 
-        item = Gtk.SeparatorMenuItem()
-        view_menu.append(item)
-        item.show()
+        sep = Gtk.SeparatorMenuItem()
+        sep.show()
+        view_menu.append(sep)
 
-        item = create_menuitem(_("Plugins"), get_icon('blueman-plugin', 16))
-        item.connect('activate', lambda *args: self.blueman.Applet.open_plugin_dialog(ignore_reply=True))
-        view_menu.append(item)
-        item.show()
+        item_plugins = create_menuitem(_("Plugins"), get_icon('blueman-plugin', 16))
+        item_plugins.show()
+        view_menu.append(item_plugins)
+        item_plugins.connect('activate', lambda *args: self.blueman.Applet.open_plugin_dialog(ignore_reply=True))
 
-        item = create_menuitem(_("_Local Services") + "...", get_icon("preferences-desktop", 16))
-        item.connect('activate',
-                     lambda *args: launch("blueman-services", None, False, "blueman", _("Service Preferences")))
-        view_menu.append(item)
-        item.show()
+        item_services = create_menuitem(_("_Local Services") + "...", get_icon("preferences-desktop", 16))
+        item_services.connect('activate',
+                              lambda *args: launch("blueman-services", None, False, "blueman", _("Service Preferences")))
+        view_menu.append(item_services)
+        item_services.show()
+
+
 
         self.item_adapter.show()
         self.item_view.show()

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -98,6 +98,7 @@ class ManagerMenu:
 
         adapter_menu = Gtk.Menu()
         self.item_adapter.set_submenu(adapter_menu)
+        self.item_adapter.props.sensitive = False
 
         search_item = create_menuitem(_("_Search"), get_icon("edit-find", 16))
         search_item.connect("activate", lambda x: self.blueman.inquiry())

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -138,7 +138,6 @@ class ManagerMenu:
         self._manager.connect_signal("adapter-removed", self.on_adapter_removed)
 
         blueman.List.connect("device-selected", self.on_device_selected)
-        blueman.List.connect("adapter-changed", self.on_adapter_changed)
 
         for adapter in self._manager.list_adapters():
             self.on_adapter_added(None, adapter.get_object_path())
@@ -206,6 +205,9 @@ class ManagerMenu:
         if adapter_path == self.blueman.List.Adapter.get_object_path():
             item.props.active = True
 
+        if len(self.adapter_items) > 0:
+            self.item_adapter.props.sensitive = True
+
     def on_adapter_removed(self, _manager, adapter_path):
         item, item_sig, adapter, adapter_sig = self.adapter_items.pop(adapter_path)
         menu = self.item_adapter.get_submenu()
@@ -216,9 +218,5 @@ class ManagerMenu:
         menu.remove(item)
         self._insert_adapter_item_pos -= 1
 
-    def on_adapter_changed(self, List, path):
-        if path is None:
+        if len(self.adapter_items) == 0:
             self.item_adapter.props.sensitive = False
-        else:
-            self.item_adapter.props.sensitive = True
-            self.generate_adapter_menu()

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -18,21 +18,14 @@ class ManagerMenu:
     def __init__(self, blueman):
         self.blueman = blueman
 
-        self.Menubar = blueman.Builder.get_object("menu")
-
         self.adapter_items = []
         self.Search = None
 
-        self.item_adapter = Gtk.MenuItem.new_with_mnemonic(_("_Adapter"))
-        self.item_device = Gtk.MenuItem.new_with_mnemonic(_("_Device"))
+        self.item_adapter = self.blueman.Builder.get_object("item_adapter")
+        self.item_device = self.blueman.Builder.get_object("item_device")
 
-        self.item_view = Gtk.MenuItem.new_with_mnemonic(_("_View"))
-        self.item_help = Gtk.MenuItem.new_with_mnemonic(_("_Help"))
-
-        self.Menubar.append(self.item_adapter)
-        self.Menubar.append(self.item_device)
-        self.Menubar.append(self.item_view)
-        self.Menubar.append(self.item_help)
+        self.item_view = self.blueman.Builder.get_object("item_view")
+        self.item_help = self.blueman.Builder.get_object("item_help")
 
         help_menu = Gtk.Menu()
 

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -168,16 +168,6 @@ class ManagerMenu:
                 else:
                     self.Search.props.sensitive = True
 
-    def generate_adapter_menu(self):
-        menu = self.item_adapter.get_submenu()
-
-        # Remove and disconnect the existing adapter menu items
-        for adapter_path in list(self.adapter_items.keys()):
-            self.on_adapter_removed(None, adapter_path)
-
-        for adapter in self._manager.list_adapters():
-            self.on_adapter_added(None, adapter.get_object_path())
-
     def on_adapter_selected(self, menuitem, adapter_path):
         if menuitem.props.active:
             if adapter_path != self.blueman.List.Adapter.get_object_path():

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -181,7 +181,7 @@ class ManagerMenu:
         menu = self.item_adapter.get_submenu()
         object_path = adapter.get_object_path()
 
-        item = Gtk.RadioMenuItem.new_with_label(self._adapters_group, adapter['Alias'])
+        item = Gtk.RadioMenuItem.new_with_label(self._adapters_group, adapter.get_name())
         item.show()
         self._adapters_group = item.get_group()
 

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -10,6 +10,38 @@
       <object class="GtkMenuBar" id="menu">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <child>
+          <object class="GtkMenuItem" id="item_adapter">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">_Adapter</property>
+            <property name="use_underline">True</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkMenuItem" id="item_device">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">_Device</property>
+            <property name="use_underline">True</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkMenuItem" id="item_view">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">_View</property>
+            <property name="use_underline">True</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkMenuItem" id="item_help">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">_Help</property>
+            <property name="use_underline">True</property>
+          </object>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>


### PR DESCRIPTION
These commits change the way we create and update the Adapter menu. The major changes are,

 * No more regenerating the __complete__ Adapter menu on every change (add/remove/select etc).
 * Use a bluez.Manager object to add and remove adapter menu entries
 * Move the creation of the adapter menu items to on_adapter_added/removed
 * Connect and disconnect the ``property-changed`` signal on the bluez.Adapter objects when added/removed. We do not rely on the DeviceList for this any-more.

There should be no functional or visual changes so let me know if you run into any of them.

Why all this work you may ask, well it came about my idea to have different sorting options (by time added, alias, ascending/decending) for the DeviceList (and the current one is horrendous). And when one starts poking at things one finds lots of things that probably made sense in the past but are now getting in the way :smile:.

What I like to do next is do more work on the ManagerDeviceList and change the way we use the strore and display the view. The idea is to have a single list with __all__ devices from __all__ adapters and then have a filter function to only project the rows that are relevant to the currently selected adapter the view.

ps: i'll also finish things up on #464 in the next couple of days.