### PR TITLE
Bluez: Implement singleton for bluemans bluez objects

### DIFF
--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -12,8 +12,10 @@ import dbus
 
 
 class Adapter(PropertiesBase):
-    def __init__(self, obj_path=None):
-        super(Adapter, self).__init__('org.bluez.Adapter1', obj_path)
+    _interface_name = 'org.bluez.Adapter1'
+
+    def _init(self, obj_path=None):
+        super(Adapter, self)._init(interface_name=self._interface_name, obj_path=obj_path)
         proxy = dbus.SystemBus().get_object('org.bluez', '/', follow_name_owner_changes=True)
         self.manager_interface = dbus.Interface(proxy, 'org.freedesktop.DBus.ObjectManager')
 

--- a/blueman/bluez/AgentManager.py
+++ b/blueman/bluez/AgentManager.py
@@ -8,9 +8,10 @@ from blueman.bluez.Base import Base
 
 
 class AgentManager(Base):
-    def __init__(self):
-        interface = 'org.bluez.AgentManager1'
-        super(AgentManager, self).__init__(interface, '/org/bluez')
+    _interface_name = 'org.bluez.AgentManager1'
+
+    def _init(self):
+        super(AgentManager, self)._init(interface_name=self._interface_name, obj_path='/org/bluez')
 
     def register_agent(self, agent_path, capability='', default=False):
         self._call('RegisterAgent', agent_path, capability)

--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -21,20 +21,33 @@ class Base(GObject):
         if instances is None:
             cls.__instances__ = instances = {}
 
-        if args:
-            path = args[0]
-        elif kwargs:
-            path = kwargs.get('obj_path')
-        else:
-            path = None
+        # ** Below argument parsing has to be kept in sync with _init **
+        path = None
+        interface_name = None
 
-        if cls._interface_name in  instances:
-            if path in instances[cls._interface_name]:
-                return instances[cls._interface_name][path]
+        if kwargs:
+            interface_name = kwargs.get('interface_name')
+            path = kwargs.get('obj_path')
+
+        if args:
+            for arg in args:
+                if args is None:
+                    continue
+                elif '/' in arg:
+                    path = arg
+                elif '.' in arg:
+                    interface_name = arg
+
+        if not interface_name:
+            interface_name = cls._interface_name
+
+        if interface_name in instances:
+            if path in instances[interface_name]:
+                return instances[interface_name][path]
 
         instance = super(Base, cls).__new__(cls)
         instance._init(*args, **kwargs)
-        cls.__instances__[cls._interface_name] = {path: instance}
+        cls.__instances__[interface_name] = {path: instance}
 
         return instance
 

--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -16,7 +16,32 @@ class Base(GObject):
     __bus = dbus.SystemBus()
     __bus_name = 'org.bluez'
 
-    def __init__(self, interface_name, obj_path):
+    def __new__(cls, *args, **kwargs):
+        instances = cls.__dict__.get("__instances__")
+        if instances is None:
+            cls.__instances__ = instances = {}
+
+        if args:
+            path = args[0]
+        elif kwargs:
+            path = kwargs.get('obj_path')
+        else:
+            path = None
+
+        if cls._interface_name in  instances:
+            if path in instances[cls._interface_name]:
+                return instances[cls._interface_name][path]
+
+        instance = super(Base, cls).__new__(cls)
+        instance._init(*args, **kwargs)
+        cls.__instances__[cls._interface_name] = {path: instance}
+
+        return instance
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def _init(self, interface_name, obj_path):
         self.__signals = []
         self.__obj_path = obj_path
         self.__interface_name = interface_name

--- a/blueman/bluez/Device.py
+++ b/blueman/bluez/Device.py
@@ -8,8 +8,10 @@ from blueman.bluez.PropertiesBase import PropertiesBase
 
 
 class Device(PropertiesBase):
-    def __init__(self, obj_path=None):
-        super(Device, self).__init__('org.bluez.Device1', obj_path)
+    _interface_name = 'org.bluez.Device1'
+
+    def _init(self, obj_path=None):
+        super(Device, self)._init(interface_name=self._interface_name, obj_path=obj_path)
 
     def pair(self, reply_handler=None, error_handler=None):
         self._call('Pair', reply_handler=reply_handler, error_handler=error_handler)

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -20,10 +20,12 @@ class Manager(PropertiesBase):
         str('device-removed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
     }
 
-    def __init__(self):
+    _interface_name = 'org.freedesktop.DBus.ObjectManager'
+
+    def _init(self):
         DBusGMainLoop(set_as_default=True)
 
-        super(Manager, self).__init__('org.freedesktop.DBus.ObjectManager', '/')
+        super(Manager, self)._init(interface_name=self._interface_name, obj_path='/')
         self._handle_signal(self._on_interfaces_added, 'InterfacesAdded')
         self._handle_signal(self._on_interfaces_removed, 'InterfacesRemoved')
 

--- a/blueman/bluez/Network.py
+++ b/blueman/bluez/Network.py
@@ -8,8 +8,10 @@ from blueman.bluez.PropertiesBase import PropertiesBase
 
 
 class Network(PropertiesBase):
-    def __init__(self, obj_path=None):
-        super(Network, self).__init__('org.bluez.Network1', obj_path)
+    _interface_name = 'org.bluez.Network1'
+
+    def _init(self, obj_path=None):
+        super(Network, self)._init(interface_name=self._interface_name, obj_path=obj_path)
 
     def connect(self, uuid, reply_handler=None, error_handler=None):
         self._call('Connect', uuid, reply_handler=reply_handler, error_handler=error_handler)

--- a/blueman/bluez/NetworkServer.py
+++ b/blueman/bluez/NetworkServer.py
@@ -8,8 +8,10 @@ from blueman.bluez.PropertiesBase import PropertiesBase
 
 
 class NetworkServer(PropertiesBase):
-    def __init__(self, obj_path):
-        super(NetworkServer, self).__init__('org.bluez.NetworkServer1', obj_path)
+    _interface_name = 'org.bluez.NetworkServer1'
+
+    def _init(self, obj_path):
+        super(NetworkServer, self)._init(interface_name=self._interface_name, obj_path=obj_path)
 
     def register(self, uuid, bridge):
         self._call('Register', uuid, bridge)

--- a/blueman/bluez/PropertiesBase.py
+++ b/blueman/bluez/PropertiesBase.py
@@ -16,8 +16,10 @@ class PropertiesBase(Base):
                                   (GObject.TYPE_PYOBJECT, GObject.TYPE_PYOBJECT, GObject.TYPE_PYOBJECT))
     }
 
-    def __init__(self, interface, obj_path):
-        super(PropertiesBase, self).__init__(interface, obj_path)
+    _interface_name = 'org.bluez.NetworkServer1'
+
+    def _init(self, interface_name, obj_path):
+        super(PropertiesBase, self)._init(interface_name=self._interface_name, obj_path=obj_path)
 
         self.__fallback = {'Icon': 'blueman', 'Class': None}
         self._handler_wrappers = {}

--- a/blueman/bluez/obex/AgentManager.py
+++ b/blueman/bluez/obex/AgentManager.py
@@ -9,8 +9,10 @@ from blueman.bluez.obex.Base import Base
 
 
 class AgentManager(Base):
-    def __init__(self):
-        super(AgentManager, self).__init__('org.bluez.obex.AgentManager1', '/org/bluez/obex')
+    _interface_name = 'org.bluez.obex.AgentManager1'
+
+    def _init(self):
+        super(AgentManager, self)._init(interface_name=self._interface_name, obj_path='/org/bluez/obex')
 
     def register_agent(self, agent_path):
         def on_registered():

--- a/blueman/bluez/obex/Client.py
+++ b/blueman/bluez/obex/Client.py
@@ -21,13 +21,15 @@ class Client(Base):
         str('session-removed'): (GObject.SignalFlags.NO_HOOKS, None, ()),
     }
 
-    def __init__(self):
+    _interface_name = 'org.bluez.obex.Client1'
+
+    def _init(self):
         obj = dbus.SessionBus().get_object('org.bluez.obex', '/')
         introspection = dbus.Interface(obj, 'org.freedesktop.DBus.Introspectable').Introspect()
         if 'org.freedesktop.DBus.ObjectManager' not in introspection:
             raise ObexdNotFoundError('Could not find any compatible version of obexd')
 
-        super(Client, self).__init__('org.bluez.obex.Client1', '/org/bluez/obex')
+        super(Client, self)._init(interface_name=self._interface_name, obj_path='/org/bluez/obex')
 
     def create_session(self, dest_addr, source_addr="00:00:00:00:00:00", pattern="opp"):
         def on_session_created(session_path):

--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -17,8 +17,10 @@ class Manager(Base):
         str('transfer-completed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT, GObject.TYPE_PYOBJECT)),
     }
 
-    def __init__(self):
-        super(Manager, self).__init__('org.freedesktop.DBus.ObjectManager', '/')
+    _interface_name = 'org.freedesktop.DBus.ObjectManager'
+
+    def _init(self):
+        super(Manager, self)._init(interface_name=self._interface_name, obj_path='/')
 
         self._transfers = {}
 

--- a/blueman/bluez/obex/ObjectPush.py
+++ b/blueman/bluez/obex/ObjectPush.py
@@ -15,8 +15,10 @@ class ObjectPush(Base):
         str('transfer-failed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
     }
 
-    def __init__(self, session_path):
-        super(ObjectPush, self).__init__('org.bluez.obex.ObjectPush1', session_path)
+    _interface_name = 'org.bluez.obex.ObjectPush1'
+
+    def _init(self, session_path):
+        super(ObjectPush, self)._init(interface_name=self._interface_name, obj_path=session_path)
 
     def send_file(self, file_path):
         def on_transfer_started(transfer_path, props):

--- a/blueman/bluez/obex/Session.py
+++ b/blueman/bluez/obex/Session.py
@@ -3,8 +3,10 @@ from blueman.bluez.obex.Base import Base
 
 
 class Session(Base):
-    def __init__(self, session_path):
-        super(Session, self).__init__('org.freedesktop.DBus.Properties', session_path)
+    _interface_name = 'org.freedesktop.DBus.Properties'
+
+    def _init(self, session_path):
+        super(Session, self)._init(interface_name=self._interface_name, obj_path=session_path)
 
     @property
     def address(self):

--- a/blueman/bluez/obex/Transfer.py
+++ b/blueman/bluez/obex/Transfer.py
@@ -16,8 +16,10 @@ class Transfer(Base):
         str('error'): (GObject.SignalFlags.NO_HOOKS, None, ())
     }
 
-    def __init__(self, transfer_path):
-        super(Transfer, self).__init__('org.freedesktop.DBus.Properties', transfer_path)
+    _interface_name = 'org.freedesktop.DBus.Properties'
+
+    def _init(self, transfer_path):
+        super(Transfer, self)._init(interface_name=self._interface_name, obj_path=transfer_path)
         self._handle_signal(self._on_properties_changed, 'PropertiesChanged')
 
     def __getattr__(self, name):


### PR DESCRIPTION
So this does not work as we do not have the necessary info to properly keep track of the objects.

The main problem is that we do not have the ``interface_name`` in ``*args`` or ``**kwargs`` provided to ``__new__`` because we do not create the object with it and provide it as default (keywword)argument. We could force all instances to use keywords and provide the both interface_name and object_path like, ``bluez.Device(interface_name='org.bluez.Device1', obj_path='/org/bluez/...')``.

Another way is to have some sort of BluezObject store/manager that is the only one creating and distributing the objects.