### PR TITLE
Put Python major version in shebang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,15 @@ Makefile
 /config.status
 /libtool
 /stamp-h1
+/apps/blueman-adapters
+/apps/blueman-applet
+/apps/blueman-assistant
+/apps/blueman-manager
+/apps/blueman-mechanism
+/apps/blueman-report
+/apps/blueman-rfcomm-watcher
+/apps/blueman-sendto
+/apps/blueman-services
 /blueman/Constants.py
 /blueman/plugins/mechanism/Rfcomm.py
 /data/configs/blueman-applet.service
@@ -42,6 +51,7 @@ Makefile
 /data/configs/org.blueman.Applet.service
 /data/configs/org.blueman.Mechanism.service
 /module/.deps
+/module/_blueman.pyx
 /po/POTFILES
 /po/stamp-it
 

--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -16,5 +16,9 @@ polkit_SCRIPTS = 	\
 
 helpersdir = $(libexecdir)
 helpers_SCRIPTS = blueman-rfcomm-watcher
+
+ALL_APPS = $(APPS) $(polkit_SCRIPTS) $(helpers_SCRIPTS)
 	
-EXTRA_DIST = $(APPS) blueman-mechanism blueman-rfcomm-watcher
+EXTRA_DIST = $(ALL_APPS) $(addsuffix .in, $(ALL_APPS))
+
+CLEANFILES = $(ALL_APPS)

--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@PYTHON_MAJOR_VERSION@
 # coding=utf-8
 
 from __future__ import print_function

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@PYTHON_MAJOR_VERSION@
 # coding=utf-8
 
 from __future__ import print_function

--- a/apps/blueman-assistant.in
+++ b/apps/blueman-assistant.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@PYTHON_MAJOR_VERSION@
 # coding=utf-8
 
 from __future__ import print_function

--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#/usr/bin/env python@PYTHON_VERSION@
 # coding=utf-8
 
 from __future__ import print_function

--- a/apps/blueman-mechanism.in
+++ b/apps/blueman-mechanism.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@PYTHON_MAJOR_VERSION@
 # coding=utf-8
 
 from __future__ import print_function

--- a/apps/blueman-report.in
+++ b/apps/blueman-report.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@PYTHON_MAJOR_VERSION@
 # coding=utf-8
 
 from __future__ import print_function

--- a/apps/blueman-rfcomm-watcher.in
+++ b/apps/blueman-rfcomm-watcher.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@PYTHON_MAJOR_VERSION@
 # coding=utf-8
 
 from __future__ import print_function

--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@PYTHON_MAJOR_VERSION@
 # coding=utf-8
 
 from __future__ import print_function

--- a/apps/blueman-services.in
+++ b/apps/blueman-services.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@PYTHON_MAJOR_VERSION@
 # coding=utf-8
 
 from __future__ import print_function

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@ AC_ENABLE_STATIC(no)
 AM_PATH_PYTHON([2.7])
 PYTHON_MAJOR_VERSION="$(echo ${PYTHON_VERSION} | cut -d . -f 1)"
 PYTHON_MINOR_VERSION="$(echo ${PYTHON_VERSION} | cut -d . -f 2)"
+AC_SUBST(PYTHON_MAJOR_VERSION)
 
 if [test ${PYTHON_MAJOR_VERSION} -eq 3] && [test ${PYTHON_MINOR_VERSION} -lt 2];then
 	AC_MSG_ERROR([Unsupported Python 3 version found (>=3.2 required)])
@@ -198,6 +199,15 @@ GLIB_GSETTINGS
 
 AC_OUTPUT([
 Makefile
+apps/blueman-adapters
+apps/blueman-applet
+apps/blueman-assistant
+apps/blueman-manager
+apps/blueman-mechanism
+apps/blueman-report
+apps/blueman-rfcomm-watcher
+apps/blueman-sendto
+apps/blueman-services
 apps/Makefile
 blueman/Makefile
 blueman/Constants.py
@@ -259,6 +269,7 @@ data/configs/blueman-applet.service
 data/configs/blueman-mechanism.service
 data/configs/org.blueman.Applet.service
 data/configs/org.blueman.Mechanism.service
+module/_blueman.pyx
 module/Makefile
 po/Makefile.in
 ])

--- a/module/_blueman.pyx.in
+++ b/module/_blueman.pyx.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@PYTHON_MAJOR_VERSION@
 # coding=utf-8
 from __future__ import print_function
 from __future__ import division


### PR DESCRIPTION
This allows building for systems with both Python 2 and 3 without replacing the shebang. Replacing will only be necessary if env shall not be used e.g. as PyEnv might be present (see #435) or a specific minor version needs to be defined (i.e. there are multiple minor versions on the target system and blueman is not built for the newest one; we cannot use minor versions as they are not mandatory, see PEP 394).

This is a solution for #482 (build for AOSC OS without shebang replacement), however it only makes sense for very few distributions that neither have pyenv and nor multiple Python minor versions. More major distributions have some shebang replacement mechanism anyway.