### PR TITLE
Use the ListStore to sort instead of rebuilding

### DIFF
--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -81,10 +81,6 @@ class Blueman(Gtk.Window):
             self.Config["window-properties"] = [w, h, x, y]
             Gtk.main_quit()
 
-        def on_latest_last_changed(ignored1, ignored2):
-            try: self.List.DisplayKnownDevices(autoselect=True)
-            except: pass
-
         def on_bt_status_changed(status):
             if not status:
                 self.hide()
@@ -154,8 +150,6 @@ class Blueman(Gtk.Window):
                     self.List.DisplayKnownDevices(autoselect=True)
 
                 self.List.connect("adapter-changed", self.on_adapter_changed)
-
-                self.Config.connect("changed::latest-last", on_latest_last_changed)
 
                 toolbar = self.Builder.get_object("toolbar")
                 statusbar = self.Builder.get_object("statusbar")

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -192,9 +192,8 @@ class DeviceList(GenericList):
         pass
 
     #called when device needs to be added to the list
-    #default action: append
     def device_add_event(self, device):
-        self.add_device(device, append=True)
+        self.add_device(device)
 
     def device_remove_event(self, device, tree_iter):
         dprint(device)
@@ -268,16 +267,13 @@ class DeviceList(GenericList):
         self.emit("discovery-progress", progress)
         return True
 
-    def add_device(self, device, append=True):
+    def add_device(self, device):
         #device belongs to another adapter
         if not device['Adapter'] == self.Adapter.get_object_path():
             return
 
         dprint("adding new device")
-        if append:
-            tree_iter = self.liststore.append()
-        else:
-            tree_iter = self.liststore.prepend()
+        tree_iter = self.liststore.append()
 
         self.set(tree_iter, device=device)
         self.row_setup_event(tree_iter, device)

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -16,6 +16,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from gi.repository import GObject
 from gi.repository import GLib
+from datetime import datetime
 import os
 import re
 
@@ -93,7 +94,8 @@ class DeviceList(GenericList):
 
         data = data + [
             ["device", object],
-            ["dbus_path", str]
+            ["dbus_path", str],
+            ["timestamp", float]
         ]
 
         super(DeviceList, self).__init__(data)
@@ -281,8 +283,9 @@ class DeviceList(GenericList):
         self.row_setup_event(tree_iter, device)
 
         object_path = device.get_object_path()
+        timestamp = datetime.strftime(datetime.now(), '%Y%m%d%H%M%S%f')
         try:
-            self.set(tree_iter, dbus_path=object_path)
+            self.set(tree_iter, dbus_path=object_path, timestamp=float(timestamp))
         except:
             pass
 

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -207,10 +207,7 @@ class ManagerDeviceList(DeviceList):
         row_fader.animate(start=row_fader.get_state(), end=0.0, duration=400)
 
     def device_add_event(self, device):
-        if self.Blueman.Config["latest-last"]:
-            self.add_device(device, append=True)
-        else:
-            self.add_device(device, append=False)
+        self.add_device(device)
 
     def make_caption(self, name, klass, address):
         return "<span size='x-large'>%(0)s</span>\n<span size='small'>%(1)s</span>\n<i>%(2)s</i>" % {"0": cgi.escape(name), "1": klass.capitalize(), "2": address}

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -105,21 +105,6 @@ class ManagerMenu:
         else:
             self._sort_type_item.props.active = True
 
-        group = []
-
-        itemf = Gtk.RadioMenuItem.new_with_mnemonic(group, _("Latest Device _First"))
-        itemf.show()
-        group = itemf.get_group()
-        view_menu.append(itemf)
-
-        iteml = Gtk.RadioMenuItem.new_with_mnemonic(group, _("Latest Device _Last"))
-        iteml.show()
-        group = iteml.get_group()
-        view_menu.append(iteml)
-
-        itemf.connect("activate", lambda x: self.blueman.Config.set_boolean("latest-last", not x.props.active))
-        iteml.connect("activate", lambda x: self.blueman.Config.set_boolean("latest-last", x.props.active))
-
         sep = Gtk.SeparatorMenuItem()
         sep.show()
         view_menu.append(sep)

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -35,11 +35,6 @@
       <summary>Show Manager's StatusBar</summary>
        <description>Show or hide the Manager's StatusBar</description>
     </key>
-    <key type="b" name="latest-last">
-      <default>true</default>
-      <summary>Sort the device list by last usage</summary>
-      <description>This sorts the devicelist in manager by last used or the reversed</description>
-    </key>
     <key type="s" name="sort-by">
       <choices>
         <choice value="timestamp"/>

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -40,6 +40,23 @@
       <summary>Sort the device list by last usage</summary>
       <description>This sorts the devicelist in manager by last used or the reversed</description>
     </key>
+    <key type="s" name="sort-by">
+      <choices>
+        <choice value="timestamp"/>
+        <choice value="alias"/>
+      </choices>
+      <default>"timestamp"</default>
+      <summary>Sort device list</summary>
+      <description>Sort the device list by column, possible values are timestamp and alias</description>
+    </key>
+    <key type="s" name="sort-order">
+      <choices>
+        <choice value="ascending"/>
+        <choice value="descending"/>
+      </choices>
+      <default>"ascending"</default>
+      <summary>Sort ascending or descending</summary>
+    </key>
     <key type="as" name="plugin-list">
       <default>[]</default>
       <summary>List of enabled/disabled plugins</summary>


### PR DESCRIPTION
Ok, this is WIP but it works. Opening a PR so people can comment, criticize and suggest things.

This makes use of the sorting capabilities of the ListStore so we do not rebuild the list every-time. I will also change how the list behaves when multiple adapters are available. As with the sorting, we should not be rebuilding the list but instead put all devices in the list and use a [filter function](http://python-gtk-3-tutorial.readthedocs.org/en/latest/treeview.html#filtering) to modify the view.

The only "drawback" currently is that it does not animate the row as it does not rebuild, it still animates on new/removed device though. However we gain the ability to apply any sorting algoritm we like on any field in the list.

The old sort menu items are still there but here is a screenshot of how it looks. Any feedback here on the ui would be nice :smile: 
![manager_sort_menu](https://cloud.githubusercontent.com/assets/3465730/13812988/4ce2f916-eb7f-11e5-8044-264a43bf5397.png)
