### PR TITLE
Check if bluetooth activation is successful

### DIFF
--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -106,6 +106,9 @@ def check_bluetooth_status(message, exitfunc, *args, **kwargs):
                 exitfunc()
             else:
                 applet.SetBluetoothStatus(True, *args, **kwargs)
+                if not applet.GetBluetoothStatus():
+                    print('Failed to enable bluetooth')
+                    exitfunc()
 
 
 def wait_for_adapter(bluez_adapter, callback, timeout=1000):


### PR DESCRIPTION
As mentioned in #443 we previously never checked if the activation (`SetBluetoothStatus(True)`) is actually successful or if it is still disabled afterward. This is expected if a hardware killswitch is switched off.