### PR TITLE
Mechanism: dbus polkit authorisation checking

### DIFF
--- a/blueman/plugins/mechanism/Network.py
+++ b/blueman/plugins/mechanism/Network.py
@@ -45,6 +45,7 @@ class Network(MechanismPlugin):
     @dbus.service.method('org.blueman.Mechanism', in_signature="ayays", out_signature="", sender_keyword="caller",
                          byte_arrays=True)
     def EnableNetwork(self, ip_address, netmask, dhcp_handler, caller):
+        self.confirm_authorization(caller, "org.blueman.network.setup")
         nc = NetConf.get_default()
         nc.set_ipv4(ip_address, netmask)
         nc.set_dhcp_handler(DHCPDHANDLERS[dhcp_handler])
@@ -52,11 +53,13 @@ class Network(MechanismPlugin):
 
     @dbus.service.method('org.blueman.Mechanism', in_signature="", out_signature="", sender_keyword="caller")
     def ReloadNetwork(self, caller):
+        self.confirm_authorization(caller, "org.blueman.network.setup")
         nc = NetConf.get_default()
         nc.apply_settings()
 
     @dbus.service.method('org.blueman.Mechanism', in_signature="", out_signature="", sender_keyword="caller")
     def DisableNetwork(self, caller):
+        self.confirm_authorization(caller, "org.blueman.network.setup")
         nc = NetConf.get_default()
         nc.remove_settings()
         nc.set_ipv4(None, None)

--- a/blueman/plugins/mechanism/Ppp.py
+++ b/blueman/plugins/mechanism/Ppp.py
@@ -22,6 +22,7 @@ class Ppp(MechanismPlugin):
     @dbus.service.method('org.blueman.Mechanism', in_signature="sss", out_signature="s", sender_keyword="caller",
                          async_callbacks=("ok", "err"))
     def PPPConnect(self, port, number, apn, caller, ok, err):
+        self.confirm_authorization(caller, "org.blueman.pppd.pppconnect")
         self.timer.stop()
         from blueman.main.PPPConnection import PPPConnection
 

--- a/blueman/plugins/mechanism/RfKill.py
+++ b/blueman/plugins/mechanism/RfKill.py
@@ -15,8 +15,9 @@ if not os.path.exists('/dev/rfkill'):
 
 
 class RfKill(MechanismPlugin):
-    @dbus.service.method('org.blueman.Mechanism', in_signature="b", out_signature="")
-    def SetRfkillState(self, state):
+    @dbus.service.method('org.blueman.Mechanism', in_signature="b", out_signature="", sender_keyword="caller")
+    def SetRfkillState(self, state, caller):
+        self.confirm_authorization(caller, "org.blueman.rfkill.setstate")
         f = open('/dev/rfkill', 'r+b', buffering=0)
         f.write(struct.pack("IBBBB", 0, RFKILL_TYPE_BLUETOOTH, RFKILL_OP_CHANGE_ALL, (0 if state else 1), 0))
         f.close()

--- a/data/configs/org.blueman.Mechanism.conf
+++ b/data/configs/org.blueman.Mechanism.conf
@@ -6,8 +6,11 @@
 <busconfig>
 	<policy user="root">
 		<allow own="org.blueman.Mechanism"/>
+		<allow send_destination="org.blueman.Mechanism"/>
+		<allow receive_sender="org.blueman.Mechanism"/>
 	</policy>
   	<policy context="default">
     		<allow send_destination="org.blueman.Mechanism"/>
+		<allow receive_sender="org.blueman.Mechanism"/>
   	</policy>
 </busconfig>

--- a/data/configs/org.blueman.policy.in
+++ b/data/configs/org.blueman.policy.in
@@ -27,6 +27,15 @@
     </defaults>
   </action>
 
+  <action id="org.blueman.pppd.pppconnect">
+    <_description>Launch PPP daemon</_description>
+    <_message>Launching PPP daemon requires privileges</_message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
   <action id="org.blueman.rfkill.setstate">
     <_description>Set RfKill State</_description>
     <_message>Setting RfKill State requires privileges</_message>

--- a/data/configs/org.blueman.policy.in
+++ b/data/configs/org.blueman.policy.in
@@ -23,7 +23,7 @@
     <_message>Launching DHCP client requires privileges</_message>
     <defaults>
       <allow_inactive>no</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 

--- a/data/configs/org.blueman.policy.in
+++ b/data/configs/org.blueman.policy.in
@@ -27,13 +27,4 @@
     </defaults>
   </action>
   
-  <action id="org.blueman.bluez.config">
-    <_description>Bluetooth Configuration</_description>
-    <_message>Changing Bluetooth system settings requires privileges</_message>
-    <defaults>
-      <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin_keep</allow_active>
-    </defaults>
-  </action>
-  
 </policyconfig>

--- a/data/configs/org.blueman.policy.in
+++ b/data/configs/org.blueman.policy.in
@@ -26,5 +26,14 @@
       <allow_active>yes</allow_active>
     </defaults>
   </action>
-  
+
+  <action id="org.blueman.rfkill.setstate">
+    <_description>Set RfKill State</_description>
+    <_message>Setting RfKill State requires privileges</_message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
 </policyconfig>


### PR DESCRIPTION
@posophe this is for #423

For all, I don't have a machine with a hardware killswitch (only have usb dongles) so I really would appreciate if people can make sure this works properly.

To not have your users to authenticate all the time distros typically ship with a polkit rules file. See below for an example.

```
/* Allow users in wheel group to run blueman network config without authentication */
polkit.addRule(function(action, subject) {
    if ((action.id == "org.blueman.network.setup" ||
         action.id == "org.blueman.dhcp.client" ||
         action.id == "org.blueman.rfkill.setstate" ||
         action.id == "org.blueman.pppd.pppconnect") &&
        subject.isInGroup("wheel")) {
        return polkit.Result.YES;
    }
});
```