### PR TITLE
Disable Gtk overlay scrolling

### DIFF
--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -137,6 +137,9 @@ class Blueman(Gtk.Window):
                 if x and y: self.move(x, y)
 
                 sw = self.Builder.get_object("scrollview")
+                # Disable overlay scrolling
+                if Gtk.get_minor_version() >= 16:
+                    sw.props.overlay_scrolling = False
 
                 self.List = ManagerDeviceList(adapter=self.Config["last-adapter"], inst=self)
 

--- a/blueman/gui/DeviceSelectorWidget.py
+++ b/blueman/gui/DeviceSelectorWidget.py
@@ -27,6 +27,10 @@ class DeviceSelectorWidget(Gtk.Box):
         self.set_size_request(360, 340)
 
         sw = Gtk.ScrolledWindow()
+        # Disable overlay scrolling
+        if Gtk.get_minor_version() >= 16:
+            sw.props.overlay_scrolling = False
+
         self.List = devlist = DeviceSelectorList(adapter)
         if self.List.Adapter is not None:
             self.List.DisplayKnownDevices()

--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -163,7 +163,15 @@ class PluginDialog(Gtk.Dialog):
         self.props.border_width = 6
         self.resize(490, 380)
 
-        self.Builder.get_object("viewport").add(self.list)
+        viewport = self.Builder.get_object("viewport")
+        viewport.add(self.list)
+
+        sw = self.Builder.get_object("main_scrolled_window")
+
+        # Disable overlay scrolling
+        if Gtk.get_minor_version() >= 16:
+            viewport.props.overlay_scrolling = False
+            sw.props.overlay_scrolling = False
 
         self.populate()
 


### PR DESCRIPTION
With many (all?) themes this overlaps the content of the ScrolledWindow, horrible.