### PR TITLE
Fix KillMode for blueman-mechanism.service

### DIFF
--- a/data/configs/blueman-mechanism.service.in
+++ b/data/configs/blueman-mechanism.service.in
@@ -3,5 +3,6 @@ Description=Bluetooth management mechanism
 
 [Service]
 Type=dbus
+KillMode=process
 BusName=org.blueman.Mechanism
 ExecStart=@LIBEXECDIR@/blueman-mechanism


### PR DESCRIPTION
systemd must not kill processes started by blueman-mechanism, i.e. DHCP handlers.

Fixes #510