### PR TITLE
NetConf: Treat UnicodeDecodeError as if there was no file

### DIFF
--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -299,7 +299,7 @@ class NetConf(object):
             NetConf.default_inst = obj
             f.close()
             return obj
-        except IOError:
+        except (IOError, UnicodeDecodeError):
             n = cls()
             try:
                 n.store()


### PR DESCRIPTION
This is unfortunate but most people will not even notice we created a new
state file.

We really should just use a plain text format like json or simple ini file. There are only a couple of variables we need to store, ip address, pid and DhcpHandler the rest, afaik, are constructed on the fly.