### PR TITLE
BlueZ: Set dbus call timeout to infinite

### DIFF
--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -108,11 +108,12 @@ class Base(GObject):
             # Make sure we have an error handler if we do async calls
             assert(error_handler != None)
 
-            dbus_proxy.call(method, param, Gio.DBusCallFlags.NONE, -1, None,
+            dbus_proxy.call(method, param, Gio.DBusCallFlags.NONE, GLib.MAXINT, None,
                 callback, ok, err)
         else:
             try:
-                result = dbus_proxy.call_sync(method, param, Gio.DBusCallFlags.NONE, -1, None)
+                result = dbus_proxy.call_sync(method, param, Gio.DBusCallFlags.NONE,
+                                              GLib.MAXINT, None)
                 if result:
                     return result.unpack()
             except GLib.Error as e:

--- a/blueman/bluez/obex/Client.py
+++ b/blueman/bluez/obex/Client.py
@@ -28,7 +28,7 @@ class Client(Base):
             'org.freedesktop.DBus.Introspectable')
 
         introspection = proxy.call_sync('Introspect', None, Gio.DBusCallFlags.NONE,
-            -1, None).unpack()[0]
+                                        GLib.MAXINT, None).unpack()[0]
 
         if 'org.freedesktop.DBus.ObjectManager' not in introspection:
             raise ObexdNotFoundError('Could not find any compatible version of obexd')


### PR DESCRIPTION
>The default proxy timeout is too short and will return before BlueZ has
the chance to send its error.

So I noticed I got a traceback when I left the request pincode dialog open too long. I was confused at first until I figured that the timeout came from the GDBusProxy object not BlueZ (BleuZ should Authentication Failed). I now set the timeout to MAXINT which means, according to the [docs](https://developer.gnome.org/gio/stable/GDBusProxy.html#g-dbus-proxy-call) means infinite.

I do not think this will break anything but to be sure a PR to gather some feedback.

```python
_on_request_pin_code (/usr/lib64/python3.5/site-packages/blueman/main/applet/BluezAgent.py:170)
Agent.RequestPinCode 
Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.
*** Tijd is verlopen
Traceback (most recent call last):
  File "/usr/lib64/python3.5/site-packages/blueman/bluez/Base.py", line 79, in callback
    result = proxy.call_finish(result).unpack()
GLib.Error: g-io-error-quark: Tijd is verlopen (24)
```

ps: github was having issues so the branch was done on the main repo. Normally I would use my fork instead.