### PR TITLE
[Serial] Open rfcomm device as unprivileged user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ Makefile
 /apps/blueman-sendto
 /apps/blueman-services
 /blueman/Constants.py
-/blueman/plugins/mechanism/Rfcomm.py
 /data/configs/blueman-applet.service
 /data/configs/blueman-mechanism.service
 /data/configs/org.blueman.Applet.service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 * Bluez managers, Subclass from GDBusObjectManagerClient
 * Notification: Use dbus for notifications and drop the libnotify dep
 * Port NMPanSupport applet plugin to GDBus
+* Open rfcomm device as unprivileged user if he has read and write access
+
 
 ### Bugs fixed
 
@@ -73,6 +75,7 @@
 * Fix SerialManager plugin
 * Close Notification when pair is successful
 * Properly unregister NAP when unloading Networking plugin
+* PPPSupport: Wait for ModemManager to complete probing and release the device
 
 
 ## 2.0

--- a/apps/blueman-rfcomm-watcher.in
+++ b/apps/blueman-rfcomm-watcher.in
@@ -11,7 +11,7 @@ from gi.repository import GLib
 import os
 import argparse
 
-from blueman.Functions import set_proc_title
+from blueman.Functions import set_proc_title, open_rfcomm
 
 
 def on_file_changed(monitor, file, other_file, event_type):
@@ -25,7 +25,7 @@ args = parser.parse_args()
 mon = Gio.File.new_for_path(args.path).monitor_file(Gio.FileMonitorFlags.NONE)
 mon.connect('changed', on_file_changed)
 
-fd = os.open(args.path, os.O_RDONLY | os.O_NONBLOCK)
+fd = open_rfcomm(args.path, os.O_RDONLY)
 
 set_proc_title()
 loop = GLib.MainLoop()

--- a/blueman/Constants.py.in
+++ b/blueman/Constants.py.in
@@ -17,6 +17,7 @@ UI_PATH = "@pkgdatadir@/ui"
 DHCP_CONFIG_FILE = "@dhconfig@"
 POLKIT = "@have_polkit@" == "yes"
 GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@"
+RFCOMM_WATCHER_PATH = "@LIBEXECDIR@/blueman-rfcomm-watcher"
 
 import os
 import gettext

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -23,6 +23,7 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from io import open
+from time import sleep
 
 from blueman.Constants import *
 
@@ -34,6 +35,7 @@ from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 from gi.repository import GLib
 from gi.repository import Gio
+from gi.repository import GObject
 import re
 import os
 import signal
@@ -399,3 +401,14 @@ def create_parser(parser=None, syslog=True, loglevel=True):
         parser.add_argument("--syslog", dest="syslog", action="store_true")
 
     return parser
+
+def open_rfcomm(file, mode):
+    try:
+        return os.open(file, mode | os.O_EXCL | os.O_NONBLOCK | os.O_NOCTTY)
+    except OSError as err:
+        if err.errno == errno.EBUSY:
+            logging.warning('%s is busy, delaying 2 seconds' % file)
+            sleep(2)
+            return open_rfcomm(file, mode)
+        else:
+            raise

--- a/blueman/main/PPPConnection.py
+++ b/blueman/main/PPPConnection.py
@@ -3,9 +3,9 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from io import open
 
 import logging
+from blueman.Functions import open_rfcomm
 import tty
 import termios
 import os
@@ -123,7 +123,7 @@ class PPPConnection(GObject.GObject):
 
     def Connect(self):
 
-        self.file = os.open(self.port, os.O_RDWR | os.O_EXCL | os.O_NONBLOCK | os.O_NOCTTY)
+        self.file = open_rfcomm(self.port, os.O_RDWR)
 
         tty.setraw(self.file)
 

--- a/blueman/plugins/mechanism/Rfcomm.py
+++ b/blueman/plugins/mechanism/Rfcomm.py
@@ -8,6 +8,7 @@ import dbus.service
 import os
 import subprocess
 import signal
+from blueman.Constants import RFCOMM_WATCHER_PATH
 from blueman.plugins.MechanismPlugin import MechanismPlugin
 
 
@@ -16,7 +17,7 @@ class Rfcomm(MechanismPlugin):
 
     @dbus.service.method('org.blueman.Mechanism', in_signature="d")
     def open_rfcomm(self, port_id):
-        subprocess.Popen(['@LIBEXECDIR@/blueman-rfcomm-watcher', '/dev/rfcomm%d' % port_id])
+        subprocess.Popen([RFCOMM_WATCHER_PATH, '/dev/rfcomm%d' % port_id])
 
     @dbus.service.method('org.blueman.Mechanism', in_signature="d")
     def close_rfcomm(self, port_id):

--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -4,10 +4,16 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import logging
+import os
+import subprocess
+from time import sleep
+
 from blueman.bluez.Adapter import Adapter
 from _blueman import rfcomm_list, release_rfcomm_device, create_rfcomm_device
 from blueman.Service import Service
 from blueman.main.Mechanism import Mechanism
+from blueman.Constants import RFCOMM_WATCHER_PATH
 
 
 class SerialService(Service):
@@ -27,9 +33,17 @@ class SerialService(Service):
         try:
             # TODO: Channel?
             port_id = create_rfcomm_device(Adapter(self.device["Adapter"])['Address'], self.device["Address"], 1)
-            Mechanism().open_rfcomm(str('(d)'), port_id)
+            filename = '/dev/rfcomm%d' % port_id
+            # We have to delay the access check to make sure the rfcomm system set up the permissions
+            sleep(0.1)
+            if os.access(filename, os.R_OK | os.W_OK):
+                logging.info('Starting rfcomm watcher as current user')
+                subprocess.Popen([RFCOMM_WATCHER_PATH, filename])
+            else:
+                logging.info('Starting rfcomm watcher as root')
+                Mechanism().open_rfcomm(str('(d)'), port_id)
             if reply_handler:
-                reply_handler('/dev/rfcomm%d' % port_id)
+                reply_handler(filename)
         except Exception as e:
             if error_handler:
                 error_handler(e)

--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -6,8 +6,10 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import signal
 import subprocess
-from time import sleep
+
+from gi.repository import Gio
 
 from blueman.bluez.Adapter import Adapter
 from _blueman import rfcomm_list, release_rfcomm_device, create_rfcomm_device
@@ -19,6 +21,7 @@ from blueman.Constants import RFCOMM_WATCHER_PATH
 class SerialService(Service):
     def __init__(self, device, uuid):
         super(SerialService, self).__init__(device, uuid)
+        self.file_changed_handler = None
 
     def serial_port_id(self, channel):
         for dev in rfcomm_list():
@@ -29,19 +32,34 @@ class SerialService(Service):
     def connected(self):
         return False
 
+    def on_file_changed(self, monitor, file, other_file, event_type, port):
+        if event_type == Gio.FileMonitorEvent.DELETED:
+            logging.info('%s got deleted' % file.get_path())
+            monitor.disconnect(self.file_changed_handler)
+        elif event_type == Gio.FileMonitorEvent.ATTRIBUTE_CHANGED:
+            self.try_replace_root_watcher(monitor, file.get_path(), port)
+
+    def try_replace_root_watcher(self, monitor, path, port):
+        if not os.access(path, os.R_OK | os.W_OK):
+            return
+
+        logging.info('User was granted access to %s' % path)
+        logging.info('Replacing root watcher')
+        Mechanism().close_rfcomm(str('(d)'), port)
+        subprocess.Popen([RFCOMM_WATCHER_PATH, path])
+        monitor.disconnect(self.file_changed_handler)
+
     def connect(self, reply_handler=None, error_handler=None):
         try:
             # TODO: Channel?
             port_id = create_rfcomm_device(Adapter(self.device["Adapter"])['Address'], self.device["Address"], 1)
             filename = '/dev/rfcomm%d' % port_id
-            # We have to delay the access check to make sure the rfcomm system set up the permissions
-            sleep(0.1)
-            if os.access(filename, os.R_OK | os.W_OK):
-                logging.info('Starting rfcomm watcher as current user')
-                subprocess.Popen([RFCOMM_WATCHER_PATH, filename])
-            else:
-                logging.info('Starting rfcomm watcher as root')
-                Mechanism().open_rfcomm(str('(d)'), port_id)
+            logging.info('Starting rfcomm watcher as root')
+            Mechanism().open_rfcomm(str('(d)'), port_id)
+            mon = Gio.File.new_for_path(filename).monitor_file(Gio.FileMonitorFlags.NONE)
+            self.file_changed_handler = mon.connect('changed', self.on_file_changed, port_id)
+            self.try_replace_root_watcher(mon, filename, port_id)
+
             if reply_handler:
                 reply_handler(filename)
         except Exception as e:

--- a/configure.ac
+++ b/configure.ac
@@ -257,7 +257,6 @@ blueman/plugins/Makefile
 blueman/plugins/services/Makefile
 blueman/plugins/applet/Makefile
 blueman/plugins/mechanism/Makefile
-blueman/plugins/mechanism/Rfcomm.py
 blueman/plugins/manager/Makefile
 blueman/main/Makefile
 blueman/main/applet/Makefile


### PR DESCRIPTION
...if he has read and write access.

This requires the watcher to wait if the device is busy which means it's opened by root (or any other user) and typically happens if ModemManager is present and probes the new device. The same method is used for PPPSupport now which previously always waited for five seconds unconditionally. While that is unnessary if ModemManager is not present, it seems to be too short if it is.

Fixes #524.

I'm not 100 % sure about the 0.1 sec delay before checking the access permissions, but if I do it immediately after creating the device, R_OK and W_OK result in False (while E_OK works, so it's not that the file would be absent).
