### PR TITLE
Drop old NetworkManager and ModemManager 0.x legacy code

### DIFF
--- a/blueman/plugins/applet/NMDUNSupport.py
+++ b/blueman/plugins/applet/NMDUNSupport.py
@@ -22,9 +22,6 @@ class ConnectionHandler:
         self.rfcomm_dev = None
         self.timeout = None
 
-        # ModemManager 0.x
-        self.parent.bus.add_signal_receiver(self.on_mm_device_added, "DeviceAdded", "org.freedesktop.ModemManager")
-        # ModemManager 1.x
         self.parent.bus.add_signal_receiver(self.on_interfaces_added, "InterfacesAdded",
                                             "org.freedesktop.DBus.ObjectManager")
 
@@ -48,7 +45,6 @@ class ConnectionHandler:
     def cleanup(self):
         if self.timeout:
             GLib.source_remove(self.timeout)
-        self.parent.bus.remove_signal_receiver(self.on_mm_device_added, "DeviceAdded", "org.freedesktop.ModemManager")
         self.parent.bus.remove_signal_receiver(self.on_interfaces_added, "InterfacesAdded",
                                                "org.freedesktop.DBus.ObjectManager")
 

--- a/blueman/plugins/applet/NMPANSupport.py
+++ b/blueman/plugins/applet/NMPANSupport.py
@@ -8,7 +8,7 @@ from blueman.Functions import dprint
 from gi.repository import GLib
 import dbus
 from blueman.plugins.AppletPlugin import AppletPlugin
-from uuid import uuid1
+from uuid import uuid4
 
 
 class NewConnectionBuilder:
@@ -36,7 +36,7 @@ class NewConnectionBuilder:
             # However users may have removed the connection and we error out
             addr_bytes = bytearray.fromhex(str.replace(str(service.device['Address']), ':', ' '))
             parent.nma.AddConnection({
-                'connection':   {'id': '%s on %s' % (service.name, service.device['Alias']), 'uuid': str(uuid1()),
+                'connection':   {'id': '%s on %s' % (service.name, service.device['Alias']), 'uuid': str(uuid4()),
                                  'autoconnect': False, 'type': 'bluetooth'},
                 'bluetooth':    {'bdaddr': dbus.ByteArray(addr_bytes), 'type': 'panu'},
                 'ipv4':         {'method': 'auto'},

--- a/blueman/plugins/applet/NMPANSupport.py
+++ b/blueman/plugins/applet/NMPANSupport.py
@@ -36,7 +36,7 @@ class NewConnectionBuilder:
             # However users may have removed the connection and we error out
             addr_bytes = bytearray.fromhex(str.replace(str(service.device['Address']), ':', ' '))
             parent.nma.AddConnection({
-                'connection':   {'id': '%s on %s' % (service.name, service.device['Alias']), 'uuid': str(uuid4()),
+                'connection':   {'id': '%s Network' % service.device['Alias'], 'uuid': str(uuid4()),
                                  'autoconnect': False, 'type': 'bluetooth'},
                 'bluetooth':    {'bdaddr': dbus.ByteArray(addr_bytes), 'type': 'panu'},
                 'ipv4':         {'method': 'auto'},


### PR DESCRIPTION
So one question, we now rely completely on bluez/networkmanager to handle the connection. This is all ok except the user may remove the connection themselves and we cannot activate the connection. The  question then is, should we still create the connection? I am leaning towards we still create the connection even if it is missing.

This works for me with a PAN phone but I don't have a phone that supports DUN. Would be nice if someone can test this with DUN :smile: 