### PR TITLE
RFC: DiscvManager: Check if adapter is None so we do not error

### DIFF
--- a/blueman/plugins/applet/DiscvManager.py
+++ b/blueman/plugins/applet/DiscvManager.py
@@ -79,7 +79,10 @@ class DiscvManager(AppletPlugin):
 
     def on_adapter_removed(self, path):
         dprint(path)
-        if path == self.adapter.get_object_path():
+        if self.adapter is None:
+            # FIXME we appear to call this more than once on adapter removal
+            dprint("Warning: adapter is None")
+        elif path == self.adapter.get_object_path():
             self.init_adapter()
             self.update_menuitems()
 


### PR DESCRIPTION
So we apparently call on_adapter_removed more than once and it only blows up here. The best solution is to figure out why this is but I do not have the time right now.

```python
on_adapter_removed (/usr/lib64/python3.5/site-packages/blueman/plugins/applet/DiscvManager.py:81)
/org/bluez/hci0 
_________
on_adapter_removed (/usr/lib64/python3.5/site-packages/blueman/plugins/applet/DiscvManager.py:81)
None 
_________
Run (/usr/lib64/python3.5/site-packages/blueman/main/PluginManager.py:208)
Function on_adapter_removed on DiscvManager Failed 
Traceback (most recent call last):
  File "/usr/lib64/python3.5/site-packages/blueman/main/PluginManager.py", line 212, in Run
    ret = getattr(inst, function)(*args, **kwargs)
  File "/usr/lib64/python3.5/site-packages/blueman/plugins/applet/DiscvManager.py", line 84, in on_adapter_removed
    if path == self.adapter.get_object_path():
AttributeError: 'NoneType' object has no attribute 'get_object_path'
```