### PR TITLE
Close bold tag in pt.po

### DIFF
--- a/po/pt.po
+++ b/po/pt.po
@@ -1352,7 +1352,7 @@ msgstr "Ligar todos os adaptadores"
 
 #: ../blueman/plugins/applet/PowerManager.py:184
 msgid "<b>Turn Bluetooth _Off</b>"
-msgstr "<b>Desligar o Bluetooth</>"
+msgstr "<b>Desligar o Bluetooth</b>"
 
 #: ../blueman/plugins/applet/GameControllerWakelock.py:15
 msgid ""


### PR DESCRIPTION
In line 1355 there was a `</>` thing. I fixed it to match the opened bold tag.