### PR TITLE
RFC: blueman-applet: Do not create and tear down manager objects

### DIFF
--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -50,6 +50,7 @@ class BluemanApplet(object):
 
         self._signals = []
 
+        self.plugin_run_state_changed = False
         self.Manager = None
         self.DbusSvc = DbusService("org.blueman.Applet", "/")
 
@@ -71,7 +72,10 @@ class BluemanApplet(object):
     def manager_init(self):
         try:
             self.Manager = Bluez.Manager()
-            self.Plugins.Run("on_manager_state_changed", True)
+            self.manager_state = True
+            self.plugin_run_state_changed = True
+        
+            self.Plugins.Run("on_manager_state_changed", self.manager_state)
 
             self._signals.append(self.Manager.connect_signal('adapter-added', self.on_adapter_added))
             self._signals.append(self.Manager.connect_signal('adapter-removed', self.on_adapter_removed))
@@ -89,7 +93,9 @@ class BluemanApplet(object):
             self.Manager.disconnect_signal(sig)
 
         self.Manager = None
-        self.Plugins.Run("on_manager_state_changed", False)
+        self.manager_state = False
+        self.plugin_run_state_changed = True
+        self.Plugins.Run("on_manager_state_changed", self.manager_state)
 
     def _on_dbus_name_appeared(self, _connection, name, owner):
         dprint(name, owner)

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -51,7 +51,13 @@ class BluemanApplet(object):
         self._signals = []
 
         self.plugin_run_state_changed = False
-        self.Manager = None
+
+        self.Manager = Bluez.Manager()
+        self._signals.append(self.Manager.connect_signal('adapter-added', self.on_adapter_added))
+        self._signals.append(self.Manager.connect_signal('adapter-removed', self.on_adapter_removed))
+        self._signals.append(self.Manager.connect_signal('device-created', self.on_device_created))
+        self._signals.append(self.Manager.connect_signal('device-removed', self.on_device_removed))
+
         self.DbusSvc = DbusService("org.blueman.Applet", "/")
 
         self.Plugins = PersistentPluginManager(AppletPlugin, blueman.plugins.applet, self)
@@ -59,7 +65,7 @@ class BluemanApplet(object):
 
         self.Plugins.Run("on_plugins_loaded")
 
-        Bluez.Manager.watch_name_owner(self._on_dbus_name_appeared, self._on_dbus_name_vanished)
+        self.Manager.watch_name_owner(self._on_dbus_name_appeared, self._on_dbus_name_vanished)
 
         self._any_adapter = Bluez.AnyAdapter()
         self._any_adapter.connect_signal('property-changed', self._on_adapter_property_changed)
@@ -69,42 +75,17 @@ class BluemanApplet(object):
 
         Gtk.main()
 
-    def manager_init(self):
-        try:
-            self.Manager = Bluez.Manager()
-            self.manager_state = True
-            self.plugin_run_state_changed = True
-        
-            self.Plugins.Run("on_manager_state_changed", self.manager_state)
-
-            self._signals.append(self.Manager.connect_signal('adapter-added', self.on_adapter_added))
-            self._signals.append(self.Manager.connect_signal('adapter-removed', self.on_adapter_removed))
-            self._signals.append(self.Manager.connect_signal('device-created', self.on_device_created))
-            self._signals.append(self.Manager.connect_signal('device-removed', self.on_device_removed))
-
-        # FIXME catch specific error(s)
-        except Exception as e:
-            dprint(e)
-            self.manager_deinit()
-            dprint("Bluez DBus API not available. Listening for DBus name ownership changes")
-
-    def manager_deinit(self):
-        for sig in self._signals:
-            self.Manager.disconnect_signal(sig)
-
-        self.Manager = None
-        self.manager_state = False
+    def _on_dbus_name_appeared(self, _connection, name, owner):
+        dprint(name, owner)
+        self.manager_state = True
         self.plugin_run_state_changed = True
         self.Plugins.Run("on_manager_state_changed", self.manager_state)
 
-    def _on_dbus_name_appeared(self, _connection, name, owner):
-        dprint(name, owner)
-        if self.Manager is None:
-            self.manager_init()
-
     def _on_dbus_name_vanished(self, _connection, name):
         dprint(name)
-        self.manager_deinit()
+        self.manager_state = False
+        self.plugin_run_state_changed = True
+        self.Plugins.Run("on_manager_state_changed", self.manager_state)
 
     def _on_adapter_property_changed(self, adapter, key, value):
         self.Plugins.Run("on_adapter_property_changed", adapter.get_object_path(), key, value)

--- a/blueman/bluez/Agent.py
+++ b/blueman/bluez/Agent.py
@@ -49,22 +49,24 @@ class Agent(object):
     __bus = Gio.bus_get_sync(Gio.BusType.SYSTEM)
 
     def __init__(self, agent_path, handle_method_call):
-        node_info = Gio.DBusNodeInfo.new_for_xml(introspection_xml)
+        self.__agent_path = agent_path
+        self.__handle_method_call = handle_method_call
+        self.__node_info = Gio.DBusNodeInfo.new_for_xml(introspection_xml)
+        self.__regid = None
 
+    def _register_object(self):
         regid = self.__bus.register_object(
-            agent_path,
-            node_info.interfaces[0],
-            handle_method_call,
+            self.__agent_path,
+            self.__node_info.interfaces[0],
+            self.__handle_method_call,
             None,
             None)
 
         if regid:
             self.__regid = regid
         else:
-            raise GLib.Error('Failed to register object with path: %s', agent_path)
-
-    def __del__(self):
-        self._unregister_object()
+            raise GLib.Error('Failed to register object with path: %s', self.__agent_path)
 
     def _unregister_object(self):
         self.__bus.unregister_object(self.__regid)
+        self.__regid = None

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -32,10 +32,14 @@ class BluezAgent(Agent):
         self.signal_id = None
         self.time_func = time_func
 
+    def register_agent(self):
+        dprint()
+        self._register_object()
         Bluez.AgentManager().register_agent(self.__agent_path, "KeyboardDisplay", default=True)
 
-    def __del__(self):
+    def unregister_agent(self):
         dprint()
+        self._unregister_object()
         Bluez.AgentManager().unregister_agent(self.__agent_path)
 
     def _handle_method_call(self, connection, sender, agent_path, interface_name, method_name, parameters, invocation):

--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -53,7 +53,9 @@ class AppletPlugin(ConfigurablePlugin):
 
         self.Applet.DbusSvc.add_definitions(self)
 
-        self.on_manager_state_changed(applet.Manager is not None)
+        # The applet will run on_manager_state_changed once at startup so until it has we don't.
+        if applet.plugin_run_state_changed:
+            self.on_manager_state_changed(applet.manager_state)
 
     # virtual funcs
     def on_manager_state_changed(self, state):

--- a/blueman/plugins/applet/AuthAgent.py
+++ b/blueman/plugins/applet/AuthAgent.py
@@ -26,15 +26,14 @@ class AuthAgent(AppletPlugin):
         self._last_event_time = time
 
     def on_unload(self):
-        self._remove_agent()
+        if self._agent:
+            self._agent.unregister_agent()
+            self._agent = None
 
     def on_manager_state_changed(self, state):
         if state:
             self._agent = BluezAgent(self.Applet.Plugins.StatusIcon, lambda: self._last_event_time)
+            self._agent.register_agent()
         else:
-            self._remove_agent()
-
-    def _remove_agent(self):
-        if self._agent:
-            self._agent._on_release()
-            del self._agent
+            # At this point bluez already called Release on the agent
+            self._agent = None

--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -51,7 +51,13 @@ class Networking(AppletPlugin):
         m.ReloadNetwork(reply_handler=reply, error_handler=err)
 
     def on_unload(self):
+        for adapter_path in self._registered:
+            s = NetworkServer(adapter_path)
+            s.unregister("nap")
+
+        self._registered = {}
         del self.Config
+
 
     def on_adapter_added(self, path):
         self.update_status()

--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -65,7 +65,7 @@ class Networking(AppletPlugin):
 
     def set_nap(self, on):
         dprint("set nap", on)
-        if self.Applet.Manager is not None:
+        if self.Applet.manager_state:
             adapters = self.Applet.Manager.list_adapters()
             for adapter in adapters:
                 object_path = adapter.get_object_path()


### PR DESCRIPTION
 * GDBus does not error if we create a proxy when bluez is not running.
 * If bluez is not running we are unlikely to see signals
 * We now only run "on_manager_state_changed" when the name (dis)appears.

------
This does expose a logic bug in BluezAgent resulting in failing to unregister. How are we supposed to unregister when the bluez was stopped? There are also some other smallish changes needed so this is not meant to be merged just yet. I need to go now and revisit this later.

```
__del__ (/usr/lib64/python3.5/site-packages/blueman/main/applet/BluezAgent.py:37)

Exception ignored in: <bound method BluezAgent.__del__ of <blueman.main.applet.BluezAgent.BluezAgent object at 0x7f23c9963588>>
Traceback (most recent call last):
  File "/usr/lib64/python3.5/site-packages/blueman/main/applet/BluezAgent.py", line 39, in __del__
    Bluez.AgentManager().unregister_agent(self.__agent_path)
  File "/usr/lib64/python3.5/site-packages/blueman/bluez/AgentManager.py", line 25, in unregister_agent
    self._call('UnregisterAgent', param)
  File "/usr/lib64/python3.5/site-packages/blueman/bluez/Base.py", line 120, in _call
    raise parse_dbus_error(e)
blueman.bluez.errors.DBusServiceUnknownError:  The name org.bluez was not provided by any .service files
```