### PR TITLE
RFC: Add some comments explaining what the plugin methods should do and do

### DIFF
--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -4,13 +4,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from gi.repository import GObject
-
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-import inspect
-import traceback
 
 from blueman.plugins.ConfigurablePlugin import ConfigurablePlugin
 from functools import partial

--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -39,6 +39,7 @@ class AppletPlugin(ConfigurablePlugin):
         self.__overrides = []
 
     def override_method(self, obj, method, override):
+        """Replace a method on an object with another which will be called instead"""
         orig = obj.__getattribute__(method)
         obj.__setattr__(method, partial(override, obj))
         self.__overrides.append((obj, method, orig))
@@ -60,24 +61,31 @@ class AppletPlugin(ConfigurablePlugin):
 
     # virtual funcs
     def on_manager_state_changed(self, state):
+        """Run when the dbus service appears and disappears. Should only be used to setup, register agents etc"""
         pass
 
     def on_adapter_added(self, adapter):
+        """Run when a new adapter is added to the system"""
         pass
 
     def on_adapter_removed(self, adapter):
+        """Run when an adapter is removed from the system"""
         pass
 
     def on_device_created(self, device):
+        """Run when a new device is found"""
         pass
 
     def on_device_removed(self, device):
+        """Run when a device is removed"""
         pass
 
     def on_adapter_property_changed(self, path, key, value):
+        """Run when a property changes of any adapters. Make sure to distinguish your actions by path"""
         pass
 
     def on_device_property_changed(self, path, key, value):
+        """Run when a property changes of any devices. Make sure to distinguish your actions by path"""
         pass
 
     #notify when all plugins finished loading

--- a/blueman/plugins/BasePlugin.py
+++ b/blueman/plugins/BasePlugin.py
@@ -34,6 +34,7 @@ class BasePlugin(object):
 
     @classmethod
     def add_method(cls, func):
+        """Add a new method that can be used by other plugins to listen for changes, query state, etc"""
         func.__self__.__methods.append((cls, func.__name__))
 
         if func.__name__ in cls.__dict__:
@@ -62,7 +63,9 @@ class BasePlugin(object):
 
     # virtual methods
     def on_load(self, applet):
+        """Do what is neccessary for the plugin to work like add watches or create ui elements"""
         pass
 
     def on_unload(self):
+        """Tear down any watches and ui elements created in on_load"""
         raise NotImplementedError

--- a/blueman/plugins/BasePlugin.py
+++ b/blueman/plugins/BasePlugin.py
@@ -55,7 +55,7 @@ class BasePlugin(object):
             self.on_load(parent)
             # self.on_manager_state_changed(applet.Manager != None)
             self.__class__.__instance__ = self
-        except Exception as e:
+        except Exception:
             # AppletPlugin.instances.remove(self)
             self.__class__.__instance__ = None
             traceback.print_exc()


### PR DESCRIPTION
The plugin system is nice but the design is not really documented anywhere. I started documenting by adding docstring to the virtual functions and a few others within the plugin context.

The basic design how I see it is:
 - Any setup/tear-down necessary for the plugin to work should be done in on_load and on_unload. This excludes any interaction directly with bluez like manipulating properties, this should be setup in on_manager_state_changed
 - on_manager_state_changed indicates whether bluez dbus api is available or not. We should add/remove watches, (dis)connect bluez object signals and setup/clean-up anything bluez related.
 - Then we have several the default functions that are run on the plugins which should be used to update state, change the ui etc.

ps: also two commits removing unused import and an unused variable