### PR TITLE
Functions: Fix error formatter function e_()

### DIFF
--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -193,7 +193,7 @@ class Blueman(Gtk.Window):
             self.List.DiscoverDevices()
         except Exception as e:
             prog.finalize()
-            MessageArea.show_message(e_(e))
+            MessageArea.show_message(*e_(e))
 
         s1 = self.List.connect("discovery-progress", on_progress)
         s2 = self.List.connect("adapter-property-changed", prop_changed)

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -216,11 +216,8 @@ def e_(msg):
     if isinstance(msg, Exception):
         return str(msg) + "\n" + traceback.format_exc()
     else:
-        msg = str(msg)
-
-        s = msg.split(": ")
-        del s[0]
-        return ": ".join(s)
+        s = msg.strip().split(": ")[-1]
+        return s
 
 
 def opacify_pixbuf(pixbuf, alpha):

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -214,11 +214,10 @@ def adapter_path_to_name(path):
 #format error
 def e_(msg):
     if isinstance(msg, Exception):
-        return str(msg) + "\n" + traceback.format_exc()
+        return (str(msg), traceback.format_exc())
     else:
         s = msg.strip().split(": ")[-1]
-        return s
-
+        return (s, None)
 
 def opacify_pixbuf(pixbuf, alpha):
     new = pixbuf.copy()

--- a/blueman/gui/MessageArea.py
+++ b/blueman/gui/MessageArea.py
@@ -86,6 +86,7 @@ class MessageArea(Gtk.EventBox):
 
     def on_more(self, button):
         d = Gtk.MessageDialog(parent=None, flags=0, type=Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.CLOSE)
+        d.set_transient_for(self.get_toplevel())
 
         d.props.text = '\n'.join((self.text, self.bt))
 

--- a/blueman/gui/MessageArea.py
+++ b/blueman/gui/MessageArea.py
@@ -87,7 +87,7 @@ class MessageArea(Gtk.EventBox):
     def on_more(self, button):
         d = Gtk.MessageDialog(parent=None, flags=0, type=Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.CLOSE)
 
-        d.props.text = self.text
+        d.props.text = '\n'.join((self.text, self.bt))
 
         d.run()
         d.destroy()
@@ -138,8 +138,9 @@ class MessageArea(Gtk.EventBox):
     def show_message(*args):
         MessageArea._inst_._show_message(*args)
 
-    def _show_message(self, text, icon="dialog-warning"):
+    def _show_message(self, text, bt=None, icon="dialog-warning"):
         self.text = text
+        self.bt = bt
 
         self.label.set_tooltip_text(text)
         self.icon.set_from_icon_name(icon, Gtk.IconSize.MENU)
@@ -165,12 +166,11 @@ class MessageArea(Gtk.EventBox):
             self.hl_anim.thaw()
             self.hl_anim.animate(start=0.7, end=1.0, duration=1000)
 
-        lines = text.split("\n")
-        if len(lines) > 1:
-            self.label.props.label = lines[0] + "..."
+        if self.bt:
+            self.label.props.label = self.text + "..."
             self.b_more.props.visible = True
         else:
-            self.label.props.label = text
+            self.label.props.label = self.text
             self.b_more.props.visible = False
 
     def draw(self, window, cr):

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -128,7 +128,8 @@ class ManagerDeviceMenu(Gtk.Menu):
 
             self.unset_op(device)
             dprint("fail", result)
-            MessageArea.show_message(_("Connection Failed: ") + e_(str(result.message)))
+            msg, tb = e_(result.message)
+            MessageArea.show_message(_("Connection Failed: ") + msg, tb)
 
         self.set_op(device, _("Connecting..."))
         prog = ManagerProgressbar(self.Blueman, False)


### PR DESCRIPTION
>We now split and always get the last item as this holds the error message.
>Also call strip() on the string as it may contain a new line and the
>MessageArea will show a "More" button.
>
>This got broken with the GDBus migration of various parts in blueman as
>GLib's exceptions do not match dbus-glib's.

------

There is, imo, a weird implicit behaviour in the ``MessageArea`` where a string containing a newline will trigger the ``More`` button to show up, see [1]. The newline is added by the ``e_`` function when it got an instance of ``Exception``. I would really like to drop this and explicitly send a tuple instead.

Any objections to this? If not I'll add it to this PR.

[1] https://github.com/blueman-project/blueman/blob/master/blueman/gui/MessageArea.py#L168