### PR TITLE
Bluez object manager

### DIFF
--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -68,7 +68,7 @@ class BluemanAdapters(Gtk.Dialog):
 
         self.manager.connect_signal('adapter-added', self.on_adapter_added)
         self.manager.connect_signal('adapter-removed', self.on_adapter_removed)
-        for adapter in self.manager.list_adapters():
+        for adapter in self.manager.get_adapters():
             path = adapter.get_object_path()
             hci_dev = os.path.basename(path)
             self._adapters[hci_dev] = adapter

--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -5,9 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from gi.repository import GObject, Gio, GLib
-from blueman.Functions import dprint
 from blueman.bluez.Base import Base
-from blueman.bluez.Device import Device
 from blueman.bluez.AnyBase import AnyBase
 
 class Adapter(Base):
@@ -15,27 +13,6 @@ class Adapter(Base):
 
     def _init(self, obj_path=None):
         super(Adapter, self)._init(self._interface_name, obj_path=obj_path)
-
-        self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
-            Gio.BusType.SYSTEM, Gio.DBusObjectManagerClientFlags.NONE,
-            'org.bluez', '/', None, None, None)
-
-    def find_device(self, address):
-        for device in self.list_devices():
-            if device['Address'] == address:
-                return device
-
-    def list_devices(self):
-        paths = []
-        for obj_proxy in self._object_manager.get_objects():
-            proxy = obj_proxy.get_interface('org.bluez.Device1')
-
-            if proxy:
-                object_path = proxy.get_object_path()
-                if object_path.startswith(self.get_object_path()):
-                    paths.append(object_path)
-
-        return [Device(path) for path in paths]
 
     def start_discovery(self):
         self._call('StartDiscovery')

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -68,7 +68,7 @@ class Manager(GObject.GObject):
             dprint(object_path)
             self.emit('device-removed', object_path)
 
-    def list_adapters(self):
+    def get_adapters(self):
         paths = []
         for obj_proxy in self._object_manager.get_objects():
             proxy = obj_proxy.get_interface('org.bluez.Adapter1')
@@ -78,7 +78,7 @@ class Manager(GObject.GObject):
         return [Adapter(path) for path in paths]
 
     def get_adapter(self, pattern=None):
-        adapters = self.list_adapters()
+        adapters = self.get_adapters()
         if pattern is None:
             if len(adapters):
                 return adapters[0]

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -8,7 +8,6 @@ from blueman.Functions import dprint
 
 from blueman.bluez.Adapter import Adapter
 from blueman.bluez.Device import Device
-from blueman.bluez.errors import DBusNoSuchAdapterError
 
 
 class Manager(GObject.GObject):
@@ -88,10 +87,6 @@ class Manager(GObject.GObject):
                 path = adapter.get_object_path()
                 if path.endswith(pattern) or adapter.get_properties()['Address'] == pattern:
                     return adapter
-
-        # If the given - or any - adapter does not exist, raise the NoSuchAdapter
-        # error BlueZ 4's DefaultAdapter and FindAdapter methods trigger
-        raise DBusNoSuchAdapterError('No such adapter')
 
     def get_devices(self, adapter_path='/'):
         paths = []

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -10,7 +10,7 @@ from blueman.bluez.Adapter import Adapter
 from blueman.bluez.Device import Device
 
 
-class Manager(GObject.GObject):
+class Manager(Gio.DBusObjectManagerClient):
     __gsignals__ = {
         str('adapter-added'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
         str('adapter-removed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
@@ -33,16 +33,16 @@ class Manager(GObject.GObject):
     def __init__(self, *args, **kwargs):
         pass
 
-    def _init(self):
-        super(Manager, self).__init__()
-        self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
-            Gio.BusType.SYSTEM, Gio.DBusObjectManagerClientFlags.NONE,
-            self.__bus_name, '/', None, None, None)
+    def _init(self, **kwargs):
+        super(Manager, self).__init__(
+            bus_type=Gio.BusType.SYSTEM,
+            flags=Gio.DBusObjectManagerClientFlags.NONE,
+            name=self.__bus_name,
+            object_path='/',
+            **kwargs)
+        self._init()
 
-        self._object_manager.connect("object-added", self._on_object_added)
-        self._object_manager.connect("object-removed", self._on_object_removed)
-
-    def _on_object_added(self, object_manager, dbus_object):
+    def do_object_added(self, dbus_object):
         device_proxy = dbus_object.get_interface('org.bluez.Device1')
         adapter_proxy = dbus_object.get_interface('org.bluez.Adapter1')
 
@@ -55,7 +55,7 @@ class Manager(GObject.GObject):
             dprint(object_path)
             self.emit('device-created', object_path)
 
-    def _on_object_removed(self, object_manager, dbus_object):
+    def do_object_removed(self, dbus_object):
         device_proxy = dbus_object.get_interface('org.bluez.Device1')
         adapter_proxy = dbus_object.get_interface('org.bluez.Adapter1')
 
@@ -70,7 +70,7 @@ class Manager(GObject.GObject):
 
     def get_adapters(self):
         paths = []
-        for obj_proxy in self._object_manager.get_objects():
+        for obj_proxy in self.get_objects():
             proxy = obj_proxy.get_interface('org.bluez.Adapter1')
 
             if proxy: paths.append(proxy.get_object_path())

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -7,6 +7,7 @@ from gi.repository import GObject, Gio
 from blueman.Functions import dprint
 
 from blueman.bluez.Adapter import Adapter
+from blueman.bluez.Device import Device
 from blueman.bluez.errors import DBusNoSuchAdapterError
 
 
@@ -91,6 +92,23 @@ class Manager(GObject.GObject):
         # If the given - or any - adapter does not exist, raise the NoSuchAdapter
         # error BlueZ 4's DefaultAdapter and FindAdapter methods trigger
         raise DBusNoSuchAdapterError('No such adapter')
+
+    def get_devices(self, adapter_path='/'):
+        paths = []
+        for obj_proxy in self.get_objects():
+            proxy = obj_proxy.get_interface('org.bluez.Device1')
+
+            if proxy:
+                object_path = proxy.get_object_path()
+                if object_path.startswith(adapter_path):
+                    paths.append(object_path)
+
+        return [Device(path) for path in paths]
+
+    def find_device(self, address, adapter_path='/'):
+        for device in self.get_devices(adapter_path):
+            if device['Address'] == address:
+                return device
 
     @classmethod
     def watch_name_owner(cls, appeared_handler, vanished_handler):

--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -9,7 +9,7 @@ from blueman.bluez.obex.Transfer import Transfer
 from gi.repository import GObject, Gio
 
 
-class Manager(GObject.GObject):
+class Manager(Gio.DBusObjectManagerClient):
     __gsignals__ = {
         str('session-removed'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
         str('transfer-started'): (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
@@ -31,23 +31,22 @@ class Manager(GObject.GObject):
     def __init__(self, *args, **kwargs):
         pass
 
-    def _init(self):
-        super(Manager, self).__init__()
+    def _init(self, **kwargs):
+        super(Manager, self).__init__(
+            bus_type=Gio.BusType.SESSION,
+            flags=Gio.DBusObjectManagerClientFlags.NONE,
+            name=self.__bus_name,
+            object_path='/',
+            **kwargs)
+        self.init()
+
         self.__transfers = {}
-        self.__signals = []
-
-        self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
-            Gio.BusType.SESSION, Gio.DBusObjectManagerClientFlags.NONE,
-            self.__bus_name, '/', None, None, None)
-
-        self.__signals.append(self._object_manager.connect('object-added', self._on_object_added))
-        self.__signals.append(self._object_manager.connect('object-removed', self._on_object_removed))
 
     def __del__(self):
         for sig in self.__signals:
             self._object_manager.disconnect(sig)
 
-    def _on_object_added(self, object_manager, dbus_object):
+    def do_object_added(self, dbus_object):
         transfer_proxy = dbus_object.get_interface('org.bluez.obex.Transfer1')
 
         if transfer_proxy:
@@ -60,7 +59,7 @@ class Manager(GObject.GObject):
             dprint(transfer_path)
             self.emit('transfer-started', transfer_path)
 
-    def _on_object_removed(self, object_manager, dbus_object):
+    def do_object_removed(self, dbus_object):
         session_proxy = dbus_object.get_interface('org.bluez.obex.Session1')
 
         if session_proxy:

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -245,7 +245,7 @@ class DeviceList(GenericList):
         except Bluez.errors.DBusNoSuchAdapterError as e:
             dprint(e)
             #try loading default adapter
-            if len(self.manager.list_adapters()) > 0 and adapter is not None:
+            if len(self.manager.get_adapters()) > 0 and adapter is not None:
                 self.SetAdapter()
             else:
                 self.Adapter = None

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -293,7 +293,7 @@ class DeviceList(GenericList):
 
     def DisplayKnownDevices(self, autoselect=False):
         self.clear()
-        devices = self.Adapter.list_devices()
+        devices = self.manager.get_devices(self.Adapter.get_object_path())
         for device in devices:
             self.device_add_event(device)
 

--- a/blueman/gui/DeviceSelectorWidget.py
+++ b/blueman/gui/DeviceSelectorWidget.py
@@ -117,7 +117,7 @@ class DeviceSelectorWidget(Gtk.Box):
     def update_adapters_list(self):
 
         self.cb_adapters.get_model().clear()
-        adapters = self.List.manager.list_adapters()
+        adapters = self.List.manager.get_adapters()
         num = len(adapters)
         if num == 0:
             self.cb_adapters.props.visible = False

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -164,7 +164,7 @@ class ManagerMenu:
 
         blueman.List.connect("device-selected", self.on_device_selected)
 
-        for adapter in self._manager.list_adapters():
+        for adapter in self._manager.get_adapters():
             self.on_adapter_added(None, adapter.get_object_path())
 
         self.device_menu = None

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -192,7 +192,7 @@ class Dialog:
             if not added:
                 name = d
                 if self.parent.Applet.Manager:
-                    for a in self.parent.Applet.Manager.list_adapters():
+                    for a in self.parent.Applet.Manager.get_adapters():
                         try:
                             device = a.find_device(d)
                             name = self.get_caption(device["Alias"], device["Address"])

--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -72,7 +72,7 @@ class Networking(AppletPlugin):
     def set_nap(self, on):
         dprint("set nap", on)
         if self.Applet.manager_state:
-            adapters = self.Applet.Manager.list_adapters()
+            adapters = self.Applet.Manager.get_adapters()
             for adapter in adapters:
                 object_path = adapter.get_object_path()
 

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -77,7 +77,7 @@ class PowerManager(AppletPlugin):
             GLib.timeout_add(1000, timeout)
 
     def get_adapter_state(self):
-        adapters = self.Applet.Manager.list_adapters()
+        adapters = self.Applet.Manager.get_adapters()
         for adapter in adapters:
             props = adapter.get_properties()
             if not props["Powered"]:
@@ -87,7 +87,7 @@ class PowerManager(AppletPlugin):
     def set_adapter_state(self, state):
         try:
             dprint(state)
-            adapters = self.Applet.Manager.list_adapters()
+            adapters = self.Applet.Manager.get_adapters()
             for adapter in adapters:
                 adapter.set("Powered", state)
 

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -165,7 +165,7 @@ class RecentConns(AppletPlugin, Gtk.Menu):
                 pass
 
             self.Item.props.sensitive = True
-            adapters = self.Applet.Manager.list_adapters()
+            adapters = self.Applet.Manager.get_adapters()
             self.Adapters = {}
             for adapter in adapters:
                 p = adapter.get_properties()

--- a/blueman/plugins/applet/ShowConnected.py
+++ b/blueman/plugins/applet/ShowConnected.py
@@ -46,7 +46,7 @@ class ShowConnected(AppletPlugin):
 
     def enumerate_connections(self):
         self.num_connections = 0
-        adapters = self.Applet.Manager.list_adapters()
+        adapters = self.Applet.Manager.get_adapters()
         for adapter in adapters:
             devices = adapter.list_devices()
             for device in devices:

--- a/blueman/plugins/applet/ShowConnected.py
+++ b/blueman/plugins/applet/ShowConnected.py
@@ -46,14 +46,11 @@ class ShowConnected(AppletPlugin):
 
     def enumerate_connections(self):
         self.num_connections = 0
-        adapters = self.Applet.Manager.get_adapters()
-        for adapter in adapters:
-            devices = adapter.list_devices()
-            for device in devices:
-                props = device.get_properties()
-                if "Connected" in props:
-                    if props["Connected"]:
-                        self.num_connections += 1
+        for device in self.Applet.Manager.get_devices():
+            props = device.get_properties()
+            if "Connected" in props:
+                if props["Connected"]:
+                    self.num_connections += 1
 
         dprint("Found %d existing connections" % self.num_connections)
         if (self.num_connections > 0 and not self.active) or \

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -65,7 +65,7 @@ class StatusIcon(AppletPlugin, Gtk.StatusIcon):
                     return
 
                 try:
-                    self.set_visible(self.Applet.Manager.list_adapters())
+                    self.set_visible(self.Applet.Manager.get_adapters())
                 except:
                     self.set_visible(False)
         else:


### PR DESCRIPTION
This changes a couple of things to make more sense.

 * Rename list_* functions to get_* as we are returning proper Adapter and Device objects.
 * Move device object handling to the manager, this is the job of the object manager not the adapter.

To then make it possible to subclass from ``Gio.DBusObjectManagerClient``. Tested this quickly and things appear to work well but feedback and more testing appreciated :smile: .