### PR TITLE
Delay hiding the status icon when ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Icon disappeared when switching off bluetooth
 * Revert "bluez manager: Subclass from GDBusObjectManagerClient"
+* Icon briefly vanished when turning on bluetooth
 
 ## 2.1.alpha1
 

--- a/blueman/plugins/applet/KillSwitch.py
+++ b/blueman/plugins/applet/KillSwitch.py
@@ -104,7 +104,7 @@ class KillSwitch(AppletPlugin):
 
         logging.info("State: %s" % self._enabled)
 
-        self.Applet.Plugins.StatusIcon.QueryVisibility()
+        self.Applet.Plugins.StatusIcon.QueryVisibility(delay_hiding=not self._hardblocked)
         self.Applet.Plugins.PowerManager.UpdatePowerState()
 
         return True

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -82,6 +82,7 @@ class StatusIcon(AppletPlugin, Gtk.StatusIcon):
 
     def on_visibility_timeout(self):
         GLib.source_remove(self.visibility_timeout)
+        self.visibility_timeout = None
         self.QueryVisibility()
 
     def set_visible(self, visible):

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -134,6 +134,7 @@ class StatusIcon(AppletPlugin, Gtk.StatusIcon):
 
         self.Applet.Plugins.RunEx("on_status_icon_query_icon", callback)
         self.props.icon_name = self.icon
+        self.QueryVisibility()
 
         return True
 


### PR DESCRIPTION
...bluetooth gets re-enabled.

Right after re-enabling bluetooth no adapters are available so the icon vanishes for a short moment until adapters are presented. To avoid that, just wait a second for adapters to show up before hiding the icon if none are present at all.

Fixes #314
