### PR TITLE
DBusService: make QueryAvailablePlugins return a list of keys instead…

### DIFF
--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -51,7 +51,7 @@ class DBusService(AppletPlugin):
 
     @dbus.service.method('org.blueman.Applet', in_signature="", out_signature="as")
     def QueryAvailablePlugins(self):
-        return self.Applet.Plugins.GetClasses()
+        return self.Applet.Plugins.GetClasses().keys()
 
     @dbus.service.method('org.blueman.Applet', in_signature="sb", out_signature="")
     def SetPluginConfig(self, plugin, value):


### PR DESCRIPTION
… of a dict

 The signature and usage elsewhere indicates we should return a list of plugin names similar to
 QueryPlugins. Python-dbus appears to extract the keys so it never causes issues but will late
 when moving to GDBus.