### PR TITLE
Makes it possible to use the gschema from the source tree

### DIFF
--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -19,6 +19,7 @@ from gi.repository import Gtk
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
+    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
 
 from blueman.Functions import set_proc_title
 from blueman.main.Adapter import BluemanAdapters

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -14,6 +14,7 @@ from blueman.Constants import *
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
+    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
 
 from blueman.Functions import  set_proc_title
 from blueman.main.Applet import BluemanApplet

--- a/apps/blueman-assistant.in
+++ b/apps/blueman-assistant.in
@@ -26,6 +26,7 @@ from locale import bind_textdomain_codeset
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
+    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
 
 from blueman.Functions import (
     setup_icon_path,

--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -19,6 +19,7 @@ from gi.repository import Gtk
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
+    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
 
 from blueman.Functions import set_proc_title
 

--- a/apps/blueman-mechanism.in
+++ b/apps/blueman-mechanism.in
@@ -16,6 +16,7 @@ _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
     timeout = 9999
+    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
 
 import dbus
 import dbus.service

--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -23,6 +23,7 @@ import argparse
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
+    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
 
 # Workaround introspection bug, gnome bug 622084
 signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/apps/blueman-services.in
+++ b/apps/blueman-services.in
@@ -12,6 +12,7 @@ import sys
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
+    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
 
 import gi
 gi.require_version("Gtk", "3.0")


### PR DESCRIPTION
With this it is possible to use the compiled schema from the source tree instead of the one installed in ``/usr/share/glib-2.0/schemas``. One less thing to install 😄 

At some point though we should probably add a new install target that only installs the bits we can not do without like the dbus services.