### PR TITLE
Avoid using get_properties

### DIFF
--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -125,8 +125,7 @@ def wait_for_adapter(bluez_adapter, callback, timeout=1000):
                "Bluez didn't provide 'Powered' property in a reasonable timeout\nAssuming adapter is ready")
         callback()
 
-    props = bluez_adapter.get_properties()
-    if props["Address"] != "00:00:00:00:00:00":
+    if bluez_adapter["Address"] != "00:00:00:00:00:00":
         callback()
         return
 

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -86,7 +86,7 @@ class Manager(Gio.DBusObjectManagerClient):
         else:
             for adapter in adapters:
                 path = adapter.get_object_path()
-                if path.endswith(pattern) or adapter.get_properties()['Address'] == pattern:
+                if path.endswith(pattern) or adapter['Address'] == pattern:
                     return adapter
             raise ValueError("No adapters found with pattern: %s" % pattern)
 

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -152,7 +152,7 @@ class DeviceList(GenericList):
                 dprint("stopping monitor (not connected)")
                 cinfo.deinit()
                 self.level_setup_event(row_ref, device, None)
-                self.monitored_devices.remove(bt_address)
+                self.monitored_devices.remove(address)
                 return False
             else:
                 self.level_setup_event(row_ref, device, cinfo)

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -140,41 +140,39 @@ class DeviceList(GenericList):
             if not row_ref.valid():
                 dprint("stopping monitor (row does not exist)")
                 cinfo.deinit()
-                self.monitored_devices.remove(props["Address"])
+                self.monitored_devices.remove(address)
                 return False
 
             if not self.get_model():
-                self.monitored_devices.remove(props["Address"])
+                self.monitored_devices.remove(address)
                 return False
 
             tree_iter = self.get_model().get_iter(row_ref.get_path())
-            device = self.get(tree_iter, "device")["device"]
             if not device['Connected']:
                 dprint("stopping monitor (not connected)")
                 cinfo.deinit()
                 self.level_setup_event(row_ref, device, None)
-                self.monitored_devices.remove(props["Address"])
+                self.monitored_devices.remove(bt_address)
                 return False
             else:
                 self.level_setup_event(row_ref, device, cinfo)
                 return True
 
-        props = device.get_properties()
-
-        if "Connected" in props and props["Connected"] and props["Address"] not in self.monitored_devices:
+        bt_address = device["Address"]
+        if device["Connected"] and bt_address not in self.monitored_devices:
             dprint("starting monitor")
             tree_iter = self.find_device(device)
 
             hci = os.path.basename(self.Adapter.get_object_path())
             try:
-                cinfo = conn_info(props["Address"], hci)
+                cinfo = conn_info(bt_address, hci)
             except Exception as e:
                 dprint("Failed to get power levels\n%s" % e)
             else:
                 r = Gtk.TreeRowReference.new(self.get_model(), self.get_model().get_path(tree_iter))
                 self.level_setup_event(r, device, cinfo)
-                GLib.timeout_add(1000, update, r, cinfo, props["Address"])
-                self.monitored_devices.append(props["Address"])
+                GLib.timeout_add(1000, update, r, cinfo, bt_address)
+                self.monitored_devices.append(bt_address)
 
     ##### virtual funcs #####
 

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -202,14 +202,12 @@ class Blueman(Gtk.Window):
         launch("blueman-adapters", None, False, "blueman", _("Adapter Preferences"))
 
     def toggle_trust(self, device):
-        props = device.get_properties()
         device['Trusted'] = not device['Trusted']
 
     def send(self, device, File=None):
         adapter = self.List.Adapter
-        props = adapter.get_properties()
 
-        command = "blueman-sendto --source=%s --device=%s" % (props["Address"], device['Address'])
+        command = "blueman-sendto --source=%s --device=%s" % (adapter["Address"], device['Address'])
         launch(command, None, False, "blueman", _("File Sender"))
 
     def remove(self, device):

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -121,7 +121,7 @@ class Sender(Gtk.Dialog):
 
     def create_session(self):
         def check():
-            if self.adapter.get_properties()['Discovering']:
+            if self.adapter['Discovering']:
                 return True
             else:
                 self._do_create_session()
@@ -130,8 +130,7 @@ class Sender(Gtk.Dialog):
 
     def _do_create_session(self):
         dprint("Creating session")
-        props = self.adapter.get_properties()
-        self.client.create_session(self.device['Address'], props["Address"])
+        self.client.create_session(self.device['Address'], self.adapter["Address"])
 
     def on_cancel(self, button):
         self.pb.props.text = _("Cancelling")

--- a/blueman/plugins/applet/GameControllerWakelock.py
+++ b/blueman/plugins/applet/GameControllerWakelock.py
@@ -32,7 +32,7 @@ class GameControllerWakelock(AppletPlugin):
 
     def on_device_property_changed(self, path, key, value):
         if key == "Connected":
-            klass = bluez.Device(path).get_properties()["Class"] & 0x1fff
+            klass = bluez.Device(path)["Class"] & 0x1fff
 
             if klass == 0x504 or klass == 0x508:
                 if value:

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -79,8 +79,7 @@ class PowerManager(AppletPlugin):
     def get_adapter_state(self):
         adapters = self.Applet.Manager.get_adapters()
         for adapter in adapters:
-            props = adapter.get_properties()
-            if not props["Powered"]:
+            if not adapter["Powered"]:
                 return False
         return bool(adapters)
 

--- a/blueman/plugins/applet/ShowConnected.py
+++ b/blueman/plugins/applet/ShowConnected.py
@@ -47,10 +47,8 @@ class ShowConnected(AppletPlugin):
     def enumerate_connections(self):
         self.num_connections = 0
         for device in self.Applet.Manager.get_devices():
-            props = device.get_properties()
-            if "Connected" in props:
-                if props["Connected"]:
-                    self.num_connections += 1
+            if device["Connected"]:
+                self.num_connections += 1
 
         dprint("Found %d existing connections" % self.num_connections)
         if (self.num_connections > 0 and not self.active) or \

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -73,7 +73,7 @@ class Services(ManagerPlugin):
             if service.group == 'network' and service.connected:
                 if "DhcpClient" in appl.QueryPlugins():
                     def renew(x):
-                        appl.DhcpClient(str('(s)'), Network(device.get_object_path()).get_properties()["Interface"])
+                        appl.DhcpClient(str('(s)'), Network(device.get_object_path())["Interface"])
 
                     item = create_menuitem(_("Renew IP Address"), get_icon("view-refresh", 16))
                     item.connect("activate", renew)

--- a/blueman/services/meta/NetworkService.py
+++ b/blueman/services/meta/NetworkService.py
@@ -18,7 +18,7 @@ class NetworkService(Service):
     @property
     def connected(self):
         try:
-            return self._service.get_properties()['Connected']
+            return self._service['Connected']
         except BluezDBusException as e:
             dprint('Could not get properties of network service: %s' % e)
             return False

--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -24,10 +24,9 @@ class SerialService(Service):
         return False
 
     def connect(self, reply_handler=None, error_handler=None):
-        props = self.device.get_properties()
         try:
             # TODO: Channel?
-            port_id = create_rfcomm_device(Adapter(props['Adapter']).get_properties()['Address'], props['Address'], 1)
+            port_id = create_rfcomm_device(Adapter(self.device["Adapter"])['Address'], self.device["Address"], 1)
             Mechanism().open_rfcomm(str('(d)'), port_id)
             if reply_handler:
                 reply_handler('/dev/rfcomm%d' % port_id)


### PR DESCRIPTION
Typically we do not need all properties and at most we use two, retrieve them directly instead.

Along the way I also found some unused variables, eccentricities (like get_device_alias) and checking for non optional properties. I put those in separate commits for easier review and debugging.