### PR TITLE
Bluez Base: WOrkaround python3 UnicodeDecodeError

### DIFF
--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -66,7 +66,8 @@ class Base(Gio.DBusProxy):
             g_interface_name=interface_name,
             g_object_path=obj_path,
             g_bus_type=self.__bus_type,
-            g_flags=Gio.DBusProxyFlags.NONE,
+            # FIXME See issue 620
+            g_flags=Gio.DBusProxyFlags.GET_INVALIDATED_PROPERTIES,
             *args, **kwargs)
 
         self.init()


### PR DESCRIPTION
The invalidated properties in do_g_properties_changed seems to be broken.