### PR TITLE
Argparse fixes and fix a bug in blueman-sendto

### DIFF
--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -31,11 +31,10 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--socket-id", dest="socket_id", action="store", type=int, metavar="ID")
-    parser.add_argument("adapter", nargs="*", metavar="ADAPTER NAME")
+    parser.add_argument("adapter", nargs="?", metavar="ADAPTER NAME")
     args = parser.parse_args()
 
     set_proc_title()
 
-    adapter_name = args.adapter[0] if args.adapter else None
-    blueman_adapters = BluemanAdapters(adapter_name, args.socket_id)
+    blueman_adapters = BluemanAdapters(args.adapter, args.socket_id)
     Gtk.main()

--- a/apps/blueman-rfcomm-watcher.in
+++ b/apps/blueman-rfcomm-watcher.in
@@ -20,7 +20,7 @@ def on_file_changed(monitor, file, other_file, event_type):
         loop.quit()
 
 parser = argparse.ArgumentParser()
-parser.add_argument("path", dest="path", nargs="+", action="store")
+parser.add_argument("path", action="store")
 args = parser.parse_args()
 
 mon = Gio.File.new_for_path(args.path).monitor_file(Gio.FileMonitorFlags.NONE)

--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -35,10 +35,10 @@ class SendTo:
 
         check_bluetooth_status(_("Bluetooth needs to be turned on for file sending to work"), lambda: exit())
 
-        if not parsed_args.files[0]:
+        if not parsed_args.files:
             self.files = self.select_files()
         else:
-            self.files = [os.path.abspath(f) for f in parsed_args.files[0]]
+            self.files = [os.path.abspath(f) for f in parsed_args.files]
 
         self.device = None
         self.adapter = None
@@ -124,7 +124,7 @@ if __name__ == '__main__':
     parser.add_argument("-s", "--source", dest="source", action="store",
                         help=_("Source adapter. Takes address or adapter's name eg. hci0"), metavar="PATTERN")
     parser.add_argument("-u", "--delete", dest="delete", action="store_true", help=_("Delete files on exit"))
-    parser.add_argument("files", nargs="*", action="append", metavar="FILE",
+    parser.add_argument("files", nargs="*", metavar="FILE",
                         help=_("Files to be send to the bluetooth device"))
 
     args = parser.parse_args()

--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -117,10 +117,8 @@ class SendTo:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--device", dest="device", action="store",
+    parser.add_argument("-d", "--device", "--dest", dest="device", action="store",
                         help=_("Send files to this device"), metavar="ADDRESS")
-    parser.add_argument("--dest", dest="device", action="store",
-                        help=_("Same as --device"), metavar="ADDRESS")
     parser.add_argument("-s", "--source", dest="source", action="store",
                         help=_("Source adapter. Takes address or adapter's name eg. hci0"), metavar="PATTERN")
     parser.add_argument("-u", "--delete", dest="delete", action="store_true", help=_("Delete files on exit"))

--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -69,6 +69,8 @@ class SendTo:
                 print("Error: No Adapters present")
                 exit()
             d = m.find_device(parsed_args.device, adapter.get_object_path())
+            if d is None:
+                exit("Unknown bluetooth device")
 
             self.device = d
             self.adapter = adapter.get_object_path()


### PR DESCRIPTION
We do not handle when a non existing device is used with bluemna-sendto. ``Manager.find_device`` returns None and when it does exit.