### PR TITLE
Make handling of BLUEMAN_SOURCE working directory independent

### DIFF
--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -19,7 +19,7 @@ from gi.repository import Gtk
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
-    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
+    os.environ["GSETTINGS_SCHEMA_DIR"] = os.path.join(_dirname, "data")
 
 from blueman.Functions import create_parser, create_logger, set_proc_title
 from blueman.main.Adapter import BluemanAdapters

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -15,7 +15,7 @@ import logging
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
-    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
+    os.environ["GSETTINGS_SCHEMA_DIR"] = os.path.join(_dirname, "data")
 
 from blueman.Functions import create_logger, create_parser, set_proc_title
 from blueman.main.Applet import BluemanApplet

--- a/apps/blueman-assistant.in
+++ b/apps/blueman-assistant.in
@@ -26,7 +26,7 @@ from locale import bind_textdomain_codeset
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
-    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
+    os.environ["GSETTINGS_SCHEMA_DIR"] = os.path.join(_dirname, "data")
 
 from blueman.Functions import (
     setup_icon_path,

--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -19,7 +19,7 @@ from gi.repository import Gtk
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
-    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
+    os.environ["GSETTINGS_SCHEMA_DIR"] = os.path.join(_dirname, "data")
 
 from blueman.main.Manager import Blueman
 from blueman.Functions import set_proc_title, create_parser, create_logger

--- a/apps/blueman-mechanism.in
+++ b/apps/blueman-mechanism.in
@@ -16,7 +16,7 @@ _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
     timeout = 9999
-    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
+    os.environ["GSETTINGS_SCHEMA_DIR"] = os.path.join(_dirname, "data")
 
 import dbus
 import dbus.service

--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -14,7 +14,7 @@ import logging
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
-    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
+    os.environ["GSETTINGS_SCHEMA_DIR"] = os.path.join(_dirname, "data")
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -30,7 +30,7 @@ from blueman.gui.DeviceSelectorDialog import DeviceSelectorDialog
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
-    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
+    os.environ["GSETTINGS_SCHEMA_DIR"] = os.path.join(_dirname, "data")
 
 # Workaround introspection bug, gnome bug 622084
 signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/apps/blueman-services.in
+++ b/apps/blueman-services.in
@@ -13,7 +13,7 @@ import logging
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
     sys.path.insert(0, _dirname)
-    os.environ["GSETTINGS_SCHEMA_DIR"] = "../data"
+    os.environ["GSETTINGS_SCHEMA_DIR"] = os.path.join(_dirname, "data")
 
 import gi
 gi.require_version("Gtk", "3.0")

--- a/blueman/Constants.py.in
+++ b/blueman/Constants.py.in
@@ -32,7 +32,8 @@ except TypeError:
     builtins.ngettext = translation.ngettext
 
 if 'BLUEMAN_SOURCE' in os.environ:
-    BIN_DIR = "./"
-    ICON_PATH = "../data/icons"
-    PIXMAP_PATH = "../data/icons/pixmaps"
-    UI_PATH = "../data/ui"
+    _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    BIN_DIR = os.path.join(_dirname, 'apps')
+    ICON_PATH = os.path.join(_dirname, 'data', 'icons')
+    PIXMAP_PATH = os.path.join(_dirname, 'data', 'icons', 'pixmaps')
+    UI_PATH = os.path.join(_dirname, 'data', 'ui')


### PR DESCRIPTION
The apps and data paths currently depend on the working directory (assuming it is `apps`).

A couple of other issues related to BLUEMAN_SOURCE:

I don't get the addition of PYTHONPATH in 508492623b95fb3757498422b19b723e3d8f3b6c. First, the underlying idea is already achieved by modifying `sys.path` and second the correct path, assuming you're in `apps`, should be `..`, not `../blueman`.

508492623b95fb3757498422b19b723e3d8f3b6c also made necessary moves in the code so that the imports happen *after* setting up the path, but #631 reverted that (merged incorrectly?).

Using apps as `BIN_DIR` never worked out of the box as the generated files are not executable. Not sure how and if we could fix that.