### PR TITLE
Implement a ServiceUUID class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * blueman-adapters is now (Xfce-)pluggable
 
+### Changes
+
+* Show "Proprietary" instead of "Unknown" for services with non-reserverd UUIDs
+
 ### Bugs fixed
 
 * Icon disappeared when switching off bluetooth

--- a/blueman/Sdp.py
+++ b/blueman/Sdp.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import gettext
+from uuid import UUID
+
 from blueman.Constants import GETTEXT_PACKAGE, LOCALEDIR
 
 translation = gettext.translation(GETTEXT_PACKAGE, LOCALEDIR, fallback=True)
@@ -305,12 +307,23 @@ MCAP_DATA_UUID = 0x001f
 L2CAP_UUID = 0x0100
 
 
-def uuid16_to_name(uuid16):
-    try:
-        return uuid_names[uuid16]
-    except KeyError:
-        return _("Unknown")
+class ServiceUUID(UUID):
+    @property
+    def short_uuid(self):
+        if self.reserved:
+            return self.int >> 96 & 0xFFFF
 
+    @property
+    def name(self):
+        if self.reserved:
+            try:
+                return uuid_names[self.short_uuid]
+            except KeyError:
+                return _("Unknown")
+        else:
+            return _('Proprietary')
 
-def uuid128_to_uuid16(uuid128):
-    return int('0x' + uuid128[4:8], 16)
+    @property
+    def reserved(self):
+        return self.int & UUID('FFFF0000-0000-FFFF-FFFF-FFFFFFFFFFFF').int == \
+               UUID('00000000-0000-1000-8000-00805F9B34FB').int

--- a/blueman/Service.py
+++ b/blueman/Service.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from blueman.Sdp import uuid128_to_uuid16, uuid16_to_name
+from blueman.Sdp import ServiceUUID
 
 
 class Service(object):
@@ -20,7 +20,7 @@ class Service(object):
 
     @property
     def name(self):
-        return uuid16_to_name(uuid128_to_uuid16(self.__uuid))
+        return ServiceUUID(self.__uuid).name
 
     @property
     def device(self):
@@ -29,6 +29,9 @@ class Service(object):
     @property
     def uuid(self):
         return self.__uuid
+
+    def short_uuid(self):
+        return ServiceUUID(self.__uuid).short_uuid
 
     @property
     def description(self):

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -7,7 +7,6 @@ from __future__ import unicode_literals
 from blueman.gui.DeviceList import DeviceList
 from blueman.DeviceClass import get_minor_class, get_major_class
 from blueman.gui.manager.ManagerDeviceMenu import ManagerDeviceMenu
-from blueman.Sdp import *
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -19,7 +18,7 @@ from gi.repository import Pango
 from gi.repository import GLib
 from blueman.Constants import *
 from blueman.Functions import get_icon, launch, opacify_pixbuf, composite_icon
-from blueman.Sdp import *
+from blueman.Sdp import ServiceUUID, OBEX_OBJPUSH_SVCLASS_ID
 import cgi
 import logging
 
@@ -146,8 +145,7 @@ class ManagerDeviceList(DeviceList):
                 device = self.get(tree_iter, "device")["device"]
                 found = False
                 for uuid in device['UUIDs']:
-                    uuid16 = uuid128_to_uuid16(uuid)
-                    if uuid16 == OBEX_OBJPUSH_SVCLASS_ID:
+                    if ServiceUUID(uuid).short_uuid == OBEX_OBJPUSH_SVCLASS_ID:
                         found = True
                         break
                 if found:
@@ -510,7 +508,6 @@ class ManagerDeviceList(DeviceList):
             return False
 
         for uuid in device["UUIDs"]:
-            uuid16 = uuid128_to_uuid16(uuid)
-            if uuid16 == OBEX_OBJPUSH_SVCLASS_ID:
+            if ServiceUUID(uuid).short_uuid == OBEX_OBJPUSH_SVCLASS_ID:
                 return True
         return False

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import logging
 from locale import bind_textdomain_codeset
 from operator import itemgetter
-from blueman.Sdp import uuid128_to_uuid16, SERIAL_PORT_SVCLASS_ID, OBEX_OBJPUSH_SVCLASS_ID, OBEX_FILETRANS_SVCLASS_ID
+from blueman.Sdp import SERIAL_PORT_SVCLASS_ID, OBEX_OBJPUSH_SVCLASS_ID, OBEX_FILETRANS_SVCLASS_ID
 from blueman.Functions import get_icon, composite_icon, create_menuitem, e_
 from blueman.bluez.Network import AnyNetwork
 from blueman.bluez.Device import AnyDevice
@@ -123,7 +123,7 @@ class ManagerDeviceMenu(Gtk.Menu):
             logging.info("success")
             prog.message(_("Success!"))
 
-            if isinstance(service, SerialPort) and SERIAL_PORT_SVCLASS_ID == uuid128_to_uuid16(service.uuid):
+            if isinstance(service, SerialPort) and SERIAL_PORT_SVCLASS_ID == service.short_uuid:
                 MessageArea.show_message(_("Serial port connected to %s") % result, None, "dialog-information")
             else:
                 MessageArea.close()

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -22,7 +22,7 @@ else:
 import random
 from xml.etree import ElementTree
 import blueman.bluez as Bluez
-from blueman.Sdp import *
+from blueman.Sdp import ServiceUUID
 from blueman.Constants import *
 from blueman.gui.Notification import Notification
 
@@ -333,8 +333,7 @@ class BluezAgent(Agent):
 
         logging.info("Agent.Authorize")
         dev_str = self.get_device_string(device)
-        uuid16 = uuid128_to_uuid16(uuid)
-        service = uuid16_to_name(uuid16)
+        service = ServiceUUID(uuid).name
         notify_message = (_("Authorization request for:") + "\n%s\n" + _("Service:") + " <b>%s</b>") % (dev_str, service)
         actions = [["always", _("Always accept")],
                    ["accept", _("Accept")],

--- a/blueman/plugins/applet/NMDUNSupport.py
+++ b/blueman/plugins/applet/NMDUNSupport.py
@@ -8,7 +8,7 @@ from blueman.plugins.AppletPlugin import AppletPlugin
 import dbus
 from gi.repository import GLib
 from blueman.gui.Notification import Notification
-from blueman.Sdp import uuid128_to_uuid16, DIALUP_NET_SVCLASS_ID
+from blueman.Sdp import DIALUP_NET_SVCLASS_ID
 from blueman.Functions import get_icon, composite_icon
 import weakref
 import logging
@@ -101,7 +101,7 @@ class NMDUNSupport(AppletPlugin):
         pass
 
     def rfcomm_connect_handler(self, service, reply, err):
-        if DIALUP_NET_SVCLASS_ID == uuid128_to_uuid16(service.uuid):
+        if DIALUP_NET_SVCLASS_ID == service.short_uuid:
             ConnectionHandler(self, service, reply, err)
             return True
         else:

--- a/blueman/plugins/applet/PPPSupport.py
+++ b/blueman/plugins/applet/PPPSupport.py
@@ -12,7 +12,7 @@ from blueman.main.Config import Config
 
 from gi.repository import GObject
 
-from blueman.Sdp import uuid128_to_uuid16, DIALUP_NET_SVCLASS_ID
+from blueman.Sdp import DIALUP_NET_SVCLASS_ID
 import os
 import logging
 
@@ -73,7 +73,7 @@ class PPPSupport(AppletPlugin):
         pass
 
     def rfcomm_connect_handler(self, service, reply, err):
-        if DIALUP_NET_SVCLASS_ID == uuid128_to_uuid16(service.uuid):
+        if DIALUP_NET_SVCLASS_ID == service.short_uuid:
             def local_reply(port):
                 Connection(self.Applet, service, port, reply, err)
 

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -15,7 +15,7 @@ from blueman.Functions import *
 from blueman.bluez.Adapter import Adapter
 from blueman.bluez.Device import Device
 from blueman.gui.Notification import Notification
-from blueman.Sdp import uuid128_to_uuid16, uuid16_to_name
+from blueman.Sdp import ServiceUUID
 
 from blueman.plugins.AppletPlugin import AppletPlugin
 
@@ -225,7 +225,7 @@ class RecentConns(AppletPlugin, Gtk.Menu):
         item["address"] = device['Address']
         item["alias"] = device['Alias']
         item["icon"] = device['Icon']
-        item["name"] = uuid16_to_name(uuid128_to_uuid16(uuid))
+        item["name"] = ServiceUUID(uuid).name
         item["uuid"] = uuid
         item["time"] = time.time()
         item["device"] = object_path

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 from blueman.Functions import *
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.gui.Notification import Notification
-from blueman.Sdp import uuid128_to_uuid16, uuid16_to_name, SERIAL_PORT_SVCLASS_ID
+from blueman.Sdp import SERIAL_PORT_SVCLASS_ID
 from blueman.services.Functions import get_services
 from _blueman import rfcomm_list
 from subprocess import Popen
@@ -57,8 +57,7 @@ class SerialManager(AppletPlugin):
 
     def on_rfcomm_connected(self, service, port):
         device = service.device
-        uuid16 = uuid128_to_uuid16(service.uuid)
-        if SERIAL_PORT_SVCLASS_ID == uuid16:
+        if SERIAL_PORT_SVCLASS_ID == service.short_uuid:
             Notification(_("Serial port connected"),
                          _("Serial port service on device <b>%s</b> now will be available via <b>%s</b>") % (
                          device['Alias'], port),
@@ -67,8 +66,8 @@ class SerialManager(AppletPlugin):
 
             self.call_script(device['Address'],
                              device['Alias'],
-                             uuid16_to_name(uuid16),
-                             uuid16,
+                             service.name,
+                             service.short_uuid,
                              port)
 
     def terminate_all_scripts(self, address):
@@ -119,7 +118,7 @@ class SerialManager(AppletPlugin):
                 os.killpg(v[node].pid, signal.SIGHUP)
 
     def rfcomm_connect_handler(self, service, reply, err):
-        if SERIAL_PORT_SVCLASS_ID == uuid128_to_uuid16(service.uuid):
+        if SERIAL_PORT_SVCLASS_ID == service.short_uuid:
             service.connect(reply_handler=reply, error_handler=err)
             return True
         else:

--- a/blueman/plugins/manager/Info.py
+++ b/blueman/plugins/manager/Info.py
@@ -2,7 +2,7 @@ from gi.repository import Gtk
 
 import logging
 from blueman.Functions import create_menuitem, get_icon
-from blueman.Sdp import uuid128_to_uuid16, uuid16_to_name
+from blueman.Sdp import ServiceUUID
 from blueman.bluez.errors import BluezDBusException
 
 from blueman.plugins.ManagerPlugin import ManagerPlugin
@@ -36,7 +36,7 @@ def show_info(device, parent):
             '{} dBm (0x{:02x})'.format(rssi, rssi)
 
     def format_uuids(uuids):
-        return "\n".join([uuid + ' ' + uuid16_to_name(uuid128_to_uuid16(uuid)) for uuid in uuids])
+        return "\n".join([uuid + ' ' + ServiceUUID(uuid).name for uuid in uuids])
 
     properties = (
         ('Address', None),

--- a/blueman/services/Functions.py
+++ b/blueman/services/Functions.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-from blueman.Sdp import uuid128_to_uuid16
+from blueman.Sdp import ServiceUUID
 from blueman.bluez.errors import BluezDBusException
 import blueman.services
 import inspect
@@ -13,7 +13,7 @@ import logging
 
 def get_service(device, uuid):
     for name, cls in inspect.getmembers(blueman.services, inspect.isclass):
-        if uuid128_to_uuid16(uuid) == cls.__svclass_id__:
+        if ServiceUUID(uuid).short_uuid == cls.__svclass_id__:
             return cls(device, uuid)
 
 


### PR DESCRIPTION
This is @infirit's idea from #648 to fix an inaccuracy in our service class handling where we just took the last 16 bits of the time_low field as a 16-bit short UUID without checking the full UUID is actually a reserved one. The consequence was that we did not differentiate between unknown reserved service classes and prorietary ones and especially that we could possibly confuse proprietary ones with known reserved ones.