### PR TITLE
invoke _NotificationDialog.callback with 1 argument

### DIFF
--- a/blueman/gui/Notification.py
+++ b/blueman/gui/Notification.py
@@ -90,7 +90,7 @@ class _NotificationDialog(Gtk.MessageDialog):
 
     def dialog_response(self, dialog, response):
         if self.callback:
-            self.callback(self, self.actions[response])
+            self.callback(self.actions[response])
         self.hide()
 
     def show(self):

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -315,7 +315,7 @@ class BluezAgent(Agent):
         self._on_request_confirmation(parameters, invocation)
 
     def _on_authorize_service(self, parameters, invocation):
-        def on_auth_action(n, action):
+        def on_auth_action(action):
             logging.info(action)
 
             #self.applet.status_icon.set_blinking(False)


### PR DESCRIPTION
The elements in `_NotificationBubble._callbacks` are invoked with a single argument (the action name), but `_NotificationDialog.callback` was invoked with two arguments: the `_NotificationDialog` instance, and the action name.

Some places expected their callbacks to be invoked one way, some the other.
I've normalised everything to always expect a single argument.