### PR TITLE
Use correct RFCOMM channel number by retrieving the RFCOMM channel nu…

### DIFF
--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -51,8 +51,11 @@ class SerialService(Service):
 
     def connect(self, reply_handler=None, error_handler=None):
         try:
-            # TODO: Channel?
-            port_id = create_rfcomm_device(Adapter(self.device["Adapter"])['Address'], self.device["Address"], 1)
+            channel = 1
+            for dev in rfcomm_list():
+                if dev["dst"] == self.device['Address']:
+                    channel = dev["channel"]
+            port_id = create_rfcomm_device(Adapter(self.device["Adapter"])['Address'], self.device["Address"], channel)
             filename = '/dev/rfcomm%d' % port_id
             logging.info('Starting rfcomm watcher as root')
             Mechanism().open_rfcomm(str('(d)'), port_id)


### PR DESCRIPTION
…mber from RFCOMM list

This is a change proposal in order to fix the issue addressed in https://github.com/blueman-project/blueman/issues/688

As already said, from my perspective it looks like everything is already there.

Please check out _rfcomm_list()_ from __blueman.pyx.in_. It generates a list of known devices and adds the address, state, flags *and* the channel to that list.

It seems that in _SerialService.py_ this information is simply not extracted at all.

Please check out this patch. I added some code to the _connect()_ function of _SerialService.py_. 

It will use _rfcomm_list()_ to retrieve the list of devices and then iterate over it to find the entry matching this connection attempt. It will then use the channel number that was stored for that rfcomm entry when the RFCOMM channel is finally set up.

Probably this is not the cleanest possible solution. 

On the one hand the list may be large and on the other hand the other information for the connection attempt by _create_rfcomm_device_ comes from _self.device[]_. So maybe the channel information should be stored as _self.device["Channel"]_ instead. But this is out of my scope to accomplish.

Anyway, with this change I can successfully connect to my RFCOMM device which uses the RFCOMM channel 5. The channel number is successfully retrieved using _rfcomm_list()_.