### PR TITLE
Fix DBus signal emission

### DIFF
--- a/blueman/main/DbusService.py
+++ b/blueman/main/DbusService.py
@@ -23,7 +23,7 @@ class DbusService(dbus.service.Object):
         super(DbusService, self).__init__(self.bus, path)
 
     def add_definitions(self, instance):
-        setattr(instance, 'locations', self.locations)
+        setattr(instance, 'locations', list(self.locations))
 
         for name, func in self._definitions(instance):
             if name in self.__class__.__dict__:


### PR DESCRIPTION
As DbusService's self.locations returns an iterator, signal emission in instance works only once and no more locations to send to are found after that.