### PR TITLE
Discussion: Have a header in the assistant?

### DIFF
--- a/apps/blueman-assistant.in
+++ b/apps/blueman-assistant.in
@@ -27,7 +27,6 @@ from blueman.Functions import (
     setup_icon_path,
     set_proc_title,
     check_bluetooth_status,
-    get_icon,
     create_logger,
     create_parser
 )
@@ -72,26 +71,14 @@ class Assistant:
         self.assistant.connect("cancel", self.on_close)
 
         pages[PAGE_INTRO] = self.Builder.get_object("l_page0")
-        self.assistant.set_page_header_image(pages[PAGE_INTRO], get_icon("blueman", 32))
         self.assistant.set_page_complete(pages[PAGE_INTRO], True)
 
         pages[PAGE_DEVLIST] = self.Builder.get_object("a_page1")
-        self.assistant.set_page_header_image(pages[PAGE_DEVLIST], get_icon("blueman", 32))
-
         pages[PAGE_PASSKEY] = self.Builder.get_object("a_page2")
-        self.assistant.set_page_header_image(pages[PAGE_PASSKEY], get_icon("dialog-password", 32))
-
         pages[PAGE_PAIRING] = self.Builder.get_object("l_page3")
-        self.assistant.set_page_header_image(pages[PAGE_PAIRING], get_icon("dialog-password", 32))
-
         pages[PAGE_CONNECT] = self.Builder.get_object("a_page4")
-        self.assistant.set_page_header_image(pages[PAGE_CONNECT], get_icon("network-transmit-recieve", 32))
-
         pages[PAGE_CONNECTING] = self.Builder.get_object("l_page5")
-        self.assistant.set_page_header_image(pages[PAGE_CONNECTING], get_icon("network-transmit-recieve", 32))
-
         pages[PAGE_FINISH] = self.Builder.get_object("l_page6")
-        self.assistant.set_page_header_image(pages[PAGE_FINISH], get_icon("help-about", 32))
 
         self.svc_vbox = self.Builder.get_object("svcs")
 
@@ -213,7 +200,6 @@ class Assistant:
                 def err(err):
                     logging.error(err)
                     pages[PAGE_FINISH].set_markup(_("<b>Failed to add device</b>"))
-                    self.assistant.set_page_header_image(pages[PAGE_FINISH], get_icon("help-about", 32))
                     self.assistant.set_current_page(PAGE_FINISH)
 
                 device = self.Manager.find_device(self.Device['Address'], self.Adapter.get_object_path())
@@ -251,13 +237,11 @@ class Assistant:
             def success(*args):
                 pages[PAGE_FINISH].set_markup(_("<b>Device added and connected successfuly</b>"))
                 self.assistant.set_page_complete(pages[PAGE_CONNECTING], True)
-                self.assistant.set_page_header_image(pages[PAGE_FINISH], get_icon("help-about", 32))
                 self.assistant.set_current_page(PAGE_FINISH)
 
             def fail(*args):
                 pages[PAGE_FINISH].set_markup(_("<b>Device added successfuly, but failed to connect</b>"))
                 self.assistant.set_page_complete(pages[PAGE_CONNECTING], True)
-                self.assistant.set_page_header_image(pages[PAGE_FINISH], get_icon("dialog-warning", 32))
                 self.assistant.set_current_page(PAGE_FINISH)
 
             self.applet.connect_service("(os)", self.service.device.get_object_path(), self.service.uuid,


### PR DESCRIPTION
There is no header any more in Gtk3 however we can replicate one as part of the page. It will require a little work to convert boxes to grids but not too major.

This commit drops the now completely useless setting of images to the header.