### PR TITLE
configure: Fix typo in icon check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,8 +194,8 @@ PKG_CHECK_MODULES([ADWAITAICONS],[adwaita-icon-theme],
 
 if test "x$HAVE_GNOME_ICONS" = "xno" &&
    test "x$HAVE_MATE_ICONS" = "xno" &&
-   test "xHAVE_FAENZA_ICONS" = "xno" &&
-   test "xHAVE_ADWAITA_ICONS" = "xno"; then
+   test "x$HAVE_FAENZA_ICONS" = "xno" &&
+   test "x$HAVE_ADWAITA_ICONS" = "xno"; then
 	AC_MSG_ERROR([Required icon themes not found.])
 fi
 


### PR DESCRIPTION
Fix missing '$' for variable references in the icon check which caused
it to always fail (-> not detect the issue).