### PR TITLE
(Manager)DeviceList scaling work

### DIFF
--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -227,12 +227,17 @@ def format_bytes(size):
     return (ret, suffix)
 
 
-def create_menuitem(text, icon_name=None, pixbuf=None):
+def create_menuitem(text, icon_name=None, pixbuf=None, surface=None):
     image = Gtk.Image(pixel_size=16)
     if icon_name:
         image.set_from_icon_name(icon_name, Gtk.IconSize.MENU)
+    elif surface:
+        image.set_from_surface(surface)
     elif pixbuf:
         image.set_from_pixbuf(pixbuf)
+    else:
+        raise ValueError("At least provide one of, icon name, surface or pixbuf")
+
     item = Gtk.ImageMenuItem(label=text, image=image, use_underline=True)
     child = item.get_child()
     child.set_use_markup(True)

--- a/blueman/gui/Animation.py
+++ b/blueman/gui/Animation.py
@@ -3,23 +3,21 @@ from gi.repository import GLib
 
 
 class Animation:
-    def __init__(self, image, images, rate=1, rev=False):
-        self.pixbuffs = []
+    def __init__(self, icon, icons, rate=1, rev=False):
+        self.icon_names = []
         self.timer = None
         self.current = 0
-        self.image = None
-
-        self.image = image
+        self.icon = icon
         self.rate = 1000 / rate
 
-        for i in range(len(images)):
-            self.pixbuffs.append(images[i])
+        for i in range(len(icons)):
+            self.icon_names.append(icons[i])
 
-        if len(self.pixbuffs) > 2 and rev:
-            ln = len(self.pixbuffs)
-            for i in range(len(self.pixbuffs)):
+        if len(self.icon_names) > 2 and rev:
+            ln = len(self.icon_names)
+            for i in range(len(self.icon_names)):
                 if i != 0 and i != ln - 1:
-                    self.pixbuffs.append(self.pixbuffs[ln - 1 - i])
+                    self.icon_names.append(self.icon_names[ln - 1 - i])
 
     def status(self):
         if self.timer:
@@ -42,15 +40,15 @@ class Animation:
     def stop(self):
         if self.timer:
             GLib.source_remove(self.timer)
-            self.image.set_from_pixbuf(self.pixbuffs[0])
+            self.icon.props.icon_name = self.icon_names[0]
             self.timer = None
 
     def _animation(self):
         self.current += 1
-        if self.current > (len(self.pixbuffs) - 1):
+        if self.current > (len(self.icon_names) - 1):
             self.current = 0
         if True:
-            self.image.set_from_pixbuf(self.pixbuffs[self.current])
+            self.icon.props.icon_name = self.icon_names[self.current]
         # print "setting " + str(self.current)
         else:
             if self.current != 0:

--- a/blueman/gui/CommonUi.py
+++ b/blueman/gui/CommonUi.py
@@ -8,8 +8,9 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 
-def show_about_dialog(app_name, run=True):
+def show_about_dialog(app_name, run=True, parent=None):
     about = Gtk.AboutDialog()
+    about.set_transient_for(parent)
     about.set_name(app_name)
     about.set_version(VERSION)
     about.set_translator_credits(_("translator-credits"))

--- a/blueman/gui/CommonUi.py
+++ b/blueman/gui/CommonUi.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-from blueman.Functions import *
 from datetime import datetime
 from blueman.Constants import WEBSITE, VERSION
 
@@ -21,8 +20,8 @@ def show_about_dialog(app_name, run=True, parent=None):
     about.set_comments(_('Blueman is a GTK+ Bluetooth manager'))
     about.set_website(WEBSITE)
     about.set_website_label(WEBSITE)
-    about.set_icon(get_icon('blueman'))
-    about.set_logo(get_icon('blueman', 48))
+    about.set_icon_name('blueman')
+    about.set_logo_icon_name('blueman')
     about.set_authors(['Valmantas Palikša <walmis@balticum-tv.lt>',
                        'Tadas Dailyda <tadas@dailyda.com>',
                        '%s/graphs/contributors' % WEBSITE

--- a/blueman/gui/DeviceSelectorList.py
+++ b/blueman/gui/DeviceSelectorList.py
@@ -2,7 +2,6 @@
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from gi.repository import GdkPixbuf
 from gi.repository import Pango
 from html import escape
 from blueman.gui.DeviceList import DeviceList
@@ -10,19 +9,18 @@ from blueman.gui.DeviceList import DeviceList
 
 class DeviceSelectorList(DeviceList):
     def __init__(self, adapter=None):
-        cr = Gtk.CellRendererText()
-        cr.props.ellipsize = Pango.EllipsizeMode.END
         tabledata = [
             #device picture
-            {"id": "device_pb", "type": GdkPixbuf.Pixbuf, "renderer": Gtk.CellRendererPixbuf(),
-             "render_attrs": {"pixbuf": 0}},
+            {"id": "device_icon", "type": str, "renderer": Gtk.CellRendererPixbuf(stock_size=Gtk.IconSize.MENU),
+             "render_attrs": {"icon_name": 0}},
             #device caption
-            {"id": "caption", "type": str, "renderer": cr, "render_attrs": {"markup": 1},
+            {"id": "caption", "type": str, "renderer": Gtk.CellRendererText(ellipsize=Pango.EllipsizeMode.END),
+             "render_attrs": {"markup": 1},
              "view_props": {"expand": True}},
-            {"id": "paired_icon", "type": GdkPixbuf.Pixbuf, "renderer": Gtk.CellRendererPixbuf(),
-             "render_attrs": {"pixbuf": 2}},
-            {"id": "trusted_icon", "type": GdkPixbuf.Pixbuf, "renderer": Gtk.CellRendererPixbuf(),
-             "render_attrs": {"pixbuf": 3}}
+            {"id": "paired_icon", "type": str, "renderer": Gtk.CellRendererPixbuf(stock_size=Gtk.IconSize.MENU),
+             "render_attrs": {"icon_name": 2}},
+            {"id": "trusted_icon", "type": str, "renderer": Gtk.CellRendererPixbuf(stock_size=Gtk.IconSize.MENU),
+             "render_attrs": {"icon_name": 3}}
         ]
 
         super(DeviceSelectorList, self).__init__(adapter, tabledata, headers_visible=False)
@@ -41,15 +39,13 @@ class DeviceSelectorList(DeviceList):
     def row_update_event(self, tree_iter, key, value):
         if key == "Trusted":
             if value:
-                icon = self.icon_theme.load_icon("blueman-trust", 16, Gtk.IconLookupFlags.FORCE_SIZE)
-                self.set(tree_iter, trusted_icon=icon)
+                self.set(tree_iter, trusted_icon="blueman-trust")
             else:
                 self.set(tree_iter, trusted_icon=None)
 
         elif key == "Paired":
             if value:
-                icon = self.icon_theme.load_icon("dialog-password", 16, Gtk.IconLookupFlags.FORCE_SIZE)
-                self.set(tree_iter, paired_icon=icon)
+                self.set(tree_iter, paired_icon="dialog-password")
             else:
                 self.set(tree_iter, paired_icon=None)
 
@@ -57,5 +53,4 @@ class DeviceSelectorList(DeviceList):
             self.set(tree_iter, caption=escape(value))
 
         elif key == "Icon":
-            icon = self.icon_theme.load_icon(value, 16, Gtk.IconLookupFlags.FORCE_SIZE)
-            self.set(tree_iter, device_pb=icon)
+            self.set(tree_iter, device_icon=value)

--- a/blueman/gui/GenericList.py
+++ b/blueman/gui/GenericList.py
@@ -34,6 +34,9 @@ class GenericList(Gtk.TreeView):
             if "view_props" in row:
                 column.set_properties(**row["view_props"])
 
+            if "celldata_func" in row:
+                column.set_cell_data_func(row["renderer"], row["celldata_func"])
+
             self.columns[row["id"]] = column
             self.append_column(column)
 

--- a/blueman/gui/GenericList.py
+++ b/blueman/gui/GenericList.py
@@ -35,7 +35,8 @@ class GenericList(Gtk.TreeView):
                 column.set_properties(**row["view_props"])
 
             if "celldata_func" in row:
-                column.set_cell_data_func(row["renderer"], row["celldata_func"])
+                func, user_data = row["celldata_func"]
+                column.set_cell_data_func(row["renderer"], func, user_data)
 
             self.columns[row["id"]] = column
             self.append_column(column)

--- a/blueman/gui/Notification.py
+++ b/blueman/gui/Notification.py
@@ -8,7 +8,6 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GLib
 from gi.repository import Gio
-from blueman.Functions import get_icon
 from blueman.gui.GtkAnimation import AnimBase
 import logging
 
@@ -61,7 +60,7 @@ class _NotificationDialog(Gtk.MessageDialog):
         self.props.window_position = Gtk.WindowPosition.CENTER
 
         if icon_name:
-            self.set_icon_from_pixbuf(get_icon(icon_name, 48))
+            self.set_icon_from_icon_name(icon_name, 48)
         elif image_data:
             self.set_icon_from_pixbuf(image_data)
 
@@ -123,6 +122,10 @@ class _NotificationDialog(Gtk.MessageDialog):
         self.set_image(im)
         im.show()
 
+    def set_icon_from_icon_name(self, icon_name, size):
+        im = Gtk.Image(icon_name=icon_name, pixel_size=size)
+        self.set_image(im)
+        im.show()
 
 class _NotificationBubble(Gio.DBusProxy):
     def __init__(self, summary, message, timeout=-1, actions=None, actions_cb=None,

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -46,7 +46,7 @@ class ManagerDeviceList(DeviceList):
             {"id": "rssi", "type": float},
             {"id": "lq", "type": float},
             {"id": "tpl", "type": float},
-            {"id": "orig_icon", "type": GdkPixbuf.Pixbuf},
+            {"id": "icon_info", "type": Gtk.IconInfo},
             {"id": "cell_fader", "type": GObject.TYPE_PYOBJECT},
             {"id": "row_fader", "type": GObject.TYPE_PYOBJECT},
             {"id": "levels_visible", "type": bool},
@@ -187,7 +187,8 @@ class ManagerDeviceList(DeviceList):
 
         return icon_info
 
-    def make_device_icon(self, target, is_paired=False, is_trusted=False):
+    def make_device_icon(self, icon_info, is_paired=False, is_trusted=False):
+        target = icon_info.load_icon()
         sources = []
         if is_paired:
             icon_info = self.get_icon_info(["dialog-password"], 16, False)
@@ -251,13 +252,11 @@ class ManagerDeviceList(DeviceList):
         if klass != "uncategorized":
             icon_names = ["blueman-" + klass.replace(" ", "-").lower(), device["Icon"], "blueman"]
             icon_info = self.get_icon_info(icon_names, 48, False)
-            icon = icon_info.load_icon()
             # get translated version
             klass = get_minor_class(device['Class'], True)
         else:
             icon_names = [device["Icon"], "blueman"]
             icon_info = self.get_icon_info(icon_names, 48, False)
-            icon = icon_info.load_icon()
             klass = get_major_class(device['Class'])
 
         name = device['Alias']
@@ -265,7 +264,7 @@ class ManagerDeviceList(DeviceList):
 
         caption = self.make_caption(name, klass, address)
 
-        self.set(tree_iter, caption=caption, orig_icon=icon, alias=name)
+        self.set(tree_iter, caption=caption, icon_info=icon_info, alias=name)
 
         try:
             self.row_update_event(tree_iter, "Trusted", device['Trusted'])
@@ -284,21 +283,21 @@ class ManagerDeviceList(DeviceList):
         logging.info("%s %s" % (key, value))
 
         if key == "Trusted":
-            row = self.get(tree_iter, "paired", "orig_icon")
+            row = self.get(tree_iter, "paired", "icon_info")
             if value:
-                icon = self.make_device_icon(row["orig_icon"], row["paired"], True)
+                icon = self.make_device_icon(row["icon_info"], row["paired"], True)
                 self.set(tree_iter, device_pb=icon, trusted=True)
             else:
-                icon = self.make_device_icon(row["orig_icon"], row["paired"], False)
+                icon = self.make_device_icon(row["icon_info"], row["paired"], False)
                 self.set(tree_iter, device_pb=icon, trusted=False)
 
         elif key == "Paired":
-            row = self.get(tree_iter, "trusted", "orig_icon")
+            row = self.get(tree_iter, "trusted", "icon_info")
             if value:
-                icon = self.make_device_icon(row["orig_icon"], True, row["trusted"])
+                icon = self.make_device_icon(row["icon_info"], True, row["trusted"])
                 self.set(tree_iter, device_pb=icon, paired=True)
             else:
-                icon = self.make_device_icon(row["orig_icon"], False, row["trusted"])
+                icon = self.make_device_icon(row["icon_info"], False, row["trusted"])
                 self.set(tree_iter, device_pb=icon, paired=False)
 
         elif key == "Alias":

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -30,7 +30,7 @@ class ManagerDeviceList(DeviceList):
         tabledata = [
             # device picture
             {"id": "device_surface", "type": str, "renderer": Gtk.CellRendererPixbuf(),
-             "render_attrs": {}, "celldata_func": self._set_device_cell_data},
+             "render_attrs": {}, "celldata_func": (self._set_device_cell_data, None)},
             # device caption
             {"id": "caption", "type": str, "renderer": cr,
              "render_attrs": {"markup": 1}, "view_props": {"expand": True}},

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -16,6 +16,7 @@ from blueman.Sdp import ServiceUUID, OBEX_OBJPUSH_SVCLASS_ID
 import html
 import logging
 import cairo
+import os.path
 
 from blueman.gui.GtkAnimation import TreeRowColorFade, TreeRowFade, CellFade
 from blueman.main.Config import Config
@@ -324,9 +325,6 @@ class ManagerDeviceList(DeviceList):
             self.set(tree_iter, connected=value)
 
     def level_setup_event(self, row_ref, device, cinfo):
-        def rnd(value):
-            return int(round(value, -1))
-
         if not row_ref.valid():
             return
 
@@ -373,16 +371,19 @@ class ManagerDeviceList(DeviceList):
 
                     signal = fader.connect("animation-finished", on_finished)
 
-                if rnd(row["rssi"]) != rnd(rssi_perc):
-                    icon = GdkPixbuf.Pixbuf.new_from_file(PIXMAP_PATH + "/blueman-rssi-" + str(rnd(rssi_perc)) + ".png")
+                if round(row["rssi"], -1) != round(rssi_perc, -1):
+                    icon_name = "blueman-rssi-%d.png" % round(rssi_perc, -1)
+                    icon = GdkPixbuf.Pixbuf.new_from_file(os.path.join(PIXMAP_PATH, icon_name))
                     self.set(tree_iter, rssi_pb=icon)
 
-                if rnd(row["lq"]) != rnd(lq_perc):
-                    icon = GdkPixbuf.Pixbuf.new_from_file(PIXMAP_PATH + "/blueman-lq-" + str(rnd(lq_perc)) + ".png")
+                if round(row["lq"], -1) != round(lq_perc, -1):
+                    icon_name = "blueman-lq-%d.png" % round(lq_perc, -1)
+                    icon = GdkPixbuf.Pixbuf.new_from_file(os.path.join(PIXMAP_PATH, icon_name))
                     self.set(tree_iter, lq_pb=icon)
 
-                if rnd(row["tpl"]) != rnd(tpl_perc):
-                    icon = GdkPixbuf.Pixbuf.new_from_file(PIXMAP_PATH + "/blueman-tpl-" + str(rnd(tpl_perc)) + ".png")
+                if round(row["tpl"], -1) != round(tpl_perc, -1):
+                    icon_name = "blueman-tpl-%d.png" % round(tpl_perc, -1)
+                    icon = GdkPixbuf.Pixbuf.new_from_file(os.path.join(PIXMAP_PATH, icon_name))
                     self.set(tree_iter, tpl_pb=icon)
 
                 self.set(tree_iter,

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -46,7 +46,8 @@ class ManagerMenu:
         help_item = create_menuitem("_Help", "help-about")
         help_item.show()
         help_menu.append(help_item)
-        help_item.connect("activate", lambda x: show_about_dialog('Blueman ' + _('Device Manager')))
+        help_item.connect("activate", lambda x: show_about_dialog('Blueman ' + _('Device Manager'),
+                                                                  parent=self.blueman.get_toplevel()))
 
         view_menu = Gtk.Menu()
         self.item_view.set_submenu(view_menu)

--- a/blueman/gui/manager/ManagerStats.py
+++ b/blueman/gui/manager/ManagerStats.py
@@ -5,7 +5,7 @@ from gi.repository import Gtk
 
 from blueman.gui.Animation import Animation
 from blueman.main.SpeedCalc import SpeedCalc
-from blueman.Functions import get_icon, adapter_path_to_name
+from blueman.Functions import adapter_path_to_name
 from blueman.Functions import format_bytes
 
 import gettext
@@ -62,10 +62,8 @@ class ManagerStats:
         hbox.show_all()
         self.on_adapter_changed(blueman.List, blueman.List.GetAdapterPath())
 
-        self.up_blinker = Animation(self.im_upload,
-                                    [get_icon("blueman-up-inactive", 15), get_icon("blueman-up-active", 15)])
-        self.down_blinker = Animation(self.im_download,
-                                      [get_icon("blueman-down-inactive", 16), get_icon("blueman-down-active", 16)])
+        self.up_blinker = Animation(self.im_upload, ["blueman-up-inactive","blueman-up-active"])
+        self.down_blinker = Animation(self.im_download, ["blueman-down-inactive", "blueman-down-active"])
 
         self.start_update()
 

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -42,7 +42,7 @@ class Blueman(Gtk.Window):
         self.add(grid)
         self.set_name("BluemanManager")
 
-        self.Plugins = PluginManager(ManagerPlugin, blueman.plugins.manager, None)
+        self.Plugins = PluginManager(ManagerPlugin, blueman.plugins.manager, self)
         self.Plugins.Load()
 
         area = MessageArea()

--- a/blueman/main/Services.py
+++ b/blueman/main/Services.py
@@ -1,13 +1,12 @@
 # coding=utf-8
 from blueman.gui.GenericList import GenericList
 
-from blueman.Functions import check_single_instance, get_icon
+from blueman.Functions import check_single_instance
 import os
 import logging
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from gi.repository import GdkPixbuf
 
 import blueman.plugins.services
 from blueman.plugins.ServicePlugin import ServicePlugin
@@ -51,8 +50,8 @@ class BluemanServices(Gtk.Dialog):
         check_single_instance("blueman-services", lambda time: self.Dialog.present_with_time(time))
 
         data = [
-            {"id": "picture", "type": GdkPixbuf.Pixbuf, "renderer": Gtk.CellRendererPixbuf(),
-             "render_attrs": {"pixbuf": 0}},
+            {"id": "icon_name", "type": str, "renderer": Gtk.CellRendererPixbuf(stock_size=Gtk.IconSize.DND),
+             "render_attrs": {"icon_name": 0}},
             {"id": "caption", "type": str, "renderer": Gtk.CellRendererText(), "render_attrs": {"markup": 1},
              "view_props": {"expand": True}},
             {"id": "id", "type": str},
@@ -117,7 +116,7 @@ class BluemanServices(Gtk.Dialog):
                 self.setup_list_item(inst, name, icon)
 
     def setup_list_item(self, inst, name, icon):
-        self.List.append(picture=get_icon(icon, 32), caption=name, id=inst.__class__.__name__)
+        self.List.append(icon_name=icon, caption=name, id=inst.__class__.__name__)
 
     #executes a function on all plugin instances
     def plugin_exec(self, func, *args, **kwargs):

--- a/blueman/plugins/ManagerPlugin.py
+++ b/blueman/plugins/ManagerPlugin.py
@@ -3,6 +3,9 @@ from blueman.plugins.BasePlugin import BasePlugin
 
 
 class ManagerPlugin(BasePlugin):
+    def __init__(self, parent):
+        super().__init__(parent)
+
     # return list of (GtkMenuItem, position) tuples
     def on_request_menu_items(self, manager_menu, device):
         pass

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -21,6 +21,8 @@ def get_x_icon(icon_name, size):
 
 
 class Services(ManagerPlugin):
+    def on_load(self, manager):
+        self.manager = manager
     def on_request_menu_items(self, manager_menu, device):
         items = []
         appl = AppletService()


### PR DESCRIPTION
Posting for interested people. The goal here is to prepare to use cairo surfaces to paint the trusted and paired icons over the device icon. Then when the cairo surface device scaling functions are in a released version of pycairo we can have nice crisp device icons when scaling. The GdkCellRenderePixbuf has a surface property so when I figure out how to use that we can drop all pixbufs.

I'll probably push some commits like the clean-ups of fake device and unused import in the next week.

ps: I have a silly example that uses a patched pycairo that shows how this is done.
https://gist.github.com/infirit/22b147bcdcdc1ed4584f1f513fd1855e