### PR TITLE
Network and Serial Service: Add property for availability

### DIFF
--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -56,6 +56,7 @@ class Services(ManagerPlugin):
                         self.has_dun = True
                 else:
                     items.append((item, service.priority))
+            item.props.sensitive = service.available
             item.show()
 
         for service in get_services(device):

--- a/blueman/services/meta/NetworkService.py
+++ b/blueman/services/meta/NetworkService.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-import logging
-from blueman.bluez.errors import BluezDBusException
 from blueman.Service import Service
 from blueman.bluez.Network import Network
 
@@ -11,12 +9,16 @@ class NetworkService(Service):
         self._service = Network(device.get_object_path())
 
     @property
+    def available(self):
+        # This interface is only available after pairing
+        return self.device["Paired"]
+
+    @property
     def connected(self):
-        try:
-            return self._service['Connected']
-        except BluezDBusException:
-            logging.warning('Could not get properties of network service', exc_info=True)
+        if not self.available:
             return False
+
+        return self._service['Connected']
 
     def connect(self, reply_handler=None, error_handler=None):
         self._service.connect(self.uuid, reply_handler=reply_handler, error_handler=error_handler)

--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -23,6 +23,11 @@ class SerialService(Service):
                 return dev["id"]
 
     @property
+    def available(self):
+        # It will ask to pair anyway so not make it available
+        return self.device["Paired"]
+
+    @property
     def connected(self):
         return False
 


### PR DESCRIPTION
For NetworkService we now handle the missing dbus interface gracefully.

For SerialService the devices I have either don't expose the uuid until
paired or ask to be paired when we attempt to connect.

Also set menu entry sensitive based of this.