### PR TITLE
Store an array of dicts for recent-connections

### DIFF
--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -233,18 +233,18 @@ class RecentConns(AppletPlugin):
     def on_item_activated(self, menu_item, item):
         logging.info("Connect %s %s" % (item["address"], item["uuid"]))
 
-        item["mitem"].props.sensitive = False
+        menu_item.props.sensitive = False
 
         def reply(*args):
-            label_text = item["mitem"].get_child().get_children()[1].get_text()
+            label_text = menu_item.get_child().get_children()[1].get_text()
             Notification(_("Connected"), _("Connected to %s") % label_text,
                          icon_name=item["icon"], pos_hint=self.Applet.Plugins.StatusIcon.geometry).show()
-            item["mitem"].props.sensitive = True
+            menu_item.props.sensitive = True
 
         def err(reason):
             Notification(_("Failed to connect"), str(reason).split(": ")[-1],
                          icon_name="dialog-error", pos_hint=self.Applet.Plugins.StatusIcon.geometry).show()
-            item["mitem"].props.sensitive = True
+            menu_item.props.sensitive = True
 
         self.Applet.DbusSvc.connect_service(item["device"], item["uuid"], reply, err)
 

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -140,10 +140,10 @@
       <summary>Maximum items</summary>
       <description>Maximum number of items recent connections menu will display</description>
     </key>
-    <key type="s" name="recent-connections">
-      <default>""</default>
+    <key type="aa{ss}" name="recent-connections">
+      <default>[]</default>
       <summary>Recent connected devices data</summary>
-      <description>A base64 encoded zlib compressed string</description>
+      <description>A list of recently connected devices stored as a dictionary</description>
     </key>
   </schema>
   <schema id="org.blueman.transfer" path="/org/blueman/transfer/">

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -87,13 +87,6 @@
       <description>Phone Number</description>
     </key>
   </schema>
-  <schema id="org.blueman.plugins.headset" path="/org/blueman/plugins/headset/">
-    <key type="s" name="command">
-      <default>""</default>
-      <summary>Execute Command</summary>
-      <description>Command to Execute when a Headset is connected</description>
-    </key>
-  </schema>
   <schema id="org.blueman.plugins.killswitch" path="/org/blueman/plugins/killswitch/">
     <key type="b" name="checked">
       <default>false</default>


### PR DESCRIPTION
I wanted to do this for some time. It could use some more work but that is for another time.

Instead of storing a binary blob as string we now store

```
[{'adapter': '00:02:72:C5:BB:B4', 'address': '00:07:61:48:7A:2C', 'alias': 'Logitech MX1000 mouse', 'icon': 'input-mouse', 'name': 'Auto connect profiles', 'uuid': '00000000-0000-0000-0000-000000000000', 'time': '1502298305.8234344', 'device': '', 'mitem': ''},
{'adapter': '00:02:72:C5:BB:B4', 'address': 'D2:0C:FD:5A:21:12', 'alias': 'M720 Triathlon', 'icon': 'input-mouse', 'name': 'Auto connect profiles', 'uuid': '00000000-0000-0000-0000-000000000000', 'time': '1502298328.266433', 'device': '', 'mitem': ''}]
```