### PR TITLE
Reintroduce ImageMenuItem

### DIFF
--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -227,25 +227,15 @@ def format_bytes(size):
     return (ret, suffix)
 
 
-def create_menuitem_box(text, icon_name, pixbuf, orientation=Gtk.Orientation.HORIZONTAL, pixel_size=16, size=6):
-    """Create a box with icon and label, optionally set size and orientation"""
-    item_box = Gtk.Box.new(orientation, size)
-    if icon_name:
-        icon = Gtk.Image(icon_name=icon_name, pixel_size=pixel_size)
-    else:
-        icon = Gtk.Image(pixbuf=pixbuf)
-    label = Gtk.Label.new_with_mnemonic(text)
-
-    item_box.add(icon)
-    item_box.add(label)
-
-    return item_box
-
-
 def create_menuitem(text, icon_name=None, pixbuf=None):
-    box = create_menuitem_box(text, icon_name, pixbuf)
-    item = Gtk.MenuItem()
-    item.add(box)
+    image = Gtk.Image(pixel_size=16)
+    if icon_name:
+        image.set_from_icon_name(icon_name, Gtk.IconSize.MENU)
+    elif pixbuf:
+        image.set_from_pixbuf(pixbuf)
+    item = Gtk.ImageMenuItem(label=text, image=image, use_underline=True)
+    child = item.get_child()
+    child.set_use_markup(True)
     item.show_all()
 
     return item

--- a/blueman/plugins/applet/DiscvManager.py
+++ b/blueman/plugins/applet/DiscvManager.py
@@ -28,7 +28,6 @@ class DiscvManager(AppletPlugin):
 
     def on_load(self, applet):
         self.item = create_menuitem(_("_Make Discoverable"), "edit-find")
-        self.item_label = self.item.get_child().get_children()[1]
         applet.Plugins.Menu.Register(self, self.item, 20, False)
 
         self.Applet = applet
@@ -57,7 +56,7 @@ class DiscvManager(AppletPlugin):
 
     def on_update(self):
         self.time_left -= 1
-        self.item_label.set_text_with_mnemonic(_("Discoverable... %ss") % self.time_left)
+        self.item.set_label(_("Discoverable... %ss") % self.time_left)
         self.item.props.sensitive = False
 
         return True
@@ -115,7 +114,7 @@ class DiscvManager(AppletPlugin):
             self.item.props.visible = False
         elif (not self.adapter["Discoverable"] or self.adapter["DiscoverableTimeout"] > 0) and self.adapter["Powered"]:
             self.item.props.visible = True
-            self.item_label.set_text_with_mnemonic(_("_Make Discoverable"))
+            self.item.set_label(_("_Make Discoverable"))
             self.item.props.sensitive = True
         else:
             self.item.props.visible = False

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -36,8 +36,7 @@ class PowerManager(AppletPlugin):
 
         self.Applet = applet
 
-        self.item = create_menuitem("Should be overwritten", "blueman-disabled")
-        self.item.get_child().get_children()[1].set_markup_with_mnemonic(_("<b>Turn Bluetooth _Off</b>"))
+        self.item = create_menuitem("<b>Turn Bluetooth _Off</b>", "blueman-disabled")
 
         self.item.props.tooltip_text = _("Turn off all adapters")
 
@@ -153,13 +152,11 @@ class PowerManager(AppletPlugin):
         foff = self.STATE_OFF_FORCED in rets
         on = self.STATE_ON in rets
 
-        icon, label = self.item.get_child().get_children()
-
         new_state = True
         if foff or off:
 
-            label.set_markup_with_mnemonic(_("<b>Turn Bluetooth _On</b>"))
-            icon.props.icon_name = "blueman"
+            self.item.set_label(_("<b>Turn Bluetooth _On</b>"))
+            self.item.get_image().props.icon_name = "blueman"
             self.item.props.tooltip_text = _("Turn on all adapters")
 
             if foff:
@@ -171,8 +168,8 @@ class PowerManager(AppletPlugin):
 
         elif on and not self.current_state:
 
-            label.set_markup_with_mnemonic(_("<b>Turn Bluetooth _Off</b>"))
-            icon.props.icon_name = "blueman-disabled"
+            self.item.set_label(_("<b>Turn Bluetooth _Off</b>"))
+            self.item.get_image().props.icon_name = "blueman-disabled"
             self.item.props.tooltip_text = _("Turn off all adapters")
             self.item.props.sensitive = True
 

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -248,8 +248,7 @@ class RecentConns(AppletPlugin):
             mitem.props.tooltip_text = None
 
         item_label_markup = _("%(service)s on %(device)s") % {"service": item["name"], "device": item["alias"]}
-        item_label = item["mitem"].get_child().get_children()[1]
-        item_label.set_markup_with_mnemonic(item_label_markup)
+        item["mitem"].set_label(item_label_markup)
 
         if item["adapter"] not in self.Adapters.values():
             item["device"] = None


### PR DESCRIPTION
Although it is deprecated it has not been removed till Gtk+4. When we
move to Gtk+4 we can either:
* create our own menuitem through a subclass
* use the ugly menuitems like we did before
* drop icons from menus

I personally lean towards creating our own widget