### PR TITLE
Fix dhcpd pid handling

### DIFF
--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -91,9 +91,7 @@ class DnsMasqHandler(object):
             else:
                 pid = self.pid
 
-            running = is_running("dnsmasq", pid) if pid else False
-
-            if running:
+            if pid and is_running("dnsmasq", pid):
                 os.kill(pid, signal.SIGTERM)
                 self.netconf.unlock("dhcp")
             else:
@@ -193,9 +191,7 @@ class DhcpdHandler(object):
             else:
                 pid = self.pid
 
-            running = is_running("dnsmasq", pid) if pid else False
-
-            if running:
+            if pid and (is_running("dhcpd3", pid) or is_running("dhcpd", pid)):
                 os.kill(pid, signal.SIGTERM)
                 self.netconf.unlock("dhcp")
             else:
@@ -265,9 +261,7 @@ option router %(rtr)s
             else:
                 pid = self.pid
 
-            running = is_running("udhcpd", pid) if pid else False
-
-            if running:
+            if pid and is_running("udhcpd", pid):
                 os.kill(pid, signal.SIGTERM)
                 self.netconf.unlock("dhcp")
             else:

--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -164,14 +164,14 @@ class DhcpdHandler(object):
             f.write(subnet)
             f.close()
 
-            cmd = [have("dhcpd3") or have("dhcpd"), "-pf", "/var/run/dhcpd-server/dhcp.pan1.pid", "pan1"]
+            cmd = [have("dhcpd3") or have("dhcpd"), "-pf", "/var/run/dhcpd.pan1.pid", "pan1"]
             p = Popen(cmd)
 
             ret = p.wait()
 
             if ret == 0:
                 logging.info("dhcpd started correctly")
-                f = open("/var/run/dhcp-server/dhcpd.pan1.pid", "r")
+                f = open("/var/run/dhcpd.pan1.pid", "r")
                 self.pid = int(f.read())
                 f.close()
                 logging.info("pid %s" % self.pid)
@@ -187,7 +187,7 @@ class DhcpdHandler(object):
 
         if self.netconf.locked("dhcp"):
             if not self.pid:
-                pid = read_pid_file("/var/run/dhcpd-server/dhcp.pan1.pid")
+                pid = read_pid_file("/var/run/dhcpd.pan1.pid")
             else:
                 pid = self.pid
 


### PR DESCRIPTION
This works properly on gentoo and debian jessie. Will backport to 2.0 when merged and add it to #736