### PR TITLE
Drop adding methods to plugin classes

### DIFF
--- a/blueman/main/PluginManager.py
+++ b/blueman/main/PluginManager.py
@@ -205,28 +205,25 @@ class PluginManager(GObject.GObject):
     def Run(self, func, *args, **kwargs):
         rets = []
         for inst in self.__plugins.values():
-            try:
-                ret = getattr(inst, func)(*args, **kwargs)
-                rets.append(ret)
-            except Exception:
-                logging.error("Function %s on %s failed" % (func, inst.__class__.__name__), exc_info=True)
+            if hasattr(inst, func):
+                try:
+                    rets.append(getattr(inst, func)(*args, **kwargs))
+                except:
+                    logging.error("Function %s on %s failed" % (func, inst.__class__.__name__), exc_info=True)
 
         return rets
 
     #executes a function on all plugin instances, runs a callback after each plugin returns something
     def RunEx(self, func, callback, *args, **kwargs):
         for inst in self.__plugins.values():
-            ret = getattr(inst, func)(*args, **kwargs)
-            try:
-                ret = callback(inst, ret)
-            except StopException:
-                return ret
-            except Exception:
-                logging.error("Function %s on %s failed" % (func, inst.__class__.__name__), exc_info=True)
-                return
-
-            if ret is not None:
-                args = ret
+            if hasattr(inst, func):
+                try:
+                    ret = callback(inst, getattr(inst, func)(*args, **kwargs))
+                except StopException:
+                    return ret
+                except Exception:
+                    logging.error("Function %s on %s failed" % (func, inst.__class__.__name__), exc_info=True)
+                    return
 
 
 class PersistentPluginManager(PluginManager):

--- a/blueman/plugins/BasePlugin.py
+++ b/blueman/plugins/BasePlugin.py
@@ -27,16 +27,6 @@ class BasePlugin(object):
     def __del__(self):
         logging.debug("Deleting plugin instance %s" % self)
 
-    @classmethod
-    def add_method(cls, func):
-        """Add a new method that can be used by other plugins to listen for changes, query state, etc"""
-        func.__self__.__methods.append((cls, func.__name__))
-
-        if func.__name__ in cls.__dict__:
-            raise MethodAlreadyExists
-        else:
-            setattr(cls, func.__name__, func)
-
     def _unload(self):
         self.on_unload()
 

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -19,13 +19,6 @@ class DBusService(AppletPlugin):
     def on_load(self, applet):
         self.Applet = applet
 
-        AppletPlugin.add_method(self.on_rfcomm_connected)
-        AppletPlugin.add_method(self.on_rfcomm_disconnect)
-        AppletPlugin.add_method(self.rfcomm_connect_handler)
-        AppletPlugin.add_method(self.service_connect_handler)
-        AppletPlugin.add_method(self.service_disconnect_handler)
-        AppletPlugin.add_method(self.on_device_disconnect)
-
     @dbus.service.method('org.blueman.Applet', in_signature="", out_signature="as")
     def QueryPlugins(self):
         return self.Applet.Plugins.GetLoaded()

--- a/blueman/plugins/applet/PPPSupport.py
+++ b/blueman/plugins/applet/PPPSupport.py
@@ -55,7 +55,7 @@ class PPPSupport(AppletPlugin):
     __priority__ = 0
 
     def on_load(self, applet):
-        AppletPlugin.add_method(self.on_ppp_connected)
+        pass
 
     def on_unload(self):
         pass

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -30,10 +30,6 @@ class PowerManager(AppletPlugin):
     }
 
     def on_load(self, applet):
-        AppletPlugin.add_method(self.on_power_state_query)
-        AppletPlugin.add_method(self.on_power_state_change_requested)
-        AppletPlugin.add_method(self.on_power_state_changed)
-
         self.Applet = applet
 
         self.item = create_menuitem("<b>Turn Bluetooth _Off</b>", "blueman-disabled")

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -26,9 +26,6 @@ class StatusIcon(AppletPlugin, Gtk.StatusIcon):
 
         self.SetTextLine(0, _("Bluetooth Enabled"))
 
-        AppletPlugin.add_method(self.on_query_status_icon_visibility)
-        AppletPlugin.add_method(self.on_status_icon_query_icon)
-
         ic = Gtk.IconTheme.get_default()
         ic.connect("changed", self.on_icon_theme_changed)
 


### PR DESCRIPTION
This is not meant to be merged, it is more to help understand.

I see no reason to add the methods to the BasePlugin class when we can just check for it when looping over all instances. Is there a benefit to doing it like this compared to how it is done in this PR?