### PR TITLE
Some fixes for the tray

### DIFF
--- a/blueman/plugins/applet/AppIndicator.py
+++ b/blueman/plugins/applet/AppIndicator.py
@@ -28,9 +28,13 @@ class AppIndicator(AppletPlugin):
         self.s = self.Applet.Plugins.StatusIcon.connect("notify::icon-name", self.on_notify)
 
         self.override_method(self.Applet.Plugins.StatusIcon, "set_visible", self.set_visible)
+        self.override_method(self.Applet.Plugins.StatusIcon, "update_tooltip", self.update_title)
         
         self.Applet.Plugins.StatusIcon.props.visible = False
         self.Applet.Plugins.StatusIcon.update_text()
+
+    def update_title(self, _, text):
+        self.indicator.set_title(text)
 
     def set_visible(self, _, visible):
         if visible:

--- a/blueman/plugins/applet/AppIndicator.py
+++ b/blueman/plugins/applet/AppIndicator.py
@@ -30,6 +30,7 @@ class AppIndicator(AppletPlugin):
         self.override_method(self.Applet.Plugins.StatusIcon, "set_visible", self.set_visible)
         
         self.Applet.Plugins.StatusIcon.props.visible = False
+        self.Applet.Plugins.StatusIcon.update_text()
 
     def set_visible(self, _, visible):
         if visible:
@@ -44,6 +45,7 @@ class AppIndicator(AppletPlugin):
         del self.indicator
         self.Applet.Plugins.StatusIcon.QueryVisibility()
         self.Applet.Plugins.StatusIcon.disconnect(self.s)
+        self.Applet.Plugins.StatusIcon.update_text()
         
     def update_icon(self):
         self.indicator.set_icon(self.Applet.Plugins.StatusIcon.props.icon_name)

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -84,16 +84,13 @@ class StatusIcon(AppletPlugin, Gtk.StatusIcon):
         else:
             self.lines.pop(lineid, None)
 
-        self.update_tooltip()
+        self.update_text()
 
-    def update_tooltip(self):
-        s = ""
-        keys = list(self.lines.keys())
-        keys.sort()
-        for k in keys:
-            s += self.lines[k] + "\n"
+    def update_text(self):
+        self.update_tooltip("\n".join([self.lines[key] for key in sorted(self.lines)]))
 
-        self.props.tooltip_markup = s[:-1]
+    def update_tooltip(self, text):
+        self.props.tooltip_markup = text
 
     def IconShouldChange(self):
         self.on_status_icon_resized()


### PR DESCRIPTION
I have been experimenting with AppIndicator and noticed we never set its title. The title, afaics, is AppIndicator terminology for setting the tooltip.

While working on this I also found that the number of connections went missing on the title/tooltip when when (un)loading the AppIndicator plugin.

