### PR TITLE
Netconf nicer error

### DIFF
--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -63,14 +63,10 @@ class DnsMasqHandler(object):
             if self.netconf.ip4_changed:
                 self.do_remove()
 
-            if 1:
-                rtr = "--dhcp-option=option:router,%s" % inet_ntoa(self.netconf.ip4_address)
-            else:
-                rtr = "--dhcp-option=3 --dhcp-option=6"  # no route and no dns
-
             start, end = calc_ip_range(self.netconf.ip4_address)
-
-            args = "--pid-file=/var/run/dnsmasq.pan1.pid --bind-interfaces --dhcp-range=%s,%s,60m --except-interface=lo --interface=pan1 %s" % (inet_ntoa(start), inet_ntoa(end), rtr)
+            args = "--pid-file=/var/run/dnsmasq.pan1.pid --bind-interfaces --dhcp-range=%s,%s,60m" \
+                " --except-interface=lo --interface=pan1 --dhcp-option=option:router,%s" % \
+                (inet_ntoa(start), inet_ntoa(end), inet_ntoa(self.netconf.ip4_address))
 
             cmd = [have("dnsmasq")] + args.split(" ")
             logging.info(cmd)


### PR DESCRIPTION
Next up is displaying a nicer error dialog.

```
blueman-mechanism 18.30.36 INFO     NetConf:342 add_ipt_rule: Return code 0
blueman-mechanism 18.30.36 INFO     NetConf:342 add_ipt_rule: Return code 0
blueman-mechanism 18.30.36 INFO     NetConf:342 add_ipt_rule: Return code 0
blueman-mechanism 18.30.36 INFO     NetConf:342 add_ipt_rule: Return code 0
blueman-mechanism 18.30.36 INFO     NetConf:73 do_apply  : ['/usr/sbin/dnsmasq', '--pid-file=/var/rn/dnsmasq.pan1.pid', '--except-interface=lo', '--interface=pan1', '--bind-interfaces', '--except-interface=lo', '--dhcp-range=10.249.217.2,10.249.217.254,60m', '--dhcp-option=option:router,10.249.217.1']
blueman-mechanism 18.30.36 INFO     NetConf:87 do_apply  : dnsmasq: failed to open pidfile /var/rn/dnsmasq.pan1.pid: No such file or directory
```

![afbeelding](https://user-images.githubusercontent.com/3465730/30251747-577a9b16-9666-11e7-9305-1f9afca74613.png)
