### PR TITLE
Rename __parent__ to parent and make it available to all plugins

### DIFF
--- a/apps/blueman-tray.in
+++ b/apps/blueman-tray.in
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
 # coding=utf-8
-
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import logging
 import os
 import sys

--- a/blueman/main/PluginManager.py
+++ b/blueman/main/PluginManager.py
@@ -117,10 +117,7 @@ class PluginManager(GObject.GObject):
                     cls.__unloadable__ = False
 
             if (cls.__autoload__ or (c and cls.__name__ in c)) and not (cls.__unloadable__ and c and "!" + cls.__name__ in c):
-                try:
-                    self.__load_plugin(cls)
-                except:
-                    pass
+                self.__load_plugin(cls)
 
     def Disabled(self, plugin):
         return False

--- a/blueman/main/PluginManager.py
+++ b/blueman/main/PluginManager.py
@@ -28,14 +28,14 @@ class PluginManager(GObject.GObject):
         'plugin-unloaded': (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_STRING,)),
     }
 
-    def __init__(self, plugin_class, module_path, user_data):
+    def __init__(self, plugin_class, module_path, parent):
         super(PluginManager, self).__init__()
         self.__plugins = {}
         self.__classes = {}
         self.__deps = {}
         self.__cfls = {}
         self.__loaded = []
-        self.user_data = user_data
+        self.parent = parent
 
         self.module_path = module_path
         self.plugin_class = plugin_class
@@ -156,9 +156,9 @@ class PluginManager(GObject.GObject):
                     raise LoadException("Not loading conflicting plugin %s due to lower priority" % cls.__name__)
 
         logging.info("loading %s" % cls)
-        inst = cls(self.user_data)
+        inst = cls(self.parent)
         try:
-            inst._load(self.user_data)
+            inst._load()
         except Exception:
             logging.error("Failed to load %s" % cls.__name__, exc_info=True)
             if not cls.__unloadable__:

--- a/blueman/main/indicators/AppIndicator.py
+++ b/blueman/main/indicators/AppIndicator.py
@@ -1,9 +1,4 @@
 # coding=utf-8
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import gi
 
 gi.require_version('AppIndicator3', '0.1')

--- a/blueman/main/indicators/GtkStatusIcon.py
+++ b/blueman/main/indicators/GtkStatusIcon.py
@@ -1,9 +1,4 @@
 # coding=utf-8
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import gi
 
 gi.require_version("Gtk", "3.0")

--- a/blueman/main/indicators/GtkStatusIcon.py
+++ b/blueman/main/indicators/GtkStatusIcon.py
@@ -2,7 +2,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib, GObject
+from gi.repository import Gtk
 from blueman.Functions import create_menuitem
 
 

--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -16,15 +16,13 @@ class MethodAlreadyExists(Exception):
 class AppletPlugin(BasePlugin):
     __icon__ = "blueman-plugin"
 
-    def __init__(self, applet):
-        super(AppletPlugin, self).__init__(applet)
+    def __init__(self, parent):
+        super(AppletPlugin, self).__init__(parent)
 
         if not ictheme.has_icon(self.__class__.__icon__):
             self.__class__.__icon__ = "blueman-plugin"
 
         self.__opts = {}
-
-        self.Applet = applet
 
         self.__overrides = []
 
@@ -43,16 +41,16 @@ class AppletPlugin(BasePlugin):
 
         super(AppletPlugin, self)._unload()
 
-        self.Applet.DbusSvc.remove_definitions(self)
+        self.parent.DbusSvc.remove_definitions(self)
 
-    def _load(self, applet):
-        super(AppletPlugin, self)._load(applet)
+    def _load(self):
+        super(AppletPlugin, self)._load()
 
-        self.Applet.DbusSvc.add_definitions(self)
+        self.parent.DbusSvc.add_definitions(self)
 
         # The applet will run on_manager_state_changed once at startup so until it has we don't.
-        if applet.plugin_run_state_changed:
-            self.on_manager_state_changed(applet.manager_state)
+        if self.parent.plugin_run_state_changed:
+            self.on_manager_state_changed(self.parent.manager_state)
 
     # virtual funcs
     def on_manager_state_changed(self, state):

--- a/blueman/plugins/BasePlugin.py
+++ b/blueman/plugins/BasePlugin.py
@@ -25,7 +25,7 @@ class BasePlugin(object):
     __options__ = {}
 
     def __init__(self, parent):
-        self.__parent__ = parent
+        self.parent = parent
 
         self.__methods = []
 
@@ -61,9 +61,9 @@ class BasePlugin(object):
 
         self.__class__.__instance__ = None
 
-    def _load(self, parent):
+    def _load(self):
         try:
-            self.on_load(parent)
+            self.on_load()
             # self.on_manager_state_changed(applet.Manager != None)
             self.__class__.__instance__ = self
         except Exception as e:
@@ -73,7 +73,7 @@ class BasePlugin(object):
             raise
 
     # virtual methods
-    def on_load(self, applet):
+    def on_load(self):
         """Do what is neccessary for the plugin to work like add watches or create ui elements"""
         pass
 

--- a/blueman/plugins/MechanismPlugin.py
+++ b/blueman/plugins/MechanismPlugin.py
@@ -1,15 +1,15 @@
 # coding=utf-8
 
 class MechanismPlugin(object):
-    def __init__(self, mechanism):
-        self.m = mechanism
-        self.timer = self.m.timer
+    def __init__(self, parent):
+        self.parent = parent
+        self.timer = self.parent.timer
 
-        self.confirm_authorization = self.m.confirm_authorization
+        self.confirm_authorization = self.parent.confirm_authorization
 
         self.on_load()
 
-        self.m.add_definitions(self)
+        self.parent.add_definitions(self)
 
     def on_load(self):
         pass

--- a/blueman/plugins/ServicePlugin.py
+++ b/blueman/plugins/ServicePlugin.py
@@ -4,11 +4,11 @@ class ServicePlugin(object):
     instances = []
     __plugin_info__ = None
 
-    def __init__(self, services_inst):
+    def __init__(self, parent):
         ServicePlugin.instances.append(self)
         self._options = []
         self._orig_state = {}
-        self.__services_inst = services_inst
+        self.parent = parent
 
         self.__is_exposed = False
         self._is_loaded = False
@@ -32,7 +32,7 @@ class ServicePlugin(object):
             if state:
                 self._options.remove(option_id)
 
-        self.__services_inst.option_changed()
+        self.parent.option_changed()
 
     def get_options(self):
         return self._options

--- a/blueman/plugins/applet/AuthAgent.py
+++ b/blueman/plugins/applet/AuthAgent.py
@@ -13,9 +13,6 @@ class AuthAgent(AppletPlugin):
     _agent = None
     _last_event_time = 0
 
-    def on_load(self, applet):
-        self.Applet = applet
-
     @dbus.service.method('org.blueman.Applet', in_signature="u")
     def SetTimeHint(self, time):
         self._last_event_time = time

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -16,8 +16,7 @@ class DBusService(AppletPlugin):
     __description__ = _("Provides DBus API for other Blueman components")
     __author__ = "Walmis"
 
-    def on_load(self, applet):
-        self.Applet = applet
+    def on_load(self):
 
         AppletPlugin.add_method(self.on_rfcomm_connected)
         AppletPlugin.add_method(self.on_rfcomm_disconnect)
@@ -28,13 +27,13 @@ class DBusService(AppletPlugin):
 
     @dbus.service.method('org.blueman.Applet', in_signature="", out_signature="as")
     def QueryPlugins(self):
-        return self.Applet.Plugins.GetLoaded()
+        return self.parent.Plugins.GetLoaded()
 
     @dbus.service.method('org.blueman.Applet', in_signature="o", out_signature="", async_callbacks=("ok", "err"))
     def DisconnectDevice(self, obj_path, ok, err):
         dev = Device(obj_path)
 
-        self.Applet.Plugins.Run("on_device_disconnect", dev)
+        self.parent.Plugins.Run("on_device_disconnect", dev)
 
         def on_timeout():
             dev.disconnect(reply_handler=ok, error_handler=err)
@@ -46,20 +45,20 @@ class DBusService(AppletPlugin):
 
     @dbus.service.method('org.blueman.Applet', in_signature="", out_signature="as")
     def QueryAvailablePlugins(self):
-        return list(self.Applet.Plugins.GetClasses())
+        return list(self.parent.Plugins.GetClasses())
 
     @dbus.service.method('org.blueman.Applet', in_signature="sb", out_signature="")
     def SetPluginConfig(self, plugin, value):
-        self.Applet.Plugins.SetConfig(plugin, value)
+        self.parent.Plugins.SetConfig(plugin, value)
 
     @dbus.service.method('org.blueman.Applet', in_signature="os", async_callbacks=("ok", "err"))
     def connect_service(self, object_path, uuid, ok, err):
         try:
-            self.Applet.Plugins.RecentConns
+            self.parent.Plugins.RecentConns
         except KeyError:
             logging.warning("RecentConns plugin is unavailable")
         else:
-            self.Applet.Plugins.RecentConns.notify(object_path, uuid)
+            self.parent.Plugins.RecentConns.notify(object_path, uuid)
 
         if uuid == '00000000-0000-0000-0000-000000000000':
             device = Device(object_path)
@@ -69,10 +68,10 @@ class DBusService(AppletPlugin):
 
             if service.group == 'serial':
                 def reply(rfcomm):
-                    self.Applet.Plugins.Run("on_rfcomm_connected", service, rfcomm)
+                    self.parent.Plugins.Run("on_rfcomm_connected", service, rfcomm)
                     ok(rfcomm)
 
-                rets = self.Applet.Plugins.Run("rfcomm_connect_handler", service, reply, err)
+                rets = self.parent.Plugins.Run("rfcomm_connect_handler", service, reply, err)
                 if True in rets:
                     pass
                 else:
@@ -84,7 +83,7 @@ class DBusService(AppletPlugin):
                     if ret:
                         raise StopException
 
-                if not self.Applet.Plugins.RunEx("service_connect_handler", cb, service, ok, err):
+                if not self.parent.Plugins.RunEx("service_connect_handler", cb, service, ok, err):
                     service.connect(reply_handler=ok, error_handler=err)
 
     @dbus.service.method('org.blueman.Applet', in_signature="osd", async_callbacks=("ok", "err"))
@@ -98,7 +97,7 @@ class DBusService(AppletPlugin):
             if service.group == 'serial':
                 service.disconnect(port)
 
-                self.Applet.Plugins.Run("on_rfcomm_disconnect", port)
+                self.parent.Plugins.Run("on_rfcomm_disconnect", port)
 
                 logging.info("Disonnecting rfcomm device")
             else:
@@ -107,7 +106,7 @@ class DBusService(AppletPlugin):
                     if ret:
                         raise StopException
 
-                if not self.Applet.Plugins.RunEx("service_disconnect_handler", cb, service, ok, err):
+                if not self.parent.Plugins.RunEx("service_disconnect_handler", cb, service, ok, err):
                     service.disconnect(reply_handler=ok, error_handler=err)
 
     def service_connect_handler(self, service, ok, err):
@@ -118,7 +117,7 @@ class DBusService(AppletPlugin):
 
     @dbus.service.method('org.blueman.Applet')
     def open_plugin_dialog(self):
-        self.Applet.Plugins.StandardItems.on_plugins()
+        self.parent.Plugins.StandardItems.on_plugins()
 
     def rfcomm_connect_handler(self, service, reply_handler, error_handler):
         return False

--- a/blueman/plugins/applet/DhcpClient.py
+++ b/blueman/plugins/applet/DhcpClient.py
@@ -14,7 +14,7 @@ class DhcpClient(AppletPlugin):
 
     _any_network = None
 
-    def on_load(self, applet):
+    def on_load(self):
         self._any_network = AnyNetwork()
         self._any_network.connect_signal('property-changed', self._on_network_prop_changed)
 

--- a/blueman/plugins/applet/DiscvManager.py
+++ b/blueman/plugins/applet/DiscvManager.py
@@ -26,19 +26,17 @@ class DiscvManager(AppletPlugin):
         }
     }
 
-    def on_load(self, applet):
-        self.item = applet.Plugins.Menu.add(self, 20, text=_("_Make Discoverable"), icon_name="edit-find",
-                                            tooltip=_("Make the default adapter temporarily visible"),
-                                            callback=self.on_set_discoverable, visible=False)
-
-        self.Applet = applet
+    def on_load(self):
+        self.item = self.parent.Plugins.Menu.add(self, 20, text=_("_Make Discoverable"), icon_name="edit-find",
+                                                 tooltip=_("Make the default adapter temporarily visible"),
+                                                 callback=self.on_set_discoverable, visible=False)
         self.adapter = None
         self.time_left = -1
 
         self.timeout = None
 
     def on_unload(self):
-        self.Applet.Plugins.Menu.unregister(self)
+        self.parent.Plugins.Menu.unregister(self)
         del self.item
 
         if self.timeout:
@@ -66,7 +64,7 @@ class DiscvManager(AppletPlugin):
 
     def init_adapter(self):
         try:
-            self.adapter = self.Applet.Manager.get_adapter()
+            self.adapter = self.parent.Manager.get_adapter()
         except ValueError:
             self.adapter = None
 

--- a/blueman/plugins/applet/ExitItem.py
+++ b/blueman/plugins/applet/ExitItem.py
@@ -11,8 +11,8 @@ class ExitItem(AppletPlugin):
     __author__ = "Walmis"
     __icon__ = "application-exit"
 
-    def on_load(self, applet):
-        applet.Plugins.Menu.add(self, 100, text="_Exit", icon_name='application-exit', callback=Gtk.main_quit)
+    def on_load(self):
+        self.parent.Plugins.Menu.add(self, 100, text="_Exit", icon_name='application-exit', callback=Gtk.main_quit)
 
     def on_unload(self):
-        self.Applet.Plugins.Menu.unregister(self)
+        self.parent.Plugins.Menu.unregister(self)

--- a/blueman/plugins/applet/GameControllerWakelock.py
+++ b/blueman/plugins/applet/GameControllerWakelock.py
@@ -17,7 +17,7 @@ class GameControllerWakelock(AppletPlugin):
     __author__ = "bwRavencl"
     __icon__ = "input-gaming"
 
-    def on_load(self, applet):
+    def on_load(self):
         self.wake_lock = 0
         self.root_window_id = "0x%x" % Gdk.Screen.get_default().get_root_window().get_xid()
 

--- a/blueman/plugins/applet/KillSwitch.py
+++ b/blueman/plugins/applet/KillSwitch.py
@@ -51,7 +51,7 @@ class KillSwitch(AppletPlugin):
     _enabled = True
     _hardblocked = False
 
-    def on_load(self, applet):
+    def on_load(self):
         self._connman_proxy = None
         self._connman_watch_id = Gio.bus_watch_name(Gio.BusType.SYSTEM, "net.connman", Gio.BusNameWatcherFlags.NONE,
                                                     self._on_connman_appeared, self._on_connman_vanished)
@@ -119,8 +119,8 @@ class KillSwitch(AppletPlugin):
 
         logging.info("State: %s" % self._enabled)
 
-        self.Applet.Plugins.StatusIcon.QueryVisibility(delay_hiding=not self._hardblocked)
-        self.Applet.Plugins.PowerManager.UpdatePowerState()
+        self.parent.Plugins.StatusIcon.QueryVisibility(delay_hiding=not self._hardblocked)
+        self.parent.Plugins.PowerManager.UpdatePowerState()
 
         return True
 

--- a/blueman/plugins/applet/Menu.py
+++ b/blueman/plugins/applet/Menu.py
@@ -91,9 +91,7 @@ class Menu(AppletPlugin):
     __author__ = "Walmis"
     __unloadable__ = False
 
-    def on_load(self, applet):
-        self.Applet = applet
-
+    def on_load(self):
         self.__plugins_loaded = False
 
         self.__menuitems = []

--- a/blueman/plugins/applet/NMDUNSupport.py
+++ b/blueman/plugins/applet/NMDUNSupport.py
@@ -89,7 +89,7 @@ class NMDUNSupport(AppletPlugin):
     __description__ = _("Provides support for Dial Up Networking (DUN) with ModemManager and NetworkManager")
     __priority__ = 1
 
-    def on_load(self, applet):
+    def on_load(self):
         self.bus = dbus.SystemBus()
 
     def on_unload(self):

--- a/blueman/plugins/applet/NMPANSupport.py
+++ b/blueman/plugins/applet/NMPANSupport.py
@@ -129,7 +129,7 @@ class NMPANSupport(AppletPlugin):
     __description__ = _("Provides support for Personal Area Networking (PAN) introduced in NetworkManager 0.8")
     __priority__ = 2
 
-    def on_load(self, applet):
+    def on_load(self):
         self.nm_manager = None
         self.nm_settings = None
         self.watch_id = None

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -322,7 +322,7 @@ class NetUsage(AppletPlugin, GObject.GObject):
 
     _any_network = None
 
-    def on_load(self, applet):
+    def on_load(self):
         GObject.GObject.__init__(self)
         self.monitors = []
         self.devices = weakref.WeakValueDictionary()
@@ -332,7 +332,7 @@ class NetUsage(AppletPlugin, GObject.GObject):
         self._any_network = AnyNetwork()
         self._any_network.connect_signal('property-changed', self._on_network_property_changed)
 
-        self.Applet.Plugins.Menu.add(self, 84, text=_("Network _Usage"), icon_name="network-wireless",
+        self.parent.Plugins.Menu.add(self, 84, text=_("Network _Usage"), icon_name="network-wireless",
                                      tooltip=_("Shows network traffic usage"), callback=self.activate_ui)
 
         self.bus.add_signal_receiver(self.on_nm_ppp_stats, "PppStats", "org.freedesktop.NetworkManager.Device.Serial",
@@ -356,8 +356,8 @@ class NetUsage(AppletPlugin, GObject.GObject):
                 ls = rfcomm_list()
                 for dev in ls:
                     if dev["id"] == portid:
-                        adapter = self.Applet.Manager.get_adapter(dev["src"])
-                        device = self.Applet.Manager.find_device(dev["dst"], adapter.get_object_path())
+                        adapter = self.parent.Manager.get_adapter(dev["src"])
+                        device = self.parent.Manager.find_device(dev["dst"], adapter.get_object_path())
 
                         self.monitor_interface(NMMonitor, device, path)
 
@@ -377,7 +377,7 @@ class NetUsage(AppletPlugin, GObject.GObject):
         self.bus.remove_signal_receiver(self.on_nm_ppp_stats, "PppStats",
                                         "org.freedesktop.NetworkManager.Device.Serial", path_keyword="path")
         del self._any_network
-        self.Applet.Plugins.Menu.unregister(self)
+        self.parent.Plugins.Menu.unregister(self)
 
     def monitor_interface(self, montype, *args):
         m = montype(*args)

--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -15,10 +15,8 @@ class Networking(AppletPlugin):
 
     _signal = None
 
-    def on_load(self, applet):
+    def on_load(self):
         self._registered = {}
-
-        self.Applet = applet
 
         self.Config = Config("org.blueman.network")
         self.Config.connect("changed", self.on_config_changed)
@@ -68,8 +66,8 @@ class Networking(AppletPlugin):
 
     def set_nap(self, on):
         logging.info("set nap %s" % on)
-        if self.Applet.manager_state:
-            adapters = self.Applet.Manager.get_adapters()
+        if self.parent.manager_state:
+            adapters = self.parent.Manager.get_adapters()
             for adapter in adapters:
                 object_path = adapter.get_object_path()
 

--- a/blueman/plugins/applet/PPPSupport.py
+++ b/blueman/plugins/applet/PPPSupport.py
@@ -17,7 +17,7 @@ class Connection:
         self.error_handler = err
         self.service = service
         self.port = port
-        self.Applet = applet
+        self.parent = applet
 
         res = os.popen("ps x -o pid,args | grep [M]odemManager").read()
         if not res:
@@ -39,7 +39,7 @@ class Connection:
 
     def on_connected(self, _obj, result, _user_data):
         self.reply_handler(self.port)
-        self.Applet.Plugins.Run("on_ppp_connected", self.service.device, self.port, result)
+        self.parent.Plugins.Run("on_ppp_connected", self.service.device, self.port, result)
 
         msg = _("Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
                 "Network is now available through <b>%(1)s</b>") % {"0": self.service.device['Alias'], "1": result}
@@ -54,7 +54,7 @@ class PPPSupport(AppletPlugin):
     __icon__ = "modem"
     __priority__ = 0
 
-    def on_load(self, applet):
+    def on_load(self):
         AppletPlugin.add_method(self.on_ppp_connected)
 
     def on_unload(self):
@@ -69,7 +69,7 @@ class PPPSupport(AppletPlugin):
     def rfcomm_connect_handler(self, service, reply, err):
         if DIALUP_NET_SVCLASS_ID == service.short_uuid:
             def local_reply(port):
-                Connection(self.Applet, service, port, reply, err)
+                Connection(self.parent, service, port, reply, err)
 
             service.connect(reply_handler=local_reply, error_handler=err)
             logging.info("Connecting rfcomm device")

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -35,7 +35,7 @@ class SerialManager(AppletPlugin):
 
     scripts = {}
 
-    def on_load(self, applet):
+    def on_load(self):
         self.scripts = {}
 
     def on_unload(self):

--- a/blueman/plugins/applet/ShowConnected.py
+++ b/blueman/plugins/applet/ShowConnected.py
@@ -12,15 +12,15 @@ class ShowConnected(AppletPlugin):
     __description__ = _(
         "Adds an indication on the status icon when Bluetooth is active and shows the number of connections in the tooltip.")
 
-    def on_load(self, applet):
+    def on_load(self):
         self.num_connections = 0
         self.active = False
         self.initialized = False
 
     def on_unload(self):
-        self.Applet.Plugins.StatusIcon.SetTextLine(1, None)
+        self.parent.Plugins.StatusIcon.SetTextLine(1, None)
         self.num_connections = 0
-        self.Applet.Plugins.StatusIcon.IconShouldChange()
+        self.parent.Plugins.StatusIcon.IconShouldChange()
 
     def on_status_icon_query_icon(self):
         if self.num_connections > 0:
@@ -31,35 +31,35 @@ class ShowConnected(AppletPlugin):
 
     def enumerate_connections(self):
         self.num_connections = 0
-        for device in self.Applet.Manager.get_devices():
+        for device in self.parent.Manager.get_devices():
             if device["Connected"]:
                 self.num_connections += 1
 
         logging.info("Found %d existing connections" % self.num_connections)
         if (self.num_connections > 0 and not self.active) or \
                 (self.num_connections == 0 and self.active):
-            self.Applet.Plugins.StatusIcon.IconShouldChange()
+            self.parent.Plugins.StatusIcon.IconShouldChange()
 
         self.update_statusicon()
 
     def update_statusicon(self):
         if self.num_connections > 0:
-            self.Applet.Plugins.StatusIcon.SetTextLine(0,
+            self.parent.Plugins.StatusIcon.SetTextLine(0,
                                                        _("Bluetooth Active"))
-            self.Applet.Plugins.StatusIcon.SetTextLine(1,
+            self.parent.Plugins.StatusIcon.SetTextLine(1,
                                                        ngettext("<b>%d Active Connection</b>",
                                                                 "<b>%d Active Connections</b>",
                                                                 self.num_connections) % self.num_connections)
         else:
-            self.Applet.Plugins.StatusIcon.SetTextLine(1, None)
+            self.parent.Plugins.StatusIcon.SetTextLine(1, None)
             try:
-                if self.Applet.Plugins.PowerManager.GetBluetoothStatus():
-                    self.Applet.Plugins.StatusIcon.SetTextLine(0,
+                if self.parent.Plugins.PowerManager.GetBluetoothStatus():
+                    self.parent.Plugins.StatusIcon.SetTextLine(0,
                                                                _("Bluetooth Enabled"))
             except:
                 #bluetooth should be always enabled if powermanager is
                 #not loaded
-                self.Applet.Plugins.StatusIcon.SetTextLine(0,
+                self.parent.Plugins.StatusIcon.SetTextLine(0,
                                                            _("Bluetooth Enabled"))
 
     def on_manager_state_changed(self, state):
@@ -82,7 +82,7 @@ class ShowConnected(AppletPlugin):
                 self.num_connections -= 1
 
             if (self.num_connections > 0 and not self.active) or (self.num_connections == 0 and self.active):
-                self.Applet.Plugins.StatusIcon.IconShouldChange()
+                self.parent.Plugins.StatusIcon.IconShouldChange()
 
             self.update_statusicon()
 

--- a/blueman/plugins/applet/StandardItems.py
+++ b/blueman/plugins/applet/StandardItems.py
@@ -15,45 +15,44 @@ class StandardItems(AppletPlugin):
     __description__ = _("Adds standard menu items to the status icon menu")
     __author__ = "walmis"
 
-    def on_load(self, applet):
-        self.Applet = applet
+    def on_load(self):
 
-        applet.Plugins.Menu.add(self, 21)
+        self.parent.Plugins.Menu.add(self, 21)
 
-        self.new_dev = self.Applet.Plugins.Menu.add(self, 30, text=_("_Set Up New Device") + "…",
+        self.new_dev = self.parent.Plugins.Menu.add(self, 30, text=_("_Set Up New Device") + "…",
                                                     icon_name="document-new", callback=self.on_setup_new)
 
-        self.Applet.Plugins.Menu.add(self, 31)
+        self.parent.Plugins.Menu.add(self, 31)
 
-        self.send = self.Applet.Plugins.Menu.add(self, 40, text=_("Send _Files to Device") + "…",
+        self.send = self.parent.Plugins.Menu.add(self, 40, text=_("Send _Files to Device") + "…",
                                                  icon_name="blueman-send-file", callback=self.on_send)
 
-        self.Applet.Plugins.Menu.add(self, 51)
+        self.parent.Plugins.Menu.add(self, 51)
 
-        self.devices = self.Applet.Plugins.Menu.add(self, 60, text=_("_Devices") + "…", icon_name="blueman",
+        self.devices = self.parent.Plugins.Menu.add(self, 60, text=_("_Devices") + "…", icon_name="blueman",
                                                     callback=self.on_devices)
 
-        self.adapters = self.Applet.Plugins.Menu.add(self, 70, text=_("Adap_ters") + "…", icon_name="blueman-device",
+        self.adapters = self.parent.Plugins.Menu.add(self, 70, text=_("Adap_ters") + "…", icon_name="blueman-device",
                                                      callback=self.on_adapters)
 
-        self.Applet.Plugins.Menu.add(self, 80, text=_("_Local Services") + "…", icon_name="preferences-desktop",
+        self.parent.Plugins.Menu.add(self, 80, text=_("_Local Services") + "…", icon_name="preferences-desktop",
                                      callback=self.on_local_services)
 
-        self.Applet.Plugins.Menu.add(self, 81)
+        self.parent.Plugins.Menu.add(self, 81)
 
-        self.Applet.Plugins.Menu.add(self, 90, text="_Help", icon_name='help-about', callback=self.on_about)
+        self.parent.Plugins.Menu.add(self, 90, text="_Help", icon_name='help-about', callback=self.on_about)
 
-        self.Applet.Plugins.Menu.add(self, 85, text=_("_Plugins"), icon_name="blueman-plugin", callback=self.on_plugins)
+        self.parent.Plugins.Menu.add(self, 85, text=_("_Plugins"), icon_name="blueman-plugin", callback=self.on_plugins)
 
-        self.Applet.Plugins.StatusIcon.connect("activate", lambda _status_icon: self.on_devices())
+        self.parent.Plugins.StatusIcon.connect("activate", lambda _status_icon: self.on_devices())
 
     def change_sensitivity(self, sensitive):
         try:
-            power = self.Applet.Plugins.PowerManager.GetBluetoothStatus()
+            power = self.parent.Plugins.PowerManager.GetBluetoothStatus()
         except:
             power = True
 
-        sensitive = sensitive and self.Applet.Manager and power
+        sensitive = sensitive and self.parent.Manager and power
         self.new_dev.set_sensitive(sensitive)
         self.send.set_sensitive(sensitive)
         self.devices.set_sensitive(sensitive)
@@ -99,7 +98,7 @@ class StandardItems(AppletPlugin):
 
     def on_plugins(self):
         def open_dialog():
-            dialog = PluginDialog(self.Applet)
+            dialog = PluginDialog(self.parent)
             dialog.run()
             dialog.destroy()
         GLib.idle_add(open_dialog)

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -35,8 +35,6 @@ class StatusIcon(AppletPlugin, GObject.GObject):
 
         self.QueryVisibility(emit=False)
 
-        launch('blueman-tray', icon_name='blueman')
-
         self.parent.Plugins.connect('plugin-loaded', self._on_plugins_changed)
         self.parent.Plugins.connect('plugin-unloaded', self._on_plugins_changed)
 

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -25,7 +25,7 @@ class StatusIcon(AppletPlugin, GObject.GObject):
 
     _implementation = None
 
-    def on_load(self, applet):
+    def on_load(self):
         GObject.GObject.__init__(self)
         self.lines = {0: _("Bluetooth Enabled")}
 
@@ -37,8 +37,8 @@ class StatusIcon(AppletPlugin, GObject.GObject):
 
         launch('blueman-tray', icon_name='blueman')
 
-        self.Applet.Plugins.connect('plugin-loaded', self._on_plugins_changed)
-        self.Applet.Plugins.connect('plugin-unloaded', self._on_plugins_changed)
+        self.parent.Plugins.connect('plugin-loaded', self._on_plugins_changed)
+        self.parent.Plugins.connect('plugin-unloaded', self._on_plugins_changed)
 
     def on_power_state_changed(self, _manager, state):
         if state:
@@ -49,16 +49,16 @@ class StatusIcon(AppletPlugin, GObject.GObject):
             self.QueryVisibility()
 
     def QueryVisibility(self, delay_hiding=False, emit=True):
-        rets = self.Applet.Plugins.Run("on_query_status_icon_visibility")
+        rets = self.parent.Plugins.Run("on_query_status_icon_visibility")
         if StatusIcon.FORCE_HIDE not in rets:
             if StatusIcon.FORCE_SHOW in rets:
                 self.set_visible(True, emit)
             else:
-                if not self.Applet.Manager:
+                if not self.parent.Manager:
                     self.set_visible(False, emit)
                     return
 
-                if self.Applet.Manager.get_adapters():
+                if self.parent.Manager.get_adapters():
                     self.set_visible(True, emit)
                 elif not self.visibility_timeout:
                     if delay_hiding:
@@ -128,7 +128,7 @@ class StatusIcon(AppletPlugin, GObject.GObject):
 
     @dbus.service.method('org.blueman.Applet', in_signature="", out_signature="s")
     def GetStatusIconImplementation(self):
-        implementations = self.Applet.Plugins.Run("on_query_status_icon_implementation")
+        implementations = self.parent.Plugins.Run("on_query_status_icon_implementation")
         return next((implementation for implementation in implementations if implementation), 'GtkStatusIcon')
 
     @dbus.service.method('org.blueman.Applet', in_signature="", out_signature="s")
@@ -142,7 +142,7 @@ class StatusIcon(AppletPlugin, GObject.GObject):
                     icon = i
                     raise StopException
 
-        self.Applet.Plugins.RunEx("on_status_icon_query_icon", callback)
+        self.parent.Plugins.RunEx("on_status_icon_query_icon", callback)
         return icon
 
     def on_query_status_icon_implementation(self):

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -122,7 +122,7 @@ class StatusIcon(AppletPlugin, GObject.GObject):
         if not self._implementation or self._implementation != implementation:
             self._implementation = implementation
             kill(get_pid(get_lockfile('blueman-tray')), 'blueman-tray')
-            launch('blueman-tray', icon_name='blueman')
+            launch('blueman-tray', icon_name='blueman', sn=False)
 
     @dbus.service.method('org.blueman.Applet', in_signature="", out_signature="s")
     def GetStatusIconImplementation(self):

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -139,7 +139,7 @@ class TransferService(AppletPlugin):
     _agent = None
     _watch = None
 
-    def on_load(self, applet):
+    def on_load(self):
         self._config = Config("org.blueman.transfer")
 
         if not self._config["shared-path"]:
@@ -174,7 +174,7 @@ class TransferService(AppletPlugin):
 
     def _register_agent(self):
         if not self._agent:
-            self._agent = Agent(self.Applet)
+            self._agent = Agent(self.parent)
         self._agent.register()
 
     def _unregister_agent(self):
@@ -216,7 +216,7 @@ class TransferService(AppletPlugin):
     def _notify_kwargs(self):
         kwargs = {"icon_name": "blueman"}
         try:
-            kwargs["pos_hint"] = self.Applet.Plugins.StatusIcon.geometry
+            kwargs["pos_hint"] = self.parent.Plugins.StatusIcon.geometry
         except AttributeError:
             logging.error("No statusicon found")
 

--- a/blueman/plugins/manager/PulseAudioProfile.py
+++ b/blueman/plugins/manager/PulseAudioProfile.py
@@ -14,7 +14,7 @@ import logging
 
 
 class PulseAudioProfile(ManagerPlugin):
-    def on_load(self, user_data):
+    def on_load(self):
         self.devices = {}
         self.item = None
 

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -13,13 +13,12 @@ from _blueman import rfcomm_list
 
 
 class Services(ManagerPlugin):
-    def on_load(self, manager):
-        self.manager = manager
+    def on_load(self):
         self.icon_theme = Gtk.IconTheme.get_default()
 
     def _make_x_icon(self, icon_name, size):
-        scale = self.manager.get_scale_factor()
-        window = self.manager.get_window()
+        scale = self.parent.get_scale_factor()
+        window = self.parent.get_window()
 
         target = self.icon_theme.load_surface(icon_name, size, scale, window, Gtk.IconLookupFlags.FORCE_SIZE)
         bmx = self.icon_theme.load_surface("blueman-x", size, scale, window, Gtk.IconLookupFlags.FORCE_SIZE)


### PR DESCRIPTION
I was looking to always have the parent available for general use [1] and found it was already there as ``__parent__``. 

```
>__parent__ is set in BasePlugin and is actually the Applet, Manager or
Service instances passed in by the PluginManager. However we also pass
these instances to on_load function meaning we may end up adding them
to the plugin twice, once as __parent__ during init and again in on_load.

This also unifies the name "parent" across all plugin bases classes.
```

[1] I am tired of fighting the GDBus service implementation from the pithos folks and make it work with our plugin system. I am looking at doing it differently.