### PR TITLE
Discussion: Usage of __del__ in blueman

### DIFF
--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import logging
+import weakref
 from blueman.bluez.obex.Transfer import Transfer
 from gi.repository import GObject, Gio
 from gi.types import GObjectMeta
@@ -39,7 +40,9 @@ class Manager(GObject.GObject, metaclass=ManagerMeta):
         self.__signals.append(self._object_manager.connect('object-added', self._on_object_added))
         self.__signals.append(self._object_manager.connect('object-removed', self._on_object_removed))
 
-    def __del__(self):
+        weakref.finalize(self, self._on_delete)
+
+    def _on_delete(self):
         for sig in self.__signals:
             self._object_manager.disconnect(sig)
 

--- a/blueman/main/PulseAudioUtils.py
+++ b/blueman/main/PulseAudioUtils.py
@@ -655,6 +655,8 @@ class PulseAudioUtils(GObject.GObject, metaclass=PulseAudioUtilsMeta):
 
         self.Connect()
 
+        weakref.finalize(self, self._on_delete)
+
     def Connect(self):
         if not self.connected:
             if self.pa_context:
@@ -673,7 +675,7 @@ class PulseAudioUtils(GObject.GObject, metaclass=PulseAudioUtilsMeta):
                                               self.event_cb,
                                               None)
 
-    def __del__(self):
+    def _on_delete(self):
         logging.info("Destroying PulseAudioUtils instance")
 
         pa_context_disconnect(self.pa_context)

--- a/blueman/plugins/BasePlugin.py
+++ b/blueman/plugins/BasePlugin.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import logging
+import weakref
 from blueman.main.Config import Config
 
 
@@ -35,7 +36,10 @@ class BasePlugin(object):
                 self.__class__.__gsettings__.get("path")
             )
 
-    def __del__(self):
+        weakref.finalize(self, self._on_plugin_delete)
+
+    def _on_plugin_delete(self):
+        self.on_delete()
         logging.debug("Deleting plugin instance %s" % self)
 
     @classmethod
@@ -80,6 +84,10 @@ class BasePlugin(object):
     def on_unload(self):
         """Tear down any watches and ui elements created in on_load"""
         raise NotImplementedError
+
+    def on_delete(self):
+        """Do cleanup that needs to happen when plugin is deleted"""
+        pass
 
     def get_option(self, key):
         if key not in self.__class__.__options__:

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -9,7 +9,7 @@ import logging
 import os
 import signal
 import blueman.bluez as Bluez
-from gi.repository import GObject
+from gi.repository import GLib
 
 
 class SerialManager(AppletPlugin):
@@ -85,7 +85,7 @@ class SerialManager(AppletPlugin):
             self.scripts[address][node].terminate()
 
         self.scripts[address][node] = process
-        GObject.child_watch_add(process.pid, self.on_script_closed, (address, node))
+        GLib.child_watch_add(process.pid, self.on_script_closed, (address, node))
 
     def call_script(self, address, name, sv_name, uuid16, node):
         c = self.get_option("script")


### PR DESCRIPTION
I was looking at ``__del__`` usage in plugins. This does not work at all as it is used. Even on proper shutdown we never saw any of the messages printed in ``__del__``.

Commit message explains,
```
This is useful for plugins that need to stop scripts and tear down
things that must always be done. For example kill running scripts like
we do in SerialManager.

We can not rely on __del__ to be run and this is most likely why
SerialManager uses the atexit module. We can howver use weakref to
run a function when the plugin is about tot be deleted.

Now we see the debug message "Deleting plugin instance %s" at shutdown
which never showed for me before.

But, this raises an interesting issue, we never see this message when
disabling a plugin. More work has to be done to properly unload plugins.
```

None of the messages printed in ``__del__`` in all of blueman show up for me. So it is probably good to stop relying on it completely.

Question, are message like https://github.com/blueman-project/blueman/blob/master/blueman/gui/manager/ManagerDeviceMenu.py#L63 really useful as I don't see any? If not Ill just get rid of all of these.