### PR TITLE
NetConf.py: explicitly pass "dev" to ip(8) command

### DIFF
--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -387,7 +387,7 @@ class NetConf(object):
             self.enable_ip4_forwarding()
 
             if have("ip"):
-                ret = call(["ip", "link", "set", "pan1", "up"])
+                ret = call(["ip", "link", "set", "dev", "pan1", "up"])
                 if ret != 0:
                     raise NetworkSetupError("Failed to bring up interface pan1")
                 ret = call(["ip", "address", "add", "/".join((ip_str, mask_str)), "dev", "pan1"])


### PR DESCRIPTION
This shouldn't actually be a problem, but as long as it's
in there, we may as well set a good example and be pedantic.

This is a minor fixup to #759 