### PR TITLE
Handle when obexd can not be autostarted

### DIFF
--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -59,7 +59,7 @@ class Base(Gio.DBusProxy, metaclass=BaseMeta):
             g_object_path=obj_path,
             g_bus_type=self.__bus_type,
             # FIXME See issue 620
-            g_flags=Gio.DBusProxyFlags.GET_INVALIDATED_PROPERTIES | Gio.DBusProxyFlags.DO_NOT_AUTO_START,
+            g_flags=Gio.DBusProxyFlags.GET_INVALIDATED_PROPERTIES,
             *args, **kwargs)
 
         self.init()

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -34,7 +34,7 @@ class Manager(GObject.GObject, metaclass=ManagerMeta):
     def __init__(self):
         super().__init__()
         self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
-            Gio.BusType.SYSTEM, Gio.DBusObjectManagerClientFlags.DO_NOT_AUTO_START,
+            Gio.BusType.SYSTEM, Gio.DBusObjectManagerClientFlags.NONE,
             self.__bus_name, '/', None, None, None)
 
         self._object_manager.connect("object-added", self._on_object_added)
@@ -109,5 +109,5 @@ class Manager(GObject.GObject, metaclass=ManagerMeta):
 
     @classmethod
     def watch_name_owner(cls, appeared_handler, vanished_handler):
-        Gio.bus_watch_name(Gio.BusType.SYSTEM, cls.__bus_name, Gio.BusNameWatcherFlags.NONE,
+        Gio.bus_watch_name(Gio.BusType.SYSTEM, cls.__bus_name, Gio.BusNameWatcherFlags.AUTO_START,
                            appeared_handler, vanished_handler)

--- a/blueman/bluez/obex/Client.py
+++ b/blueman/bluez/obex/Client.py
@@ -4,10 +4,6 @@ from blueman.bluez.obex.Base import Base
 from gi.repository import GObject, GLib, Gio
 
 
-class ObexdNotFoundError(Exception):
-    pass
-
-
 class Client(Base):
     __gsignals__ = {
         'session-created': (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
@@ -18,16 +14,6 @@ class Client(Base):
     _interface_name = 'org.bluez.obex.Client1'
 
     def __init__(self):
-        proxy = Gio.DBusProxy.new_for_bus_sync(
-            Gio.BusType.SESSION, Gio.DBusProxyFlags.NONE, None, 'org.bluez.obex', '/',
-            'org.freedesktop.DBus.Introspectable')
-
-        introspection = proxy.call_sync('Introspect', None, Gio.DBusCallFlags.NONE,
-                                        GLib.MAXINT, None).unpack()[0]
-
-        if 'org.freedesktop.DBus.ObjectManager' not in introspection:
-            raise ObexdNotFoundError('Could not find any compatible version of obexd')
-
         super().__init__(interface_name=self._interface_name, obj_path='/org/bluez/obex')
 
     def create_session(self, dest_addr, source_addr="00:00:00:00:00:00", pattern="opp"):

--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -34,7 +34,7 @@ class Manager(GObject.GObject, metaclass=ManagerMeta):
         self.__signals = []
 
         self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
-            Gio.BusType.SESSION, Gio.DBusObjectManagerClientFlags.DO_NOT_AUTO_START,
+            Gio.BusType.SESSION, Gio.DBusObjectManagerClientFlags.NONE,
             self.__bus_name, '/', None, None, None)
 
         self.__signals.append(self._object_manager.connect('object-added', self._on_object_added))
@@ -83,5 +83,5 @@ class Manager(GObject.GObject, metaclass=ManagerMeta):
 
     @classmethod
     def watch_name_owner(cls, appeared_handler, vanished_handler):
-        Gio.bus_watch_name(Gio.BusType.SESSION, cls.__bus_name, Gio.BusNameWatcherFlags.NONE,
+        Gio.bus_watch_name(Gio.BusType.SESSION, cls.__bus_name, Gio.BusNameWatcherFlags.AUTO_START,
                            appeared_handler, vanished_handler)

--- a/blueman/bluez/obex/__init__.py
+++ b/blueman/bluez/obex/__init__.py
@@ -2,7 +2,6 @@
 from blueman.bluez.obex.Agent import Agent
 from blueman.bluez.obex.AgentManager import AgentManager
 from blueman.bluez.obex.Client import Client
-from blueman.bluez.obex.Client import ObexdNotFoundError
 from blueman.bluez.obex.Manager import Manager
 from blueman.bluez.obex.ObjectPush import ObjectPush
 from blueman.bluez.obex.Transfer import Transfer

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -95,11 +95,6 @@ class Sender(Gtk.Dialog):
         self.num_files = len(self.files)
         try:
             self.client = obex.Client()
-        except obex.ObexdNotFoundError:
-            d = ErrorDialog(_("obexd not available"), _("obexd is probably not installed"))
-            d.run()
-            d.destroy()
-            exit(1)
         except GLib.Error as e:
             if 'StartServiceByName' in e.message:
                 logging.debug(e.message)

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -14,6 +14,7 @@ gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import GObject
+from gi.repository import GLib
 
 from blueman.bluez.Adapter import Adapter
 from blueman.bluez.obex.ObjectPush import ObjectPush
@@ -99,6 +100,17 @@ class Sender(Gtk.Dialog):
             d.run()
             d.destroy()
             exit(1)
+        except GLib.Error as e:
+            if 'StartServiceByName' in e.message:
+                logging.debug(e.message)
+                d = ErrorDialog(_("obexd not available"), _("Failed to autostart obex service. Make sure the obex "
+                                                            "daemon is running"))
+                d.run()
+                d.destroy()
+                exit(1)
+            else:
+                # Fail on anything else
+                raise
 
         if self.num_files == 0:
             exit(1)


### PR DESCRIPTION
Works for me on Gentoo (without systemd) but needs some testing on other ditros.

The TransferService plugin is handled nicely now. It waits for the name ``org.bluez.obex`` to show up before setting up the obex.Manager.

But in blueman-sendto I had to resort to checking the error message for ``StartServiceByName``. The string shows up in the error on a Fedora vm and my gentoo workstation so it should be fairly safe to rely on it.

The best way to test this is to to modify the obex dbus service file. Either set the exec entry to ``Exec=/path/to/obexd`` or ``Exec=/bin/false``.