### PR TITLE
Allow setting systemd unit dirs separately, and get sane defaults from pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -215,14 +215,23 @@ AC_ARG_ENABLE([appindicator],
 
 AM_CONDITIONAL([HAVE_APPINDICATOR], [test "x$use_appindicator" = "xyes"])
 
-AC_ARG_WITH([systemdunitdir],
-  AS_HELP_STRING([--with-systemdunitdir=PATH],
-    [Directory for systemd unit files]
-    [[default=${prefix}/lib/systemd]]),
-  [systemd_unit_dir="$withval"],
-  [systemd_unit_dir='${prefix}/lib/systemd'])
-AC_SUBST([systemd_unit_dir])
-AM_CONDITIONAL([SYSTEMD_UNIT_DIR], [test "x$systemd_unit_dir" != "xno"])
+AC_ARG_WITH([systemdsystemunitdir],
+  AS_HELP_STRING([--with-systemdsystemunitdir=PATH],
+    [Directory for systemd system unit files]
+    [[default=${prefix}/lib/systemd/system]]),
+  [systemd_system_unit_dir="$withval"],
+  [systemd_system_unit_dir='${prefix}/lib/systemd/system'])
+AC_SUBST([systemd_system_unit_dir])
+AM_CONDITIONAL([SYSTEMD_SYSTEM_UNIT_DIR], [test "x$systemd_system_unit_dir" != "xno"])
+
+AC_ARG_WITH([systemduserunitdir],
+  AS_HELP_STRING([--with-systemduserunitdir=PATH],
+    [Directory for systemd user unit files]
+    [[default=${prefix}/lib/systemd/user]]),
+  [systemd_user_unit_dir="$withval"],
+  [systemd_user_unit_dir='${prefix}/lib/systemd/user'])
+AC_SUBST([systemd_user_unit_dir])
+AM_CONDITIONAL([SYSTEMD_USER_UNIT_DIR], [test "x$systemd_user_unit_dir" != "xno"])
 
 # GSettings related settings
 GLIB_GSETTINGS
@@ -324,5 +333,6 @@ echo Settings menu integration enabled: $have_settings
 echo Dhcpd 3 configuration file: $dhconfig
 echo PulseAudio support: $use_pulseaudio
 echo AppIndicator support: $use_appindicator
-echo Systemd unit dir: ${systemd_unit_dir}
+echo Systemd system unit dir: ${systemd_system_unit_dir}
+echo Systemd user unit dir: ${systemd_user_unit_dir}
 echo

--- a/data/configs/Makefile.am
+++ b/data/configs/Makefile.am
@@ -7,11 +7,13 @@ dbus_services_DATA = org.blueman.Mechanism.service
 dbus_sessdir = $(datadir)/dbus-1/services
 dbus_sess_DATA = org.blueman.Applet.service
 
-if SYSTEMD_UNIT_DIR
-systemd_systemdir = $(systemd_unit_dir)/system
+if SYSTEMD_SYSTEM_UNIT_DIR
+systemd_systemdir = $(systemd_system_unit_dir)
 systemd_system_DATA = blueman-mechanism.service
+endif
 
-systemd_userdir = $(systemd_unit_dir)/user
+if SYSTEMD_USER_UNIT_DIR
+systemd_userdir = $(systemd_user_unit_dir)
 systemd_user_DATA = blueman-applet.service
 endif
 


### PR DESCRIPTION
Currently blueman uses custom-made `--with-systemdunitdir` that sets top directory for systemd units. This doesn't work for split /usr systems because system units need to go into `/lib/systemd` while user units need to go into `/usr/lib/systemd`.

Replace the custom option with quasi-standard `--with-systemdsystemunitdir` and `--with-systemduserunitdir` that allow setting both necessary directories separately. <del>Furthermore, default to querying pkg-config for the correct paths from systemd.pc.</del>