### PR TITLE
RFC: Networking: Also allow for busybox binary for udhcpd

### DIFF
--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -234,7 +234,11 @@ class UdhcpdHandler(object):
             os.close(config_file)
 
             logging.info("Running udhcpd with config file %s" % config_path)
-            cmd = [have("udhcpd"), "-S", config_path]
+            udhcpd_bin = have("udhcpd")
+            if udhcpd_bin is None:
+                udhcpd_bin = [have("busybox"), "udhcpd"] if have("busybox") else None
+
+            cmd = udhcpd_bin + ["-S", config_path]
             p = Popen(cmd, stderr=PIPE)
             error = p.communicate()[1]
 

--- a/blueman/plugins/services/Network.py
+++ b/blueman/plugins/services/Network.py
@@ -167,6 +167,8 @@ class Network(ServicePlugin):
         have_dhcpd = have("dhcpd3") or have("dhcpd")
         have_dnsmasq = have("dnsmasq")
         have_udhcpd = have("udhcpd")
+        if have_udhcpd is None:
+            have_udhcpd = have("busybox")
 
         if nc.get_dhcp_handler() == DnsMasqHandler and have_dnsmasq:
             r_dnsmasq.props.active = True


### PR DESCRIPTION
Untested code just looking for feedback. In gentoo for example we have busybox and can (at own risk) have it create the symlinks but the default is not to. So we have busybox bot not the symlink to udhcpd. There should be no difference using ``busybox udhcpd`` but I am not sure if this is a good idea.