### PR TITLE
AutoConnect plugin

### DIFF
--- a/blueman/plugins/applet/AutoConnect.py
+++ b/blueman/plugins/applet/AutoConnect.py
@@ -1,3 +1,5 @@
+from gi.repository import GLib
+
 from blueman.Sdp import ServiceUUID
 from blueman.gui.Notification import Notification
 from blueman.plugins.AppletPlugin import AppletPlugin
@@ -14,21 +16,28 @@ class AutoConnect(AppletPlugin):
         "services": {"type": list, "default": "[]"}
     }
 
-    def on_manager_state_changed(self, state):
-        if not state:
-            return
+    def __init__(self, parent):
+        super().__init__(parent)
+        GLib.timeout_add(60000, self._run)
 
+    def on_manager_state_changed(self, state):
+        if state:
+            self._run()
+
+    def _run(self):
         for address, uuid in self.get_option('services'):
             device = self.parent.Manager.find_device(address)
-            if device is None:
-                return
+            if device is None or device.get("Connected"):
+                continue
 
-            def reply(*args):
+            def reply(*_args):
                 Notification(_("Connected"), _("Automatically connected to %(service)s on %(device)s") %
                              {"service": ServiceUUID(uuid).name, "device": device["Alias"]},
                              icon_name=device["Icon"]).show()
 
-            def err(reason):
+            def err(_reason):
                 pass
 
             self.parent.Plugins.DBusService.connect_service(device.get_object_path(), uuid, reply, err)
+
+        return True

--- a/blueman/plugins/applet/AutoConnect.py
+++ b/blueman/plugins/applet/AutoConnect.py
@@ -14,7 +14,10 @@ class AutoConnect(AppletPlugin):
         "services": {"type": list, "default": "[]"}
     }
 
-    def on_load(self):
+    def on_manager_state_changed(self, state):
+        if not state:
+            return
+
         for address, uuid in self.get_option('services'):
             device = self.parent.Manager.find_device(address)
             if device is None:

--- a/blueman/plugins/applet/AutoConnect.py
+++ b/blueman/plugins/applet/AutoConnect.py
@@ -1,0 +1,31 @@
+from blueman.Sdp import ServiceUUID
+from blueman.gui.Notification import Notification
+from blueman.plugins.AppletPlugin import AppletPlugin
+
+
+class AutoConnect(AppletPlugin):
+    __depends__ = ["DBusService"]
+
+    __gsettings__ = {
+        "schema": "org.blueman.plugins.autoconnect",
+        "path": None
+    }
+    __options__ = {
+        "services": {"type": list, "default": "[]"}
+    }
+
+    def on_load(self):
+        for address, uuid in self.get_option('services'):
+            device = self.parent.Manager.find_device(address)
+            if device is None:
+                return
+
+            def reply(*args):
+                Notification(_("Connected"), _("Automatically connected to %(service)s on %(device)s") %
+                             {"service": ServiceUUID(uuid).name, "device": device["Alias"]},
+                             icon_name=device["Icon"]).show()
+
+            def err(reason):
+                pass
+
+            self.parent.Plugins.DBusService.connect_service(device.get_object_path(), uuid, reply, err)

--- a/blueman/plugins/applet/Makefile.am
+++ b/blueman/plugins/applet/Makefile.am
@@ -3,6 +3,7 @@ bluemandir = $(pythondir)/blueman/plugins/applet
 blueman_PYTHON = \
     __init__.py \
     AuthAgent.py \
+    AutoConnect.py \
     DBusService.py \
     DhcpClient.py \
     DiscvManager.py \

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -23,7 +23,7 @@ class DeviceNotFound(Exception):
 
 
 class RecentConns(AppletPlugin):
-    __depends__ = ["Menu"]
+    __depends__ = ["DBusService", "Menu"]
     __icon__ = "document-open-recent"
     __description__ = _("Provides a menu item that contains last used connections for quick access")
     __author__ = "Walmis"

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -130,6 +130,13 @@
       <description></description>
     </key>
   </schema>
+  <schema id="org.blueman.plugins.autoconnect" path="/org/blueman/plugins/autoconnect/">
+    <key type="a(ss)" name="services">
+      <default>[]</default>
+      <summary>Services to connect to automatically</summary>
+      <description>A list of services to connect to stored as tuples with the address and the UUID</description>
+    </key>
+  </schema>
   <schema id="org.blueman.plugins.powermanager" path="/org/blueman/plugins/powermanager/">
     <key type="mb" name="auto-power-on">
         <default>nothing</default>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -71,6 +71,7 @@ blueman/plugins/BasePlugin.py
 blueman/plugins/ServicePlugin.py
 blueman/plugins/AppletPlugin.py
 blueman/plugins/__init__.py
+blueman/plugins/applet/AutoConnect.py
 blueman/plugins/applet/NetUsage.py
 blueman/plugins/applet/StatusIcon.py
 blueman/plugins/applet/Networking.py


### PR DESCRIPTION
Initial draft for #239. It's currently just a "backend" you can configure via gsettings, e.g. `gsettings set org.blueman.plugins.autoconnect services '[("CC:9F:7A:A5:47:34","00000000-0000-0000-0000-000000000000")]'`.

The only useful UUIDs are the above one for auto-connect services (audio, HID) and the specific UUIDs for for other services we can handle (serial, network). Anything else currently causes a crash as `DBusService.connect_service` only expects those UUIDs.

I applied small fixes to the RecentConns plugin on the way. It used a wrapper for the `connect_service` method for no reason and in any case it depends on `DBusService` plugins to be loaded.