### PR TITLE
Re-implement PANU and DUN connection through NetworkManager

### DIFF
--- a/blueman/main/Makefile.am
+++ b/blueman/main/Makefile.am
@@ -17,7 +17,8 @@ blueman_PYTHON = \
 	Sendto.py \
 	Services.py \
 	Tray.py \
-	DBusProxies.py
+	DBusProxies.py \
+	NetworkManager.py
 
 if HAVE_PULSEAUDIO
 blueman_PYTHON += PulseAudioUtils.py

--- a/blueman/main/NetworkManager.py
+++ b/blueman/main/NetworkManager.py
@@ -1,0 +1,217 @@
+import gi
+import logging
+import uuid
+gi.require_version('NM', '1.0')
+from gi.repository import GLib, NM
+from blueman.main.Config import Config
+
+
+class NMConnectionError(Exception):
+    pass
+
+
+class NMConnectionBase(object):
+    conntype = None
+
+    def __init__(self, service, reply_handler=None, error_handler=None):
+        if self.conntype not in ('dun', 'panu'):
+            self._raise_or_error_handler(
+                NMConnectionError('Invalid connection type %s, should be panu or dun' % self.conntype)
+            )
+        self.device = service.device
+        self.bdaddr = self.device['Address']
+        self.error_handler = error_handler
+        self.reply_handler = reply_handler
+        self.connection = None
+        self.active_connection = None
+        self.client = NM.Client.new()
+        self.Config = Config('org.blueman.gsmsetting', '/org/blueman/gsmsettings/%s/' % self.bdaddr)
+
+        self.find_or_create_connection()
+
+    def _return_or_reply_handler(self, msg):
+        logging.debug(msg)
+        if not self.reply_handler:
+            return msg
+        else:
+            self.reply_handler(msg)
+            return
+
+    def _raise_or_error_handler(self, error):
+        logging.debug(str(error))
+        if not self.error_handler:
+            raise error
+        else:
+            self.error_handler(error)
+            return
+
+    def _on_connection_added(self, client, result, conn_uuid):
+        try:
+            self.connection = client.add_connection_finish(result)
+        except GLib.Error as e:
+            self._raise_or_error_handler(e)
+
+        self.store_uuid(conn_uuid)
+
+    def _on_device_state_changed(self, device, new_state, old_state, reason):
+        new = NM.DeviceState(new_state)
+        old = NM.DeviceState(old_state)
+        state_reason = NM.DeviceStateReason(reason)
+        logging.debug('New: %s Old: %s Reason: %s' % (new.value_nick, old.value_nick, state_reason.value_nick))
+
+        error_msg = None
+        reply_msg = None
+
+        if new == NM.DeviceState.FAILED:
+            error_msg = 'Connection failed with reason: %s' % state_reason.value_nick
+        elif new == NM.DeviceState.ACTIVATED:
+            reply_msg = 'Connection sucesfully activated'
+        elif (new <= NM.DeviceState.DISCONNECTED or new == NM.DeviceState.DEACTIVATING) and \
+                (NM.DeviceState.DISCONNECTED < old <= NM.DeviceState.ACTIVATED):
+            error_msg = 'Connection disconnected with reason %s' % state_reason.value_nick
+        else:
+            return  # Keep checking the state changes
+
+        # We are done with state changes
+        device.disconnect_by_func(self._on_device_state_changed)
+        if error_msg is None:
+            self._return_or_reply_handler(reply_msg)
+        else:
+            logging.debug(error_msg)
+            self._raise_or_error_handler(NMConnectionError(error_msg))
+
+    def activate(self):
+        def on_connection_activate(client, result):
+            try:
+                self.active_connection = client.activate_connection_finish(result)
+            except GLib.Error as e:
+                self._raise_or_error_handler(e)
+
+        device = self.client.get_device_by_iface(self.bdaddr)
+        if not device:
+            self._raise_or_error_handler(NMConnectionError('Could not find device %s' % self.bdaddr))
+        elif device.get_state() == NM.DeviceState.ACTIVATED:
+            self._raise_or_error_handler(NMConnectionError('Device %s already activated' % self.bdaddr))
+        else:
+            device.connect('state-changed', self._on_device_state_changed)
+            self.client.activate_connection_async(self.connection, device, None, None, on_connection_activate)
+
+    def deactivate(self):
+        def on_connection_deactivate(client, result):
+            try:
+                client.deactivate_connection_finish(result)
+                self._return_or_reply_handler('Device %s deactivated sucessfully' % self.bdaddr)
+                self.active_connection = None
+            except GLib.Error as e:
+                self._raise_or_error_handler(e)
+
+        self.client.deactivate_connection_async(self.active_connection, None, on_connection_deactivate)
+
+    def find_or_create_connection(self):
+        if not self.connection_uuid:
+            self.create_connection()
+        else:
+            conn = self.client.get_connection_by_uuid(self.connection_uuid)
+            if conn is None:
+                self.create_connection()
+            else:
+                logging.debug('Found existing connection with uuid %s' % self.connection_uuid)
+                self.connection = conn
+
+                if self.conntype == 'dun':
+                    settings_gsm = conn.get_setting_gsm()
+
+                    if settings_gsm.props.apn != self.Config['apn']:
+                        logging.debug('Updating apn on connection to %s' % self.Config['apn'])
+                        settings_gsm.props.apn = self.Config['apn']
+                    if settings_gsm.props.number != self.Config['number']:
+                        logging.debug('Updating number on connection to %s' % self.Config['number'])
+                        settings_gsm.props.number = self.Config['number']
+
+                conn.commit_changes(True, None)
+
+        # Try to find active connection
+        for active_conn in self.client.get_active_connections():
+            conn = active_conn.get_connection()
+            if conn == self.connection:
+                self.active_connection = active_conn
+
+    @property
+    def connected(self):
+        if self.active_connection is None:
+            return False
+
+        state = self.active_connection.get_state()
+        if state == NM.ActiveConnectionState.CONNECTED:
+            return True
+        else:
+            return False
+
+    def create_connection(self):
+        raise NotImplementedError
+
+    def store_uuid(self, conn_uuid):
+        raise NotImplementedError
+
+    @property
+    def connection_uuid(self):
+        raise NotImplementedError
+
+
+class NMPANConnection(NMConnectionBase):
+    conntype = 'panu'
+
+    def store_uuid(self, conn_uuid):
+        self.Config['nmpanuuid'] = conn_uuid
+
+    @property
+    def connection_uuid(self):
+        # PANU connections are automatically created so attempt to find it
+        # It appears the Name property is used not Alias!
+        conn = self.client.get_connection_by_id('%s Network' % self.device['Name'])
+        if conn is not None:
+            conn_settings = conn.get_setting_connection()
+            return conn_settings.get_uuid()
+        else:
+            return self.Config['nmpanuuid']
+
+    def create_connection(self):
+        conn = NM.SimpleConnection()
+        conn_id = '%s Network' % self.device['Name']
+        conn_uuid = str(uuid.uuid4())
+
+        conn_sett = NM.SettingConnection(type='bluetooth', id=conn_id, uuid=conn_uuid, autoconnect=False)
+        conn_sett_bt = NM.SettingBluetooth(type=self.conntype, bdaddr=self.bdaddr)
+        conn.add_setting(conn_sett)
+        conn.add_setting(conn_sett_bt)
+
+        self.client.add_connection_async(conn, True, None, self._on_connection_added, conn_uuid)
+
+
+class NMDUNConnection(NMConnectionBase):
+    conntype = 'dun'
+
+    def store_uuid(self, conn_uuid):
+        self.Config['nmdunuuid'] = conn_uuid
+
+    @property
+    def connection_uuid(self):
+        return self.Config['nmdunuuid']
+
+    def create_connection(self):
+        if not self.Config['apn']:
+            self._raise_or_error_handler(NMConnectionError('No apn configured, make sure to configure dialup settings'))
+            return
+
+        conn = NM.SimpleConnection()
+        conn_id = 'blueman dun for %s' % self.device['Alias']
+        conn_uuid = str(uuid.uuid4())
+
+        conn_sett = NM.SettingConnection(type='bluetooth', id=conn_id, uuid=conn_uuid, autoconnect=False)
+        conn_sett_bt = NM.SettingBluetooth(type=self.conntype, bdaddr=self.bdaddr)
+        conn_sett_gsm = NM.SettingGsm(apn=self.Config['apn'], number=self.Config['number'])
+        conn.add_setting(conn_sett)
+        conn.add_setting(conn_sett_bt)
+        conn.add_setting(conn_sett_gsm)
+
+        self.client.add_connection_async(conn, True, None, self._on_connection_added, conn_uuid)

--- a/blueman/plugins/applet/NMDUNSupport.py
+++ b/blueman/plugins/applet/NMDUNSupport.py
@@ -1,107 +1,36 @@
 # coding=utf-8
 from blueman.plugins.AppletPlugin import AppletPlugin
-from gi.repository import Gio, GLib
-from blueman.gui.Notification import Notification
+from blueman.main.NetworkManager import NMDUNConnection
 from blueman.Sdp import DIALUP_NET_SVCLASS_ID
-from blueman.Functions import get_icon, composite_icon
-import weakref
-import logging
-
-
-class ConnectionHandler:
-    def __init__(self, parent, service, reply, err):
-        self.parent = parent
-        self.service = service
-        self.reply = reply
-        self.err = err
-        self.rfcomm_dev = None
-        self.timeout = None
-
-        self.signal_sub = self.parent._bus.signal_subscribe("org.freedesktop.ModemManager1",
-                                                            "org.freedesktop.DBus.ObjectManager",
-                                                            "InterfacesAdded",
-                                                            "/org/freedesktop/ModemManager1",
-                                                            None,
-                                                            Gio.DBusSignalFlags.NONE,
-                                                            self.on_interfaces_added)
-
-        # for some reason these handlers take a reference and don't give it back
-        # so i have to workaround :(
-        w = weakref.ref(self)
-        service.connect(reply_handler=lambda *args: w() and w().on_connect_reply(*args),
-                        error_handler=lambda *args: w() and w().on_connect_error(*args))
-
-    def on_connect_reply(self, rfcomm):
-        self.rfcomm_dev = rfcomm
-        self.timeout = GLib.timeout_add(20000, self.on_timeout)
-
-    def on_connect_error(self, *args):
-        self.err(*args)
-        self.cleanup()
-
-    def cleanup(self):
-        if self.timeout:
-            GLib.source_remove(self.timeout)
-
-        self.parent._bus.signal_unsubscribe(self.signal_sub)
-        self.signal_sub = None
-        self.service = None
-
-    def on_mm_device_added(self, path, name="org.freedesktop.ModemManager"):
-        logging.info(path)
-        interface = "%s.Modem" % name
-        res = self.parent._bus.call_sync(name, path, 'org.freedesktop.DBus.Properties', "GetAll",
-                                         GLib.Variant("(s)", (interface,)),
-                                         None, Gio.DBusCallFlags.NONE, GLib.MAXINT, None)
-        props = res.unpack()[0]
-
-        if self.rfcomm_dev and "bluetooth" in props["Drivers"] and self.rfcomm_dev.split('/')[-1] in props["Device"]:
-            logging.info("It's our bluetooth modem!")
-
-            modem = get_icon("modem", 24)
-            blueman = get_icon("blueman", 48)
-
-            icon = composite_icon(blueman, [(modem, 24, 24, 255)])
-
-            Notification(
-                _("Bluetooth Dialup"),
-                _("DUN connection on %s will now be available in Network Manager") % self.service.device['Alias'],
-                image_data=icon).show()
-
-            self.reply(self.rfcomm_dev)
-            self.cleanup()
-
-    def on_interfaces_added(self, connection, sender_name, object_path, interface_name, signal_name, param):
-        path, interfaces = param.unpack()
-        if 'org.freedesktop.ModemManager1.Modem' in interfaces:
-            self.on_mm_device_added(path, "org.freedesktop.ModemManager1")
-
-    def on_timeout(self):
-        self.timeout = None
-        self.err(GLib.Error(_("Modem Manager did not support the connection")))
-        self.cleanup()
 
 
 class NMDUNSupport(AppletPlugin):
     __depends__ = ["StatusIcon", "DBusService"]
     __conflicts__ = ["PPPSupport"]
     __icon__ = "modem"
-    __author__ = "Walmis"
+    __author__ = "infirit"
     __description__ = _("Provides support for Dial Up Networking (DUN) with ModemManager and NetworkManager")
     __priority__ = 1
 
     def on_load(self):
-        def on_dbus_connection_finnish(cancellable, result):
-            self._bus = Gio.bus_get_finish(result)
-
-        Gio.bus_get(Gio.BusType.SYSTEM, None, on_dbus_connection_finnish)
-
-    def on_unload(self):
         pass
 
-    def rfcomm_connect_handler(self, service, reply, err):
-        if DIALUP_NET_SVCLASS_ID == service.short_uuid:
-            ConnectionHandler(self, service, reply, err)
-            return True
-        else:
+    @staticmethod
+    def service_connect_handler(service, ok, err):
+        if DIALUP_NET_SVCLASS_ID != service.short_uuid:
             return False
+
+        conn = NMDUNConnection(service, ok, err)
+        conn.activate()
+
+        return True
+
+    @staticmethod
+    def service_disconnect_handler(service, ok, err):
+        if DIALUP_NET_SVCLASS_ID != service.short_uuid:
+            return False
+
+        conn = NMDUNConnection(service, ok, err)
+        conn.deactivate()
+
+        return True

--- a/blueman/plugins/applet/NMPANSupport.py
+++ b/blueman/plugins/applet/NMPANSupport.py
@@ -1,261 +1,35 @@
 # coding=utf-8
-from gi.repository import Gio, GLib
 from blueman.plugins.AppletPlugin import AppletPlugin
-from uuid import uuid4
-import logging
-
-
-class NewConnectionBuilder:
-    DEVICE_STATE_DISCONNECTED = 30
-    DEVICE_STATE_ACTIVATED = 100
-    DEVICE_STATE_DEACTIVATING = 110
-    DEVICE_STATE_FAILED = 120
-
-    def __init__(self, parent, service, ok_cb, err_cb):
-        self.parent = parent
-        self.ok_cb = ok_cb
-        self.err_cb = err_cb
-
-        self.device = None
-        self.connection = None
-
-        self.signal_subs = []
-
-        nm_sub = parent._bus.signal_subscribe(self.parent.nm_manager_name,
-                                              self.parent.nm_manager_interface,
-                                              'DeviceAdded',
-                                              None,
-                                              None,
-                                              Gio.DBusSignalFlags.NONE,
-                                              self.on_nm_device_added)
-        self.signal_subs.append(nm_sub)
-        nms_sub = parent._bus.signal_subscribe(self.parent.nm_manager_name,
-                                               self.parent.nm_settings_interface,
-                                               'NewConnection',
-                                               None,
-                                               None,
-                                               Gio.DBusSignalFlags.NONE,
-                                               self.on_nma_new_connection)
-        self.signal_subs.append(nms_sub)
-
-        self.device = self.parent.find_device(service.device['Address'])
-
-        self.connection = self.parent.find_connection(service.device['Address'], "panu")
-        if not self.connection:
-            # Newer versions that support BlueZ 5 add a default connection automatically
-            # However users may have removed the connection and we error out
-            addr_bytes = bytearray.fromhex(service.device['Address'].replace(':', ' '))
-            parent.nm_settings.AddConnection('(a{sa{sv}})', {
-                'connection': {'id': GLib.Variant.new_string('%s Network' % service.device['Alias']),
-                               'uuid': GLib.Variant.new_string(str(uuid4())),
-                               'autoconnect': GLib.Variant.new_boolean(False),
-                               'type': GLib.Variant.new_string('bluetooth')},
-                'bluetooth': {'bdaddr': GLib.Variant.new_bytestring_array(addr_bytes),
-                              'type': GLib.Variant.new_string('panu')},
-                'ipv4': {'method': GLib.Variant.new_string('auto')},
-                'ipv6': {'method': GLib.Variant.new_string('auto')}
-            })
-            GLib.timeout_add(1000, self.signal_wait_timeout)
-        else:
-            self.init_connection()
-
-    def cleanup(self):
-        for sub in self.signal_subs:
-            self.parent._bus.signal_unsubscribe(sub)
-        self.signal_subs = []
-
-    def signal_wait_timeout(self):
-        if not self.device or not self.connection:
-            self.err_cb(GLib.Error("Network Manager did not support the connection"))
-            self.cleanup()
-
-    def on_nm_device_added(self, connection, sender_name, object_path, interface_name, signal_name, param):
-        logging.info(object_path)
-        self.device = object_path
-        if self.device and self.connection:
-            self.init_connection()
-
-    def on_nma_new_connection(self, connection, sender_name, object_path, interface_name, signal_name, param):
-        logging.info(object_path)
-        self.connection = object_path
-        if self.device and self.connection:
-            self.init_connection()
-
-    def init_connection(self):
-        self.cleanup()
-        logging.info("activating %s %s" % (self.connection, self.device))
-        if not self.device or not self.connection:
-            self.err_cb(GLib.Error("Network Manager did not support the connection"))
-            self.cleanup()
-        else:
-            sub = self.parent._bus.signal_subscribe(self.parent.nm_manager_name,
-                                                    'org.freedesktop.NetworkManager.Device',
-                                                    'StateChanged',
-                                                    self.device,
-                                                    None,
-                                                    Gio.DBusSignalFlags.NONE,
-                                                    self.on_device_state)
-
-            self.signal_subs.append(sub)
-            args = [self.connection, self.device, self.connection]
-
-            self.parent.nm_manager.ActivateConnection('(ooo)', *args)
-
-    def on_device_state(self, connection, sender_name, object_path, interface_name, signal_name, param):
-        state, oldstate, reason = param.unpack()
-        logging.info("state=%s oldstate=%s reason=%s" % (state, oldstate, reason))
-        if (state <= self.DEVICE_STATE_DISCONNECTED or state == self.DEVICE_STATE_DEACTIVATING) and \
-                self.DEVICE_STATE_DISCONNECTED < oldstate <= self.DEVICE_STATE_ACTIVATED:
-            if self.err_cb:
-                self.err_cb(GLib.Error("Connection was interrupted"))
-
-            self.cleanup()
-
-        elif state == self.DEVICE_STATE_FAILED:
-            self.err_cb(GLib.Error("Network Manager Failed to activate the connection"))
-            self.cleanup()
-
-        elif state == self.DEVICE_STATE_ACTIVATED:
-            self.ok_cb()
-            self.err_cb = None
-            self.ok_cb = None
+from blueman.main.NetworkManager import NMPANConnection
 
 
 class NMPANSupport(AppletPlugin):
     __depends__ = ["DBusService"]
     __conflicts__ = ["DhcpClient"]
     __icon__ = "network"
-    __author__ = "Walmis"
+    __author__ = "infirit"
     __description__ = _("Provides support for Personal Area Networking (PAN) introduced in NetworkManager 0.8")
     __priority__ = 2
 
     def on_load(self):
-        self.nm_manager = None
-        self.nm_settings = None
-        self.watch_id = None
-
-        self.nm_manager_name = self.nm_manager_interface = 'org.freedesktop.NetworkManager'
-        self.nm_manager_path = '/org/freedesktop/NetworkManager'
-        self.nm_settings_interface = 'org.freedesktop.NetworkManager.Settings'
-        self.connection_settings_interface = 'org.freedesktop.NetworkManager.Settings.Connection'
-        self.nm_settings_path = "/org/freedesktop/NetworkManager/Settings"
-
-        Gio.bus_get(Gio.BusType.SYSTEM, None, self.on_dbus_connection_finnish)
-
-    def on_dbus_connection_finnish(self, cancellable, result):
-        self._bus = Gio.bus_get_finish(result)
-        watch = Gio.bus_watch_name(Gio.BusType.SYSTEM,
-                                   self.nm_manager_name,
-                                   Gio.BusNameWatcherFlags.NONE,
-                                   self.on_name_appeared, self.on_name_vanished)
-        self.watch_id = watch
-
-    def on_name_appeared(self, connection, name, owner):
-        Gio.DBusProxy.new(connection,
-                          Gio.DBusProxyFlags.NONE,
-                          None,
-                          self.nm_manager_name,
-                          self.nm_manager_path,
-                          self.nm_manager_interface,
-                          None,
-                          self.on_proxy_finnish,
-                          'nm-manager')
-
-        Gio.DBusProxy.new(connection,
-                          Gio.DBusProxyFlags.NONE,
-                          None,
-                          self.nm_manager_name,
-                          self.nm_settings_path,
-                          self.nm_settings_interface,
-                          None,
-                          self.on_proxy_finnish,
-                          'nm-settings')
-
-    def on_name_vanished(self, connection, name):
-        self.nm_manager = None
-        self.nm_settings = None
-
-    def on_proxy_finnish(self, proxy, result, nm_name):
-        nm_proxy = proxy.new_finish(result)
-        if nm_name == 'nm-manager':
-            self.nm_manager = nm_proxy
-        elif nm_name == 'nm-settings':
-            self.nm_settings = nm_proxy
+        pass
 
     @staticmethod
-    def format_bdaddr(addr):
-        return "%02X:%02X:%02X:%02X:%02X:%02X" % (addr[0], addr[1], addr[2], addr[3], addr[4], addr[5])
-
-    def find_device(self, bdaddr):
-        devices = self.nm_manager.GetDevices()
-        for dev in devices:
-            try:
-                d = self._bus.call_sync(self.nm_manager_name, dev, "org.freedesktop.DBus.Properties", "GetAll",
-                                        GLib.Variant("(s)", ("org.freedesktop.NetworkManager.Device.Bluetooth",)),
-                                        None, Gio.DBusCallFlags.NONE, GLib.MAXINT, None).unpack()[0]
-
-                if d["HwAddress"] == bdaddr:
-                    logging.info(d["HwAddress"])
-                    return dev
-
-            except GLib.Error:
-                pass
-
-    def find_connection(self, address, t):
-        conns = self.nm_settings.ListConnections()
-        for conn in conns:
-            c = self._bus.call_sync(self.nm_manager_name, conn, self.connection_settings_interface, "GetSettings",
-                                    None, None, Gio.DBusCallFlags.NONE, GLib.MAXINT, None).unpack()[0]
-            if "bluetooth" not in c:
-                continue
-
-            if (self.format_bdaddr(c["bluetooth"]["bdaddr"]) == address) and c["bluetooth"]["type"] == t:
-                return conn
-
-    def find_active_connection(self, address, conntype):
-        props = self._bus.call_sync(self.nm_manager_name, self.nm_manager_path,
-                                    "org.freedesktop.DBus.Properties", "GetAll",
-                                    GLib.Variant("(s)", ("org.freedesktop.NetworkManager",)), None,
-                                    Gio.DBusCallFlags.NONE, GLib.MAXINT, None).unpack()[0]
-
-        nma_connection = self.find_connection(address, conntype)
-        if nma_connection:
-            active_conns = props["ActiveConnections"]
-            for conn in active_conns:
-                conn_props = self._bus.call_sync(
-                    self.nm_manager_name, conn,
-                    "org.freedesktop.DBus.Properties", "GetAll",
-                    GLib.Variant("(s)", ("org.freedesktop.NetworkManager.Connection.Active",)),
-                    None, Gio.DBusCallFlags.NONE, GLib.MAXINT, None
-                ).unpack()[0]
-
-                if conn_props["Connection"] == nma_connection:
-                    return conn
-
-    def on_unload(self):
-        Gio.bus_unwatch_name(self.watch_id)
-
-    def service_connect_handler(self, service, ok, err):
+    def service_connect_handler(service, ok, err):
         if service.group != 'network':
-            return
+            return False
 
-        if self.find_active_connection(service.device['Address'], "panu"):
-            err(GLib.Error(_("Already connected")))
-        else:
-            NewConnectionBuilder(self, service, ok, err)
+        conn = NMPANConnection(service, ok, err)
+        conn.activate()
 
         return True
 
-    def service_disconnect_handler(self, service, ok, err):
+    @staticmethod
+    def service_disconnect_handler(service, ok, err):
         if service.group != 'network':
-            return
+            return False
 
-        d = service.device
-        active_conn_path = self.find_active_connection(d['Address'], "panu")
+        conn = NMPANConnection(service, ok, err)
+        conn.deactivate()
 
-        if not active_conn_path:
-            return
-
-        self.nm_manager.DeactivateConnection('(o)', active_conn_path)
-        ok()
         return True

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -82,7 +82,7 @@ class Services(ManagerPlugin):
                     item.show()
                     items.append((item, 201))
 
-        if self.has_dun and "PPPSupport" in appl.QueryPlugins():
+        if self.has_dun and ('PPPSupport' in appl.QueryPlugins() or 'NMDUNSupport' in appl.QueryPlugins()):
             def open_settings(i, device):
                 from blueman.gui.GsmSettings import GsmSettings
 

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -86,6 +86,16 @@
       <summary>PhoneNumber</summary>
       <description>Phone Number</description>
     </key>
+    <key type="s" name="nmdunuuid">
+      <default>""</default>
+      <summary>NM DUN Connection uuid</summary>
+      <description>The uuid of the NM DUN Connection which may not exist anymore</description>
+    </key>
+    <key type="s" name="nmpanuuid">
+      <default>""</default>
+      <summary>NM PANU Connection uuid</summary>
+      <description>The uuid of the NM PANU Connection which may not exist anymore</description>
+    </key>
   </schema>
   <schema id="org.blueman.plugins.killswitch" path="/org/blueman/plugins/killswitch/">
     <key type="b" name="checked">


### PR DESCRIPTION
Putting my work here as it is mostly done. Still need to clean a few things.

 * make sure error and reply handlers are reaching blueman-manager properly
 * Handle apn/number changes
 * Update the Service manager plugin to show the GsmSettings menu for NMDUNSupport

There is no api exposed over bluez dbus for DUN connection to check if it is actually connected like there is for PANU. It is trivial to get this from NM but afaics we have no functionality to communicate this to blueman-manager. Not sure if it is worth the effort though but if I can figure out a simple way I'll open a separate PR for this.