### PR TITLE
Dialog with no parent

### DIFF
--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -86,17 +86,17 @@ class SettingsWidget(Gtk.Box):
             return b
 
 
-class PluginDialog(Gtk.Dialog):
+class PluginDialog(Gtk.Window):
     def __init__(self, applet):
         super().__init__(
-            buttons=("_Close", Gtk.ResponseType.CLOSE),
             title=_("Plugins"),
             icon_name="blueman",
             name="PluginDialog",
             border_width=6,
             default_width=490,
             default_height=380,
-            resizable=False
+            resizable=False,
+            visible=False
         )
 
         self.applet = applet
@@ -121,11 +121,9 @@ class PluginDialog(Gtk.Dialog):
         self.b_prefs = self.Builder.get_object("b_prefs")
         self.b_prefs.connect("toggled", self.on_prefs_toggled)
 
-        widget = self.Builder.get_object("all")
-
         ref = weakref.ref(self)
 
-        self.vbox.pack_start(widget, True, True, 0)
+        self.add(self.Builder.get_object("all"))
 
         cr = Gtk.CellRendererToggle()
         cr.connect("toggled", lambda *args: ref() and ref().on_toggled(*args))
@@ -160,7 +158,7 @@ class PluginDialog(Gtk.Dialog):
 
         self.sig_a = self.applet.Plugins.connect("plugin-loaded", self.plugin_state_changed, True)
         self.sig_b = self.applet.Plugins.connect("plugin-unloaded", self.plugin_state_changed, False)
-        self.connect("response", self.on_response)
+        self.connect("delete-event", self._on_close)
 
         self.list.set_cursor(0)
 
@@ -182,7 +180,7 @@ class PluginDialog(Gtk.Dialog):
             elif not a["activatable"] and b["activatable"]:
                 return 1
 
-    def on_response(self, dialog, resp):
+    def _on_close(self, *args, **kwargs):
         self.applet.Plugins.disconnect(self.sig_a)
         self.applet.Plugins.disconnect(self.sig_b)
 

--- a/blueman/main/Adapter.py
+++ b/blueman/main/Adapter.py
@@ -14,30 +14,29 @@ from gi.repository import Gtk
 from gi.repository import Pango
 
 
-class BluemanAdapters(Gtk.Dialog):
+class BluemanAdapters(Gtk.Window):
     def __init__(self, selected_hci_dev, socket_id):
-        super(BluemanAdapters, self).__init__(title=_("Bluetooth Adapters"))
-        # Setup dialog
-        self.set_border_width(5)
-        self.set_resizable(False)
-        self.props.icon_name = "blueman-device"
-        self.props.window_position = Gtk.WindowPosition.CENTER
-        self.set_name("BluemanAdapters")
-        self.connect("response", self.on_dialog_response)
+        super().__init__(
+            title=_("Bluetooth Adapters"),
+            border_width=5,
+            resizable=False,
+            icon_name="blueman-device",
+            name="BluemanAdapters"
+        )
+        self.connect("delete-event", self._on_close)
 
-        close_button = self.add_button("_Close", Gtk.ResponseType.CLOSE)
-        close_button.props.receives_default = True
-        close_button.props.use_underline = True
+        self.notebook = Gtk.Notebook(visible=True)
 
-        self.notebook = Gtk.Notebook()
         if socket_id:
             plug = Gtk.Plug.new(socket_id)
-            plug.connect('delete-event', lambda _plug, _event: Gtk.main_quit())
-            plug.add(self.notebook)
             plug.show()
+            plug.connect('delete-event', self._on_close)
+            plug.add(self.notebook)
         else:
-            self.get_content_area().add(self.notebook)
+            self.add(self.notebook)
+            self.connect("delete-event", self._on_close)
             self.show()
+
         self.tabs = {}
         self._adapters = {}
 
@@ -72,7 +71,7 @@ class BluemanAdapters(Gtk.Dialog):
                 logging.error('Error: the selected adapter does not exist')
         self.notebook.show_all()
 
-    def on_dialog_response(self, dialog, response_id):
+    def _on_close(self, *args, **kwargs):
         Gtk.main_quit()
 
     def on_property_changed(self, adapter, name, value, path):

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -98,7 +98,7 @@ class Sender(Gtk.Dialog):
             if 'StartServiceByName' in e.message:
                 logging.debug(e.message)
                 d = ErrorDialog(_("obexd not available"), _("Failed to autostart obex service. Make sure the obex "
-                                                            "daemon is running"))
+                                                            "daemon is running"), parent=self.get_toplevel())
                 d.run()
                 d.destroy()
                 exit(1)
@@ -215,7 +215,7 @@ class Sender(Gtk.Dialog):
         if not self.error_dialog:
             self.speed.reset()
             d = ErrorDialog(msg, _("Error occurred while sending file %s") % os.path.basename(self.files[-1]),
-                            modal=True, icon_name="blueman")
+                            modal=True, icon_name="blueman", parent=self.get_toplevel())
 
             if len(self.files) > 1:
                 d.add_button(_("Skip"), Gtk.ResponseType.NO)
@@ -257,7 +257,9 @@ class Sender(Gtk.Dialog):
         self.process_queue()
 
     def on_session_failed(self, _client, msg):
-        d = ErrorDialog(_("Error occurred"), msg.reason.split(None, 1)[1], icon_name="blueman")
+        d = ErrorDialog(_("Error occurred"), msg.reason.split(None, 1)[1], icon_name="blueman",
+                        parent=self.get_toplevel())
+
         d.run()
         d.destroy()
         exit(1)

--- a/blueman/main/Services.py
+++ b/blueman/main/Services.py
@@ -13,40 +13,38 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 
-class BluemanServices(Gtk.Dialog):
+class BluemanServices(Gtk.Window):
     def __init__(self):
         super().__init__(
             title=_("Local Services"),
             name="BluemanServices",
             icon_name="blueman",
-            default_width=520,
-            default_height=420,
             border_width=5
 
         )
 
-        self.b_apply = self.add_button("_Apply", Gtk.ResponseType.APPLY)
-        self.b_apply.props.receives_default = True
-        self.b_apply.props.sensitive = False
-        self.b_apply.props.use_underline = True
-
-        self.b_close = self.add_button("_Close", Gtk.ResponseType.CLOSE)
-        self.b_close.props.use_underline = True
-
-        self.content_area = self.get_content_area()
+        grid = Gtk.Grid(orientation=Gtk.Orientation.VERTICAL, visible=True, row_spacing=10)
+        self.add(grid)
 
         self.box = Gtk.Box(Gtk.Orientation.HORIZONTAL, vexpand=True, visible=True)
+        grid.add(self.box)
+
+        button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, halign=Gtk.Align.END, visible=True)
+        grid.add(button_box)
+
+        self.b_apply = Gtk.Button("_Apply", receives_default=True, use_underline=True, sensitive=False, visible=True,
+                                  width_request=80)
+        button_box.add(self.b_apply)
 
         self.viewport = Gtk.Viewport(visible=True, width_request=120)
 
         self.box.add(self.viewport)
-        self.content_area.add(self.box)
 
         self.connect("delete-event", Gtk.main_quit)
 
         self.Config = Config("org.blueman.general")
 
-        check_single_instance("blueman-services", lambda time: self.Dialog.present_with_time(time))
+        check_single_instance("blueman-services", lambda time: self.present_with_time(time))
 
         data = [
             {"id": "icon_name", "type": str, "renderer": Gtk.CellRendererPixbuf(stock_size=Gtk.IconSize.DND),
@@ -67,7 +65,6 @@ class BluemanServices(Gtk.Dialog):
         ls.selection.select_path(self.Config["services-last-item"])
 
         self.b_apply.connect("clicked", self.on_apply_clicked)
-        self.b_close.connect("clicked", Gtk.main_quit)
 
         self.show()
 

--- a/blueman/main/Services.py
+++ b/blueman/main/Services.py
@@ -15,12 +15,15 @@ from gi.repository import Gtk
 
 class BluemanServices(Gtk.Dialog):
     def __init__(self):
-        super(BluemanServices, self).__init__(title=_("Local Services"))
-        self.resize(520, 420)
-        self.set_name("BluemanServices")
-        self.set_position(Gtk.WindowPosition.CENTER)
-        self.props.border_width = 5
-        self.props.icon_name = "blueman"
+        super().__init__(
+            title=_("Local Services"),
+            name="BluemanServices",
+            icon_name="blueman",
+            default_width=520,
+            default_height=420,
+            border_width=5
+
+        )
 
         self.b_apply = self.add_button("_Apply", Gtk.ResponseType.APPLY)
         self.b_apply.props.receives_default = True
@@ -32,13 +35,9 @@ class BluemanServices(Gtk.Dialog):
 
         self.content_area = self.get_content_area()
 
-        self.box = Gtk.Box(Gtk.Orientation.HORIZONTAL)
-        self.box.props.vexpand = True
-        self.box.props.visible = True
+        self.box = Gtk.Box(Gtk.Orientation.HORIZONTAL, vexpand=True, visible=True)
 
-        self.viewport = Gtk.Viewport()
-        self.viewport.props.visible = True
-        self.viewport.props.width_request = 120
+        self.viewport = Gtk.Viewport(visible=True, width_request=120)
 
         self.box.add(self.viewport)
         self.content_area.add(self.box)
@@ -57,14 +56,11 @@ class BluemanServices(Gtk.Dialog):
             {"id": "id", "type": str},
         ]
 
-        ls = GenericList(data)
-        ls.props.headers_visible = False
+        self.List = ls = GenericList(data, headers_visible=False, visible=True)
 
         ls.selection.connect("changed", self.on_selection_changed)
-        self.List = ls
 
         self.viewport.add(ls)
-        ls.show()
 
         self.load_plugins()
 

--- a/blueman/plugins/applet/StandardItems.py
+++ b/blueman/plugins/applet/StandardItems.py
@@ -6,7 +6,7 @@ from blueman.gui.applet.PluginDialog import PluginDialog
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk
 
 
 class StandardItems(AppletPlugin):
@@ -16,6 +16,7 @@ class StandardItems(AppletPlugin):
     __author__ = "walmis"
 
     def on_load(self):
+        self._plugin_window = None
 
         self.parent.Plugins.Menu.add(self, 21)
 
@@ -97,8 +98,13 @@ class StandardItems(AppletPlugin):
         about.destroy()
 
     def on_plugins(self):
-        def open_dialog():
-            dialog = PluginDialog(self.parent)
-            dialog.run()
-            dialog.destroy()
-        GLib.idle_add(open_dialog)
+        def on_close(win, event):
+            win.destroy()
+            self._plugin_window = None
+
+        if self._plugin_window:
+            self._plugin_window.present()
+        else:
+            self._plugin_window = PluginDialog(self.parent)
+            self._plugin_window.connect("delete-event", on_close)
+            self._plugin_window.show()

--- a/data/ui/applet-plugins-widget.ui
+++ b/data/ui/applet-plugins-widget.ui
@@ -12,7 +12,7 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <child>
-      <object class="GtkScrolledWindow" id="viewport">
+      <object class="GtkScrolledWindow" id="plugin_list">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="hscrollbar_policy">never</property>
@@ -107,7 +107,7 @@
                 <property name="can_focus">False</property>
                 <property name="row_spacing">12</property>
                 <child>
-                  <object class="GtkLabel" id="label2">
+                  <object class="GtkLabel" id="plugin_description_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>

--- a/data/ui/services-network.ui
+++ b/data/ui/services-network.ui
@@ -7,6 +7,7 @@
     <property name="can_focus">False</property>
     <property name="margin_left">12</property>
     <property name="margin_top">10</property>
+    <property name="hexpand">True</property>
     <property name="label_xalign">0</property>
     <property name="shadow_type">none</property>
     <child>

--- a/data/ui/services-transfer.ui
+++ b/data/ui/services-transfer.ui
@@ -4,6 +4,7 @@
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkFrame" id="transfer">
     <property name="can_focus">False</property>
+    <property name="hexpand">True</property>
     <property name="border_width">6</property>
     <property name="label_xalign">0</property>
     <property name="shadow_type">none</property>


### PR DESCRIPTION
This turns all dialogs with not parent into normal windows. If there is a parent pass it to the dialog.

I left blueman-sendto as I rather redo it and deal with it then.

This was split from #789 as it is getting too big. There will be another PR for other cleanups.

edit: remove unused import flake8 reported