### PR TITLE
Avoid authorization check

### DIFF
--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -349,12 +349,6 @@ class NetConf(object):
         return type(self.dhcp_handler)
 
     def apply_settings(self):
-        if self.ip4_address is None or self.ip4_mask is None:
-            if self.ip4_changed:
-                self.ip4_changed = False
-            self.store()
-            return
-
         if self != NetConf.get_default():
             NetConf.get_default().remove_settings()
             NetConf.default_inst = self

--- a/blueman/plugins/mechanism/Network.py
+++ b/blueman/plugins/mechanism/Network.py
@@ -45,8 +45,13 @@ class Network(MechanismPlugin):
 
     @dbus.service.method('org.blueman.Mechanism', in_signature="", out_signature="", sender_keyword="caller")
     def ReloadNetwork(self, caller):
-        self.confirm_authorization(caller, "org.blueman.network.setup")
         nc = NetConf.get_default()
+        if nc.ip4_address is None or nc.ip4_mask is None:
+            nc.ip4_changed = False
+            nc.store()
+            return
+
+        self.confirm_authorization(caller, "org.blueman.network.setup")
         nc.apply_settings()
 
     @dbus.service.method('org.blueman.Mechanism', in_signature="", out_signature="", sender_keyword="caller")


### PR DESCRIPTION
We might ask for network setup authorization even if no network settings are configured and we do not actually set anything up. Moving the check in front of the confirmation should avoid that.

Fixes #948