### PR TITLE
Add default polkit rules

### DIFF
--- a/data/configs/Makefile.am
+++ b/data/configs/Makefile.am
@@ -9,9 +9,12 @@ dbus_sess_DATA = blueman-applet.service
 
 if HAVE_POLKIT
 @INTLTOOL_POLICY_RULE@ 
-policykitdir = $(datadir)/polkit-1/actions
-policykit_in_files = org.blueman.policy.in
-policykit_DATA = $(policykit_in_files:.policy.in=.policy)
+policykitactionsdir = $(datadir)/polkit-1/actions
+policykitactions_in_files = org.blueman.policy.in
+policykitactions_DATA = $(policykitactions_in_files:.policy.in=.policy)
+
+policykitrulesdir = $(datadir)/polkit-1/rules.d
+policykitrules_DATA = blueman.rules
 endif
 
 EXTRA_DIST = org.blueman.Mechanism.conf		\

--- a/data/configs/blueman.rules
+++ b/data/configs/blueman.rules
@@ -1,0 +1,10 @@
+/* Allow users in wheel group to use blueman feature requiring root without authentication */
+polkit.addRule(function(action, subject) {
+    if ((action.id == "org.blueman.network.setup" ||
+         action.id == "org.blueman.dhcp.client" ||
+         action.id == "org.blueman.rfkill.setstate" ||
+         action.id == "org.blueman.pppd.pppconnect") &&
+        subject.isInGroup("wheel")) {
+        return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
At least in Arch it seems to be a policy to not change any sources, so its users currently do not get any rules that allow admin users to use privileged features. We now install a default rules file that targets the standard wheel group.

Cherry-picked 7df40b57.