### PR TITLE
Class id is not handle in several places so revert for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * Avoid authorization check
 * Use GtkWindow for instead of a GtkDialog when there is no parent
 * Stop using and remove TimeHint
-* Bump NetConf class_id because of backwards incompatible changes. This will reset your network configuration
 
 ### Bugs fixed
 

--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -253,7 +253,7 @@ class UdhcpdHandler(object):
             self.netconf.unlock("dhcp")
 
 
-class_id = 11
+class_id = 10
 
 
 class NetConf(object):


### PR DESCRIPTION
changes in class_id do not work as I had thought so revert for now

I have been thinking and experimenting with moving ip, netmask and dhcphandler to gsettings. It will move the logic into applet plugins but this is not ready yet for this alpha.