### PR TITLE
Add elementary-xfce as compatible icon-theme

### DIFF
--- a/Dependencies.md
+++ b/Dependencies.md
@@ -8,7 +8,7 @@
 * [GdkPixbuf](http://www.gtk.org/) (GI bindings)
 * [GLib 2, Gio 2](http://www.gtk.org/) (>= 2.32) (GI bindings)
 * [GTK+ 3](http://www.gtk.org/) (GI bindings) [1]
-* [gnome-icon-theme](https://git.gnome.org/browse/adwaita-icon-theme/) or [mate-icon-theme](https://github.com/mate-desktop/mate-icon-theme)
+* [gnome-icon-theme](https://git.gnome.org/browse/adwaita-icon-theme/) or [mate-icon-theme](https://github.com/mate-desktop/mate-icon-theme) or [elementary-xfce](https://github.com/shimmerproject/elementary-xfce)
 * [libappindicator](https://launchpad.net/libappindicator) (optional) (GI bindings)
 * [notification-daemon](https://developer.gnome.org/notification-spec/) that provides dbus name org.freedesktop.Notifications
 * [obexd 5](http://www.bluez.org/)


### PR DESCRIPTION
Some time ago I identified elementary-xfce as an additional compatible icon theme. It actually looks like it's currently the only one that provides all of the icon names that we use (mate-icon-theme and gnome-icon-theme e.g. lack `menu-editor`).