### PR TITLE
Change network plugins icons

### DIFF
--- a/blueman/plugins/applet/DhcpClient.py
+++ b/blueman/plugins/applet/DhcpClient.py
@@ -9,7 +9,7 @@ from blueman.main.DBusProxies import Mechanism
 
 class DhcpClient(AppletPlugin):
     __description__ = _("Provides a basic dhcp client for Bluetooth PAN connections.")
-    __icon__ = "network"
+    __icon__ = "network-workgroup"
     __author__ = "Walmis"
 
     _any_network = None

--- a/blueman/plugins/applet/NMPANSupport.py
+++ b/blueman/plugins/applet/NMPANSupport.py
@@ -6,7 +6,7 @@ from blueman.main.NetworkManager import NMPANConnection
 class NMPANSupport(AppletPlugin):
     __depends__ = ["DBusService"]
     __conflicts__ = ["DhcpClient"]
-    __icon__ = "network"
+    __icon__ = "network-workgroup"
     __author__ = "infirit"
     __description__ = _("Provides support for Personal Area Networking (PAN) introduced in NetworkManager 0.8")
     __priority__ = 2

--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -9,7 +9,7 @@ import logging
 
 
 class Networking(AppletPlugin):
-    __icon__ = "network"
+    __icon__ = "network-workgroup"
     __description__ = _("Manages local network services, like NAP bridges")
     __author__ = "Walmis"
 


### PR DESCRIPTION
As discussed in #976 the network icon is not part of the Icon Naming Specification and there is no specific need for it.