### PR TITLE
Replace some menu icons

### DIFF
--- a/blueman/plugins/manager/Info.py
+++ b/blueman/plugins/manager/Info.py
@@ -105,7 +105,7 @@ class Info(ManagerPlugin):
         pass
 
     def on_request_menu_items(self, manager_menu, device):
-        item = create_menuitem(_("_Info"), "info")
+        item = create_menuitem(_("_Info"), "dialog-information")
         item.props.tooltip_text = _("Show device information")
         item.connect('activate', lambda x: show_info(device, manager_menu.get_toplevel()))
         return [(item, 400)]

--- a/blueman/plugins/manager/Notes.py
+++ b/blueman/plugins/manager/Notes.py
@@ -49,7 +49,7 @@ class Notes(ManagerPlugin):
         pass
 
     def on_request_menu_items(self, manager_menu, device):
-        item = create_menuitem(_("Send _note"), "info")
+        item = create_menuitem(_("Send _note"), "dialog-information")
         item.props.tooltip_text = _("Send a text note")
         item.connect('activate', lambda x: send_note(device, manager_menu.get_toplevel()))
         return [(item, 500)]

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -94,7 +94,7 @@ class Services(ManagerPlugin):
             item.show()
             serial_items.append(item)
 
-            item = create_menuitem(_("Dialup Settings"), "gtk-preferences")
+            item = create_menuitem(_("Dialup Settings"), "preferences-other")
             serial_items.append(item)
             item.show()
             item.connect("activate", open_settings, device)


### PR DESCRIPTION
gtk-preferences -> preferences-other
info -> dialog-information

This improves compatiblity with the Icon Naming Specification and themes like adwaita-icon-theme and Papirus (#976)