### PR TITLE
Small 'unknown' class bugfix

### DIFF
--- a/blueman/DeviceClass.py
+++ b/blueman/DeviceClass.py
@@ -232,6 +232,10 @@ gatt_appearance_categories = {
 
 
 def get_major_class(klass):
+    # class might be 'unknown'
+    if(type(klass) == str):
+        return klass
+
     index = (klass >> 8) & 0x1F
 
     if index > 8:


### PR DESCRIPTION
This bug was preventing the blueman-manager to start in my case because klass was a string. After this fix it shows 'Unknown' in the device list instead of crashing.