### PR TITLE
Update pindb from gnome-bluetooth

### DIFF
--- a/data/pin-code-database.xml
+++ b/data/pin-code-database.xml
@@ -61,22 +61,6 @@
 	     with a OUI from Alps Electric -->
 	<device vendor="alps" name="BD Remote Control" pin="NULL"/>
 
-	<!-- Apple Wireless and Mighty Mouse
-	     Note: Apple doesn't follow the specs, and requires their mice
-	     to be paired -->
-	<device vendor="apple" type="mouse" pin="0000"/>
-
-	<!-- Apple Magic Trackpad
-	     Note: same as above, tablet needs to be paired -->
-	<device vendor="apple" type="tablet" pin="0000"/>
-
-	<!-- Microsoft mice
-	     Again, same as above -->
-	<device oui="7C:1E:52:" type="mouse" name="Microsoft Wedge Touch Mouse" pin="0000"/>
-	<device oui="00:1D:D8:" type="mouse" name="Microsoft Wireless Notebook Presenter Mouse 8000" pin="0000"/>
-	<device oui="28:18:78:" type="mouse" name="Microsoft Sculpt Comfort Mouse" pin="0000"/>
-	<device oui="30:59:B7:" type="mouse" name="Microsoft Sculpt Comfort Mouse" pin="0000"/>
-
 	<!-- BT-GPS8 JENTRO, GPS mouse -->
 	<device oui="00:0D:B5:" name="BT-GPS8 JENTRO" pin="0000"/>
 
@@ -86,8 +70,8 @@
 	<!-- ION iCade Game Controller -->
 	<device name="iCade" type="keyboard" pin="ICADE"/>
 
-	<!-- Logitech Ultrathin Touch Mouse -->
-	<device oui="00:1F:20:" name="Ultrathin Touch Mouse" pin="0000"/>
+	<!-- Wacom Graphire Bluetooth -->
+	<device name="WACOM Pen Tablet" type="mouse" pin="NULL"/>
 
 <!-- GPS devices -->
 	<device oui="00:0D:B5:" name="TomTom Wireless GPS MkII" pin="0000"/>
@@ -151,20 +135,13 @@
 
 <!-- Audio devices -->
 
-	<!-- http://bugzilla.gnome.org/show_bug.cgi?id=560315 -->
-	<device type="headset" name="X3 micro" pin="1234"/>
+	<!-- http://bugzilla.gnome.org/show_bug.cgi?id=583651 -->
+	<device type="audio" oui="00:1A:80:" name="CMT-DH5BT" pin="max:4"/>
 
-	<!-- http://bugzilla.gnome.org/show_bug.cgi?id=561324 -->
-	<device type="headset" oui="00:03:C9:" name="BT Headset" pin="1111"/>
-
-	<!-- http://bugzilla.gnome.org/show_bug.cgi?id=573059 -->
-	<device type="headset" oui="00:12:A1:" name="BT Stereo Headset" pin="1234"/>
+<!-- Other devices -->
 
 	<!-- http://bugzilla.gnome.org/show_bug.cgi?id=561325 -->
 	<device type="network" oui="00:06:66:" name="OBDPros scantool" pin="1234"/>
-
-	<!-- http://bugzilla.gnome.org/show_bug.cgi?id=583651 -->
-	<device type="audio" oui="00:1A:80:" name="CMT-DH5BT" pin="max:4"/>
 
 <!-- Generic types -->
 
@@ -173,11 +150,6 @@
 
 	<!-- Joypads and joysticks -->
 	<device type="joypad" pin="0000"/>
-
-	<!-- Headphones and headsets -->
-	<device type="headphones" pin="0000"/>
-	<device type="headset" pin="0000"/>
-	<device type="audio" pin="0000"/>
 
 	<!-- Keyboard need a special help text -->
 	<device type="keyboard" pin="KEYBOARD"/>


### PR DESCRIPTION
I verified that the changes in the git log from gnome-bluetooth make sense for blueman. They removed a lot of default pins as BlueZ now handles this through the autopair plugin.