### PR TITLE
Sendto fixes

### DIFF
--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -114,6 +114,7 @@ class SendTo:
         adapter_name = os.path.split(self.adapter_path)[-1]
         d = DeviceSelectorDialog(discover=False, adapter_name=adapter_name)
         resp = d.run()
+        d.close()
         if resp == Gtk.ResponseType.ACCEPT:
             if d.selection:
                 self.adapter_path, self.device = d.selection

--- a/blueman/bluez/AnyBase.py
+++ b/blueman/bluez/AnyBase.py
@@ -16,7 +16,7 @@ class AnyBase(GObject.GObject):
     __bus_interface_name = 'org.freedesktop.DBus.Properties'
 
     def __init__(self, interface_name):
-        super(AnyBase, self).__init__()
+        super().__init__()
 
         self.__interface_name = interface_name
         self.__signal = None

--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -53,7 +53,7 @@ class Base(Gio.DBusProxy, metaclass=BaseMeta):
     }
 
     def __init__(self, interface_name, obj_path, *args, **kwargs):
-        super(Base, self).__init__(
+        super().__init__(
             g_name=self.__name,
             g_interface_name=interface_name,
             g_object_path=obj_path,

--- a/blueman/bluez/Device.py
+++ b/blueman/bluez/Device.py
@@ -21,4 +21,4 @@ class Device(Base):
 
 class AnyDevice(AnyBase):
     def __init__(self):
-        super(AnyDevice, self).__init__('org.bluez.Device1')
+        super().__init__('org.bluez.Device1')

--- a/blueman/bluez/obex/Client.py
+++ b/blueman/bluez/obex/Client.py
@@ -6,9 +6,7 @@ from gi.repository import GObject, GLib
 
 class Client(Base):
     __gsignals__ = {
-        'session-created': (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
         'session-failed': (GObject.SignalFlags.NO_HOOKS, None, (GObject.TYPE_PYOBJECT,)),
-        'session-removed': (GObject.SignalFlags.NO_HOOKS, None, ()),
     }
 
     _interface_name = 'org.bluez.obex.Client1'
@@ -19,7 +17,6 @@ class Client(Base):
     def create_session(self, dest_addr, source_addr="00:00:00:00:00:00", pattern="opp"):
         def on_session_created(session_path):
             logging.info("%s %s %s %s" % (dest_addr, source_addr, pattern, session_path))
-            self.emit("session-created", session_path)
 
         def on_session_failed(error):
             logging.error("%s %s %s %s" % (dest_addr, source_addr, pattern, error))
@@ -33,7 +30,6 @@ class Client(Base):
     def remove_session(self, session_path):
         def on_session_removed():
             logging.info(session_path)
-            self.emit('session-removed')
 
         def on_session_remove_failed(error):
             logging.error("%s %s" % (session_path, error))

--- a/blueman/gui/CommonUi.py
+++ b/blueman/gui/CommonUi.py
@@ -10,8 +10,8 @@ from gi.repository import Gtk
 class ErrorDialog(Gtk.MessageDialog):
     def __init__(self, markup, secondary_markup=None, excp=None, icon_name="dialog-error",
                  buttons=Gtk.ButtonsType.CLOSE, **kwargs):
-        super(ErrorDialog, self).__init__(name="ErrorDialog", icon_name=icon_name, buttons=buttons,
-                                          type=Gtk.MessageType.ERROR, **kwargs)
+        super().__init__(name="ErrorDialog", icon_name=icon_name, buttons=buttons,
+                         type=Gtk.MessageType.ERROR, **kwargs)
 
         self.set_markup(markup)
 

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -85,8 +85,8 @@ class DeviceList(GenericList):
         self.manager.connect_signal('device-created', on_device_created)
         self.manager.connect_signal('device-removed', on_device_removed)
 
-        any_device = bluez.AnyDevice()
-        any_device.connect_signal("property-changed", self._on_device_property_changed)
+        self.any_device = bluez.AnyDevice()
+        self.any_device.connect_signal("property-changed", self._on_device_property_changed)
 
         self.__discovery_time = 0
         self.__adapter_path = None
@@ -112,6 +112,10 @@ class DeviceList(GenericList):
         self.icon_theme.prepend_search_path(ICON_PATH)
         # handle icon theme changes
         self.icon_theme.connect("changed", self.on_icon_theme_changed)
+
+    def destroy(self):
+        self.any_device.disconnect_by_func(self._on_device_property_changed)
+        super().destroy()
 
     def on_selection_changed(self, selection):
         _model, tree_iter = selection.get_selected()

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -41,6 +41,7 @@ class DeviceList(GenericList):
 
     def __del__(self):
         logging.debug("deleting mainlist")
+        super().__del__()
 
     def __init__(self, adapter_name=None, tabledata=None, **kwargs):
         if not tabledata:
@@ -98,7 +99,7 @@ class DeviceList(GenericList):
             {"id": "timestamp", "type": float}
         ]
 
-        super(DeviceList, self).__init__(data, **kwargs)
+        super().__init__(data, **kwargs)
         self.set_name("DeviceList")
 
         self.set_adapter(adapter_name)

--- a/blueman/gui/DeviceSelectorDialog.py
+++ b/blueman/gui/DeviceSelectorDialog.py
@@ -29,6 +29,10 @@ class DeviceSelectorDialog(Gtk.Dialog):
 
         self.selector.List.connect("row-activated", self.on_row_activated)
 
+    def close(self):
+        self.selector.destroy()
+        super().close()
+
     def on_row_activated(self, treeview, path, view_column, *args):
         self.response(Gtk.ResponseType.ACCEPT)
 

--- a/blueman/gui/DeviceSelectorList.py
+++ b/blueman/gui/DeviceSelectorList.py
@@ -24,7 +24,7 @@ class DeviceSelectorList(DeviceList):
              "render_attrs": {"icon_name": 3}}
         ]
 
-        super(DeviceSelectorList, self).__init__(adapter_name, tabledata, headers_visible=False)
+        super().__init__(adapter_name, tabledata, headers_visible=False)
 
     def on_icon_theme_changed(self, widget):
         for row in self.liststore:

--- a/blueman/gui/DeviceSelectorWidget.py
+++ b/blueman/gui/DeviceSelectorWidget.py
@@ -12,9 +12,9 @@ from gi.repository import Gtk
 class DeviceSelectorWidget(Gtk.Box):
     def __init__(self, adapter_name=None, orientation=Gtk.Orientation.VERTICAL, **kwargs):
 
-        super(DeviceSelectorWidget, self).__init__(orientation=orientation, spacing=1, vexpand=True,
-                                                   width_request=360, height_request=340,
-                                                   name="DeviceSelectorWidget", **kwargs)
+        super().__init__(orientation=orientation, spacing=1, vexpand=True,
+                         width_request=360, height_request=340,
+                         name="DeviceSelectorWidget", **kwargs)
 
         self.List = DeviceSelectorList(adapter_name)
         if self.List.Adapter is not None:

--- a/blueman/gui/GenericList.py
+++ b/blueman/gui/GenericList.py
@@ -7,7 +7,7 @@ from gi.repository import Gtk
 # noinspection PyAttributeOutsideInit
 class GenericList(Gtk.TreeView):
     def __init__(self, data, **kwargs):
-        super(GenericList, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.set_name("GenericList")
         self.selection = self.get_selection()
         self._load(data)

--- a/blueman/gui/GsmSettings.py
+++ b/blueman/gui/GsmSettings.py
@@ -11,7 +11,7 @@ from gi.repository import Gtk
 
 class GsmSettings(Gtk.Dialog):
     def __init__(self, bd_address):
-        super(GsmSettings, self).__init__()
+        super().__init__()
 
         self.set_name("GsmSettings")
         self.device = bd_address

--- a/blueman/gui/GtkAnimation.py
+++ b/blueman/gui/GtkAnimation.py
@@ -31,7 +31,7 @@ class AnimBase(GObject.GObject):
     }
 
     def __init__(self, state=1.0):
-        super(AnimBase, self).__init__()
+        super().__init__()
         self._source = None
         self._state = state
         self.frozen = False
@@ -118,7 +118,7 @@ class AnimBase(GObject.GObject):
 
 class TreeRowFade(AnimBase):
     def __init__(self, tw, path, columns=None):
-        super(TreeRowFade, self).__init__(1.0)
+        super().__init__(1.0)
         self.tw = tw
 
         self.sig = self.tw.connect_after("draw", self.on_draw)
@@ -169,7 +169,7 @@ class TreeRowFade(AnimBase):
 
 class TreeRowColorFade(TreeRowFade):
     def __init__(self, tw, path, color):
-        super(TreeRowColorFade, self).__init__(tw, path, None)
+        super().__init__(tw, path, None)
 
         self.color = color
 
@@ -203,7 +203,7 @@ class TreeRowColorFade(TreeRowFade):
 
 class CellFade(AnimBase):
     def __init__(self, tw, path, columns=None):
-        super(CellFade, self).__init__(1.0)
+        super().__init__(1.0)
         self.tw = tw
 
         self.frozen = False
@@ -266,7 +266,7 @@ class CellFade(AnimBase):
 
 class WidgetFade(AnimBase):
     def __init__(self, widget, color):
-        super(WidgetFade, self).__init__(1.0)
+        super().__init__(1.0)
 
         self.widget = widget
         self.color = color

--- a/blueman/gui/MessageArea.py
+++ b/blueman/gui/MessageArea.py
@@ -14,12 +14,12 @@ class MessageArea(Gtk.InfoBar):
 
     def __new__(cls):
         if not MessageArea._inst_:
-            MessageArea._inst_ = super(MessageArea, cls).__new__(cls)
+            MessageArea._inst_ = super().__new__(cls)
 
         return MessageArea._inst_
 
     def __init__(self):
-        super(MessageArea, self).__init__(show_close_button=True)
+        super().__init__(show_close_button=True)
 
         self.set_name("MessageArea")
 

--- a/blueman/gui/Notification.py
+++ b/blueman/gui/Notification.py
@@ -16,7 +16,7 @@ OPACITY_START = 0.7
 
 class Fade(AnimBase):
     def __init__(self, window):
-        super(Fade, self).__init__(state=OPACITY_START)
+        super().__init__(state=OPACITY_START)
         self.window = window
 
     def state_changed(self, state):
@@ -26,8 +26,8 @@ class Fade(AnimBase):
 class _NotificationDialog(Gtk.MessageDialog):
     def __init__(self, summary, message, timeout=-1, actions=None, actions_cb=None,
                  icon_name=None, image_data=None):
-        super(_NotificationDialog, self).__init__(parent=None, flags=0, type=Gtk.MessageType.QUESTION,
-                                                  buttons=Gtk.ButtonsType.NONE, message_format=None)
+        super().__init__(parent=None, flags=0, type=Gtk.MessageType.QUESTION,
+                         buttons=Gtk.ButtonsType.NONE, message_format=None)
 
         self.set_name("NotificationDialog")
         i = 100
@@ -130,7 +130,7 @@ class _NotificationDialog(Gtk.MessageDialog):
 class _NotificationBubble(Gio.DBusProxy):
     def __init__(self, summary, message, timeout=-1, actions=None, actions_cb=None,
                  icon_name=None, image_data=None):
-        super(_NotificationBubble, self).__init__(
+        super().__init__(
             g_name='org.freedesktop.Notifications',
             g_interface_name='org.freedesktop.Notifications',
             g_object_path='/org/freedesktop/Notifications',

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -54,7 +54,7 @@ class ManagerDeviceList(DeviceList):
             {"id": "levels_visible", "type": bool},
             {"id": "initial_anim", "type": bool},
         ]
-        super(ManagerDeviceList, self).__init__(adapter, tabledata)
+        super().__init__(adapter, tabledata)
         self.set_name("ManagerDeviceList")
         self.set_headers_visible(False)
         self.props.has_tooltip = True
@@ -211,7 +211,7 @@ class ManagerDeviceList(DeviceList):
 
             fader.disconnect(signal)
             fader.freeze()
-            super(ManagerDeviceList, self).device_remove_event(device, tree_iter)
+            super().device_remove_event(device, tree_iter)
 
         signal = row_fader.connect("animation-finished", on_finished)
         row_fader.thaw()

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -31,7 +31,7 @@ class ManagerDeviceMenu(Gtk.Menu):
     __instances__ = []
 
     def __init__(self, blueman):
-        super(ManagerDeviceMenu, self).__init__()
+        super().__init__()
         self.set_name("ManagerDeviceMenu")
         self.Blueman = blueman
         self.SelectedDevice = None

--- a/blueman/gui/manager/ManagerProgressbar.py
+++ b/blueman/gui/manager/ManagerProgressbar.py
@@ -18,7 +18,7 @@ class ManagerProgressbar(GObject.GObject):
     __instances__ = []
 
     def __init__(self, blueman, cancellable=True, text=_("Connecting")):
-        super(ManagerProgressbar, self).__init__()
+        super().__init__()
         self.Blueman = blueman
 
         self.cancellable = cancellable

--- a/blueman/main/Config.py
+++ b/blueman/main/Config.py
@@ -6,9 +6,9 @@ class Config(Gio.Settings):
     def __init__(self, schema_id, path=None):
         # Add backwards compat with pygobject < 3.11.2
         if Gio.Settings.__init__.__name__ == "new_init":
-            super(Config, self).__init__(schema_id=schema_id, path=path)
+            super().__init__(schema_id=schema_id, path=path)
         else:
-            super(Config, self).__init__(schema=schema_id, path=path)
+            super().__init__(schema=schema_id, path=path)
 
     def bind_to_widget(self, key, widget, prop, flags=Gio.SettingsBindFlags.DEFAULT):
         self.bind(key, widget, prop, flags)

--- a/blueman/main/DhcpClient.py
+++ b/blueman/main/DhcpClient.py
@@ -24,7 +24,7 @@ class DhcpClient(GObject.GObject):
     quering = []
 
     def __init__(self, interface, timeout=30):
-        super(DhcpClient, self).__init__()
+        super().__init__()
 
         self._interface = interface
         self._timeout = timeout

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -26,7 +26,7 @@ from gi.repository import Gtk
 
 class Blueman(Gtk.Window):
     def __init__(self):
-        super(Blueman, self).__init__(title=_("Bluetooth Devices"))
+        super().__init__(title=_("Bluetooth Devices"))
 
         self._applet_sig = None
 

--- a/blueman/main/PPPConnection.py
+++ b/blueman/main/PPPConnection.py
@@ -46,7 +46,7 @@ class PPPConnection(GObject.GObject):
     }
 
     def __init__(self, port, number="*99#", apn="", user="", pwd=""):
-        super(PPPConnection, self).__init__()
+        super().__init__()
 
         self.apn = apn
         self.number = number

--- a/blueman/main/PluginManager.py
+++ b/blueman/main/PluginManager.py
@@ -29,7 +29,7 @@ class PluginManager(GObject.GObject):
     }
 
     def __init__(self, plugin_class, module_path, parent):
-        super(PluginManager, self).__init__()
+        super().__init__()
         self.__plugins = {}
         self.__classes = {}
         self.__deps = {}
@@ -229,7 +229,7 @@ class PluginManager(GObject.GObject):
 
 class PersistentPluginManager(PluginManager):
     def __init__(self, *args):
-        super(PersistentPluginManager, self).__init__(*args)
+        super().__init__(*args)
 
         self.__config = Config("org.blueman.general")
 

--- a/blueman/main/PulseAudioUtils.py
+++ b/blueman/main/PulseAudioUtils.py
@@ -628,7 +628,7 @@ class PulseAudioUtils(GObject.GObject, metaclass=PulseAudioUtilsMeta):
         self.emit("event", event_type, idx)
 
     def __init__(self):
-        super(PulseAudioUtils, self).__init__()
+        super().__init__()
 
         self.event_cb = pa_context_subscribe_cb_t(self.__event_callback)
 

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -96,7 +96,7 @@ class Sender(Gtk.Dialog):
             self.total_bytes += file_info.get_size()
 
         if len(self.files) == 0:
-            exit(1)
+            self.emit("result", False)
 
         try:
             self.client = obex.Client()
@@ -107,7 +107,7 @@ class Sender(Gtk.Dialog):
                                                             "daemon is running"), parent=self.get_toplevel())
                 d.run()
                 d.destroy()
-                exit(1)
+                self.emit("result", False)
             else:
                 # Fail on anything else
                 raise
@@ -266,7 +266,7 @@ class Sender(Gtk.Dialog):
 
         d.run()
         d.destroy()
-        exit(1)
+        self.emit("result", False)
 
     def on_session_removed(self, _client):
         self.emit("result", False)

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -227,6 +227,8 @@ class Sender(Gtk.Dialog):
             d.add_button(_("Retry"), Gtk.ResponseType.YES)
             d.add_button("_Cancel", Gtk.ResponseType.CANCEL)
 
+            self.client.remove_session(self.object_push.get_object_path())
+
             def on_response(dialog, resp):
                 dialog.destroy()
                 self.error_dialog = None

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 import time
 import logging
-import os
 from locale import bind_textdomain_codeset
 from gettext import ngettext
 
@@ -233,7 +232,8 @@ class Sender(Gtk.Dialog):
                 if resp == "_Cancel":
                     self.on_cancel(None)
                 elif resp == Gtk.ResponseType.NO:
-                    self.total_bytes -= os.path.getsize(self.files[-1])
+                    finfo = self.files[-1].query_info('standard::*', Gio.FileQueryInfoFlags.NONE)
+                    self.total_bytes -= finfo.get_size()
                     self.total_transferred -= self.transferred
                     self.transferred = 0
                     del self.files[-1]

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -218,7 +218,7 @@ class Sender(Gtk.Dialog):
         if not self.error_dialog:
             self.speed.reset()
             d = ErrorDialog(msg, _("Error occurred while sending file %s") % self.files[-1].get_basename(),
-                            modal=True, icon_name="blueman", parent=self.get_toplevel())
+                            modal=True, icon_name="blueman", parent=self.get_toplevel(), buttons=[])
 
             if len(self.files) > 1:
                 d.add_button(_("Skip"), Gtk.ResponseType.NO)

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -218,7 +218,7 @@ class Sender(Gtk.Dialog):
     def on_transfer_error(self, _transfer, msg=""):
         if not self.error_dialog:
             self.speed.reset()
-            d = ErrorDialog(msg, _("Error occurred while sending file %s") % os.path.basename(self.files[-1]),
+            d = ErrorDialog(msg, _("Error occurred while sending file %s") % self.files[-1].get_basename(),
                             modal=True, icon_name="blueman", parent=self.get_toplevel())
 
             if len(self.files) > 1:

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -229,7 +229,7 @@ class Sender(Gtk.Dialog):
                 dialog.destroy()
                 self.error_dialog = None
 
-                if resp == "_Cancel":
+                if resp == Gtk.ResponseType.CANCEL:
                     self.on_cancel(None)
                 elif resp == Gtk.ResponseType.NO:
                     finfo = self.files[-1].query_info('standard::*', Gio.FileQueryInfoFlags.NONE)

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -140,8 +140,8 @@ class Sender(Gtk.Dialog):
 
         if self.object_push:
             self.client.remove_session(self.object_push.get_session_path())
-        else:
-            self.emit("result", False)
+
+        self.emit("result", False)
 
     def on_transfer_started(self, _object_push, transfer_path, filename):
         if self.total_transferred == 0:

--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -15,7 +15,7 @@ class AppletPlugin(BasePlugin):
     _dbus_signals = None
 
     def __init__(self, parent):
-        super(AppletPlugin, self).__init__(parent)
+        super().__init__(parent)
 
         if not ictheme.has_icon(self.__class__.__icon__):
             self.__class__.__icon__ = "blueman-plugin"
@@ -46,7 +46,7 @@ class AppletPlugin(BasePlugin):
         for (obj, method, orig) in self.__overrides:
             obj.__setattr__(method, orig)
 
-        super(AppletPlugin, self)._unload()
+        super()._unload()
 
         for method in self._dbus_methods:
             self._dbus_service.remove_method(method)
@@ -54,7 +54,7 @@ class AppletPlugin(BasePlugin):
             self._dbus_service.remove_signal(signal)
 
     def _load(self):
-        super(AppletPlugin, self)._load()
+        super()._load()
 
         # The applet will run on_manager_state_changed once at startup so until it has we don't.
         if self.parent.plugin_run_state_changed:

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -29,7 +29,7 @@ class MonitorBase(GObject.GObject):
     }
 
     def __init__(self, device, interface):
-        super(MonitorBase, self).__init__()
+        super().__init__()
 
         self.interface = interface
         self.device = device
@@ -67,7 +67,7 @@ class MonitorBase(GObject.GObject):
 
 class Monitor(MonitorBase):
     def __init__(self, device, interface):
-        super(Monitor, self).__init__(device, interface)
+        super().__init__(device, interface)
         self.poller = None
         self.ppp_port = None
 

--- a/blueman/services/meta/NetworkService.py
+++ b/blueman/services/meta/NetworkService.py
@@ -5,7 +5,7 @@ from blueman.bluez.Network import Network
 
 class NetworkService(Service):
     def __init__(self, device, uuid):
-        super(NetworkService, self).__init__(device, uuid)
+        super().__init__(device, uuid)
         self._service = Network(device.get_object_path())
 
     @property

--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -14,7 +14,7 @@ from blueman.Constants import RFCOMM_WATCHER_PATH
 
 class SerialService(Service):
     def __init__(self, device, uuid):
-        super(SerialService, self).__init__(device, uuid)
+        super().__init__(device, uuid)
         self.file_changed_handler = None
 
     def serial_port_id(self, channel):


### PR DESCRIPTION
I still need to  pass the parent to a dialog but I need some help with an obex error I am seeing.

Steps to reproduce (after these fixes).

1. Start a largish transfer (so we get the opportunity to stop it on the receiver).
2. Accept the file on the receiver
3. Stop the transfer on the receiver
4. Choose cancel in sendto dialog

This will result in an error removing the session because of invalid argument. But I don't understand why as we pass a proper objectpath to ``RemoveSession``.. :confused: 

```
blueman-sendto 23.57.51 ERROR    Client:39 on_session_remove_failed: /org/bluez/obex/client/session8 org.bluez.obex.Error.InvalidArguments
```
