### PR TITLE
Fix trust icon surface source

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -196,10 +196,8 @@ class ManagerDeviceList(DeviceList):
             height = target.get_height()
             mini_height = trusted_surface.get_height()
             y = height / scale - mini_height / scale - 1 / scale
-            width = trusted_surface.get_width()
-            x = width / scale - width / scale - 1 / scale
 
-            ctx.set_source_surface(trusted_surface, x, y)
+            ctx.set_source_surface(trusted_surface, 1 / scale, y)
             ctx.paint_with_alpha(0.8)
 
         return target


### PR DESCRIPTION
(Found this while playing with SonarCloud.) The calculation for x is bogus as it is always just a negated 1 / scale. I did not notice any difference (does the negative value fall back to 0?) but I think the intended value is a positive 1 / scale to align with the paired icon.