### PR TITLE
Info Manager plugin: Do not check if Class is None

### DIFF
--- a/blueman/plugins/manager/Info.py
+++ b/blueman/plugins/manager/Info.py
@@ -71,7 +71,7 @@ def show_info(device, parent):
         ('AddressType', None),
         ('Name', None),
         ('Alias', None),
-        ('Class', lambda x: x and "0x{:06x}".format(x)),
+        ('Class', lambda x: "0x{:06x}".format(x)),
         ('Appearance', lambda x: "0x{:04x}".format(x)),
         ('Icon', None),
         ('Paired', format_boolean),


### PR DESCRIPTION
It will never be None and will always return an int, zero as default.