### PR TITLE
PowerManager scan bluetooth config file

### DIFF
--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -30,14 +30,12 @@ class PowerManager(AppletPlugin):
         }
     }
 
-
     def __init__(self, parent):
         super().__init__(parent)
         conf = GLib.KeyFile()
         conf.load_from_file('/etc/bluetooth/main.conf', GLib.KeyFileFlags.NONE)
         self.__options__["auto-power-on"]["default"] = conf.get_boolean('Policy', 'AutoEnable')
-    
-
+ 
     def on_load(self):
         AppletPlugin.add_method(self.on_power_state_query)
         AppletPlugin.add_method(self.on_power_state_change_requested)

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -35,7 +35,7 @@ class PowerManager(AppletPlugin):
         conf = GLib.KeyFile()
         conf.load_from_file('/etc/bluetooth/main.conf', GLib.KeyFileFlags.NONE)
         self.__options__["auto-power-on"]["default"] = conf.get_boolean('Policy', 'AutoEnable')
- 
+
     def on_load(self):
         AppletPlugin.add_method(self.on_power_state_query)
         AppletPlugin.add_method(self.on_power_state_change_requested)

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -30,6 +30,14 @@ class PowerManager(AppletPlugin):
         }
     }
 
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        conf = GLib.KeyFile()
+        conf.load_from_file('/etc/bluetooth/main.conf', GLib.KeyFileFlags.NONE)
+        self.__options__["auto-power-on"]["default"] = conf.get_boolean('Policy', 'AutoEnable')
+    
+
     def on_load(self):
         AppletPlugin.add_method(self.on_power_state_query)
         AppletPlugin.add_method(self.on_power_state_change_requested)


### PR DESCRIPTION
PowerManager applet has to scan for bluetooth main.conf file otherwise main.conf "AutoEnable" parameter simply gets overwritten by PowerManager auto-power default: True.

I am sorry I am not a python dev and they may be errors, I am a ParrotOS/Debian user and I get many errors when I launch blueman or reboot, so I am unable to run it from source.