### PR TITLE
Move D-Bus conf file to share/dbus-1/system.d

### DIFF
--- a/Dependencies.md
+++ b/Dependencies.md
@@ -3,7 +3,7 @@
 ## Runtime dependencies
 
 * [BlueZ 5](http://www.bluez.org/)
-* [dbus](http://www.freedesktop.org/wiki/Software/dbus/)
+* [dbus](http://www.freedesktop.org/wiki/Software/dbus/) (>= 1.9.18)
 * [GdkPixbuf](http://www.gtk.org/) (GI bindings)
 * [GLib 2, Gio 2](http://www.gtk.org/) (>= 2.32) (GI bindings)
 * [GTK+ 3](http://www.gtk.org/) (GI bindings) [1]

--- a/data/configs/Makefile.am
+++ b/data/configs/Makefile.am
@@ -1,4 +1,4 @@
-dbusdir = $(sysconfdir)/dbus-1/system.d
+dbusdir = $(datadir)/dbus-1/system.d
 dbus_DATA = org.blueman.Mechanism.conf
 
 dbus_servicesdir = $(datadir)/dbus-1/system-services
@@ -18,7 +18,7 @@ systemd_user_DATA = blueman-applet.service
 endif
 
 if HAVE_POLKIT
-@INTLTOOL_POLICY_RULE@ 
+@INTLTOOL_POLICY_RULE@
 policykitactionsdir = $(datadir)/polkit-1/actions
 policykitactions_in_files = org.blueman.policy.in
 policykitactions_DATA = $(policykitactions_in_files:.policy.in=.policy)
@@ -43,7 +43,7 @@ CLEANFILES =		\
 	org.blueman.policy		\
 	org.blueman.Applet.service		\
 	$(BUILT_SOURCES)
-	
+
 DISTCLEANFILES = \
 	$(CLEANFILES)
 

--- a/meson.build
+++ b/meson.build
@@ -257,7 +257,7 @@ endforeach
 
 install_data(
     'data/configs/org.blueman.Mechanism.conf',
-    install_dir: join_paths(get_option('sysconfdir'), 'dbus-1', 'system.d')
+    install_dir: join_paths(get_option('datadir'), 'dbus-1', 'system.d')
 )
 
 


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party should
go in share/dbus-1/system.d. The old location is for sysadmin overrides.