### PR TITLE
Connect/disconnect on double-click

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -156,6 +156,25 @@ class ManagerDeviceList(DeviceList):
 
     def on_event_clicked(self, widget, event):
 
+        if event.type == Gdk.EventType._2BUTTON_PRESS and event.button == 1:
+            path = self.get_path_at_pos(int(event.x), int(event.y))
+            if path is not None:
+                row = self.get(path[0], "device", "connected")
+
+                if row:
+                    device = row["device"]
+                    if device:
+                        if self.Blueman is not None:
+                            if self.menu is None:
+                                self.menu = ManagerDeviceMenu(self.Blueman)
+                                show_generic_connect = self.menu.show_generic_connect_calc(device['UUIDs'])
+                                if not row["connected"] and show_generic_connect:
+                                    self.menu._generic_connect(item=None, device=device, connect=True)
+                                elif show_generic_connect:
+                                    self.menu._generic_connect(item=None, device=device, connect=False)
+                                self.menu.clear()
+                                self.menu = None
+
         if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 3:
             path = self.get_path_at_pos(int(event.x), int(event.y))
             if path is not None:

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -158,22 +158,23 @@ class ManagerDeviceList(DeviceList):
 
         if event.type == Gdk.EventType._2BUTTON_PRESS and event.button == 1:
             path = self.get_path_at_pos(int(event.x), int(event.y))
-            if path is not None:
-                row = self.get(path[0], "device", "connected")
+            if path is None:
+                return
 
-                if row:
-                    device = row["device"]
-                    if device:
-                        if self.Blueman is not None:
-                            if self.menu is None:
-                                self.menu = ManagerDeviceMenu(self.Blueman)
-                                show_generic_connect = self.menu.show_generic_connect_calc(device['UUIDs'])
-                                if not row["connected"] and show_generic_connect:
-                                    self.menu._generic_connect(item=None, device=device, connect=True)
-                                elif show_generic_connect:
-                                    self.menu._generic_connect(item=None, device=device, connect=False)
-                                self.menu.clear()
-                                self.menu = None
+            row = self.get(path[0], "device", "connected")
+
+            if not row:
+                return
+
+            device = row["device"]
+            if device:
+                if self.Blueman is not None:
+                    if self.menu is None:
+                        self.menu = ManagerDeviceMenu(self.Blueman)
+                        if self.menu.show_generic_connect_calc(device['UUIDs']):
+                            self.menu._generic_connect(item=None, device=device, connect=not row["connected"])
+                        self.menu.clear()
+                        self.menu = None
 
         if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 3:
             path = self.get_path_at_pos(int(event.x), int(event.y))

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -167,14 +167,13 @@ class ManagerDeviceList(DeviceList):
                 return
 
             device = row["device"]
-            if device:
-                if self.Blueman is not None:
-                    if self.menu is None:
-                        self.menu = ManagerDeviceMenu(self.Blueman)
-                        if self.menu.show_generic_connect_calc(device['UUIDs']):
-                            self.menu._generic_connect(item=None, device=device, connect=not row["connected"])
-                        self.menu.clear()
-                        self.menu = None
+            if self.Blueman is not None:
+                if self.menu is None:
+                    self.menu = ManagerDeviceMenu(self.Blueman)
+                    if self.menu.show_generic_connect_calc(device['UUIDs']):
+                        self.menu._generic_connect(item=None, device=device, connect=not row["connected"])
+                    self.menu.clear()
+                    self.menu = None
 
         if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 3:
             path = self.get_path_at_pos(int(event.x), int(event.y))

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -240,13 +240,13 @@ class ManagerDeviceMenu(Gtk.Menu):
                     break
 
         if not row["connected"] and show_generic_connect:
-            connect_item = create_menuitem(_("_Connect"), "blueman")
+            connect_item = create_menuitem(_("_<b>Connect</b>"), "blueman")
             connect_item.connect("activate", self._generic_connect, self.SelectedDevice, True)
             connect_item.props.tooltip_text = _("Connects auto connect profiles A2DP source, A2DP sink, and HID")
             connect_item.show()
             self.append(connect_item)
         elif show_generic_connect:
-            connect_item = create_menuitem(_("_Disconnect"), "network-offline")
+            connect_item = create_menuitem(_("_<b>Disconnect</b>"), "network-offline")
             connect_item.props.tooltip_text = _("Forcefully disconnect the device")
             connect_item.connect("activate", self._generic_connect, self.SelectedDevice, False)
             connect_item.show()

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -193,7 +193,7 @@ class ManagerDeviceMenu(Gtk.Menu):
         prog.start()
 
     def show_generic_connect_calc(self, device_uuids):
-    # Generic (dis)connect
+        # Generic (dis)connect
         for uuid in device_uuids:
             service_uuid = ServiceUUID(uuid)
             if service_uuid.short_uuid in (

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -192,24 +192,20 @@ class ManagerDeviceMenu(Gtk.Menu):
         prog = ManagerProgressbar(self.Blueman, False)
         prog.start()
 
-    # Generic (dis)connect
-    # LE devices do not appear to expose certain properties like uuids until connect to at least once.
-    # show generic connect for these as we will not show any way to connect otherwise.
     def show_generic_connect_calc(self, device_uuids):
-        show_generic_connect = not device_uuids
+    # Generic (dis)connect
         for uuid in device_uuids:
             service_uuid = ServiceUUID(uuid)
             if service_uuid.short_uuid in (
                     AUDIO_SOURCE_SVCLASS_ID, AUDIO_SINK_SVCLASS_ID, HANDSFREE_AGW_SVCLASS_ID, HANDSFREE_SVCLASS_ID,
                     HEADSET_SVCLASS_ID, HID_SVCLASS_ID, 0x1812
             ):
-                show_generic_connect = True
-                break
+                return True
             elif not service_uuid.reserved:
                 if uuid == '03b80e5a-ede8-4b33-a751-6ce34ec4c700':
-                    show_generic_connect = True
-                    break
-        return show_generic_connect
+                    return True
+        # LE devices do not appear to expose certain properties like uuids until connect to at least once.
+        return not device_uuids
 
     def generate(self):
         self.clear()


### PR DESCRIPTION
Connect/disconnect with a device can be performed when the user double-clicks on the device. Connect/disconnect labels are bold for the purpose of clarity.

I rebased my repo and changed the code according to the requests (except for https://github.com/blueman-project/blueman/pull/1099#discussion_r324483125 since I didn't understand it. Could you please specify what changes do you expect?).