### PR TITLE
PowerManager.py: provides a new dbus method

### DIFF
--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from time import sleep
+from time import sleep, time
 from typing import Optional, Dict, Tuple, List
 import re
 import os
@@ -83,6 +83,13 @@ def check_bluetooth_status(message, exitfunc):
             return
 
     applet.SetBluetoothStatus('(b)', True)
+
+    timeout = time() + 60
+    while applet.GetRequestStatus():
+        sleep(0.1)
+        if time() > timeout:
+            break
+
     if not applet.GetBluetoothStatus():
         print('Failed to enable bluetooth')
         exitfunc()

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -50,6 +50,7 @@ class PowerManager(AppletPlugin):
         self._add_dbus_signal("BluetoothStatusChanged", "b")
         self._add_dbus_method("SetBluetoothStatus", ("b",), "", self.request_power_state)
         self._add_dbus_method("GetBluetoothStatus", (), "b", self.get_bluetooth_status)
+        self._add_dbus_method("GetRequestStatus", (), "b", self.get_request_status)
 
     def on_unload(self):
         self.parent.Plugins.Menu.unregister(self)
@@ -183,6 +184,9 @@ class PowerManager(AppletPlugin):
 
     def get_bluetooth_status(self):
         return self.current_state
+
+    def get_request_status(self):
+        return self.request_in_progress
 
     def on_adapter_property_changed(self, _path, key, value):
         if key == "Powered":


### PR DESCRIPTION
Provides a new dbus method for PowerManager that whether dbus method
SetBluetoothStatus() has finished. Otherwise GetBluetoothStatus() may
get a wrong value if called right after SetBluetoothStatus().

Signed-off-by: Kai Kang <kai.kang@windriver.com>