### PR TITLE
Simplify BaseMeta

### DIFF
--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -10,7 +10,7 @@ class Adapter(Base):
     _interface_name = 'org.bluez.Adapter1'
 
     def __init__(self, obj_path: str):
-        super().__init__(self._interface_name, obj_path=obj_path)
+        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
 
     def start_discovery(self) -> None:
         self._call('StartDiscovery')

--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -10,7 +10,7 @@ class Adapter(Base):
     _interface_name = 'org.bluez.Adapter1'
 
     def __init__(self, obj_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
+        super().__init__(obj_path=obj_path)
 
     def start_discovery(self) -> None:
         self._call('StartDiscovery')

--- a/blueman/bluez/AgentManager.py
+++ b/blueman/bluez/AgentManager.py
@@ -5,9 +5,10 @@ from gi.repository import GLib
 
 class AgentManager(Base):
     _interface_name = 'org.bluez.AgentManager1'
+    _obj_path = '/org/bluez'
 
     def __init__(self) -> None:
-        super().__init__(interface_name=self._interface_name, obj_path='/org/bluez')
+        super().__init__(interface_name=self._interface_name, obj_path=self._obj_path)
 
     def register_agent(self, agent_path: str, capability: str = "", default: bool = False) -> None:
         param = GLib.Variant('(os)', (agent_path, capability))

--- a/blueman/bluez/AgentManager.py
+++ b/blueman/bluez/AgentManager.py
@@ -8,7 +8,7 @@ class AgentManager(Base):
     _obj_path = '/org/bluez'
 
     def __init__(self) -> None:
-        super().__init__(interface_name=self._interface_name, obj_path=self._obj_path)
+        super().__init__(obj_path=self._obj_path)
 
     def register_agent(self, agent_path: str, capability: str = "", default: bool = False) -> None:
         param = GLib.Variant('(os)', (agent_path, capability))

--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -12,18 +12,17 @@ from blueman.typing import GSignals
 class BaseMeta(GObjectMeta):
     def __call__(cls, **kwargs: str) -> "Base":
         if not hasattr(cls, "__instances__"):
-            cls.__instances__: Dict[str, Dict[str, "Base"]] = {}
+            cls.__instances__: Dict[str, "Base"] = {}
 
         path = kwargs.get('obj_path')
         if path is None:
             path = cls._obj_path
 
-        if cls._interface_name in cls.__instances__:
-            if path in cls.__instances__[cls._interface_name]:
-                return cls.__instances__[cls._interface_name][path]
+        if path in cls.__instances__:
+            return cls.__instances__[path]
 
         instance: "Base" = super().__call__(**kwargs)
-        cls.__instances__[cls._interface_name] = {path: instance}
+        cls.__instances__[path] = instance
 
         return instance
 
@@ -38,7 +37,7 @@ class Base(Gio.DBusProxy, metaclass=BaseMeta):
     __gsignals__: GSignals = {
         'property-changed': (GObject.SignalFlags.NO_HOOKS, None, (str, object, str))
     }
-    __instances__: Dict[str, Dict[str, "Base"]]
+    __instances__: Dict[str, "Base"]
 
     def __init__(self, obj_path: str):
         super().__init__(

--- a/blueman/bluez/Device.py
+++ b/blueman/bluez/Device.py
@@ -10,7 +10,7 @@ class Device(Base):
     _interface_name = 'org.bluez.Device1'
 
     def __init__(self, obj_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
+        super().__init__(obj_path=obj_path)
 
     def pair(
         self,

--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -67,7 +67,7 @@ class Manager(GObject.GObject, metaclass=SingletonGObjectMeta):
             if proxy:
                 paths.append(proxy.get_object_path())
 
-        return [Adapter(path) for path in paths]
+        return [Adapter(obj_path=path) for path in paths]
 
     def get_adapter(self, pattern: Optional[str] = None) -> Adapter:
         adapters = self.get_adapters()
@@ -93,7 +93,7 @@ class Manager(GObject.GObject, metaclass=SingletonGObjectMeta):
                 if object_path.startswith(adapter_path):
                     paths.append(object_path)
 
-        return [Device(path) for path in paths]
+        return [Device(obj_path=path) for path in paths]
 
     def find_device(self, address: str, adapter_path: str = "/") -> Optional[Device]:
         for device in self.get_devices(adapter_path):

--- a/blueman/bluez/Network.py
+++ b/blueman/bluez/Network.py
@@ -12,7 +12,7 @@ class Network(Base):
     _interface_name = 'org.bluez.Network1'
 
     def __init__(self, obj_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
+        super().__init__(obj_path=obj_path)
 
     def connect(
         self,

--- a/blueman/bluez/NetworkServer.py
+++ b/blueman/bluez/NetworkServer.py
@@ -7,7 +7,7 @@ class NetworkServer(Base):
     _interface_name = 'org.bluez.NetworkServer1'
 
     def __init__(self, obj_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
+        super().__init__(obj_path=obj_path)
 
     def register(self, uuid: str, bridge: str) -> None:
         param = GLib.Variant('(ss)', (uuid, bridge))

--- a/blueman/bluez/obex/AgentManager.py
+++ b/blueman/bluez/obex/AgentManager.py
@@ -11,7 +11,7 @@ class AgentManager(Base):
     _obj_path = '/org/bluez/obex'
 
     def __init__(self) -> None:
-        super().__init__(interface_name=self._interface_name, obj_path=self._obj_path)
+        super().__init__(obj_path=self._obj_path)
 
     def register_agent(self, agent_path: str) -> None:
         def on_registered() -> None:

--- a/blueman/bluez/obex/AgentManager.py
+++ b/blueman/bluez/obex/AgentManager.py
@@ -8,9 +8,10 @@ from gi.repository import GLib
 
 class AgentManager(Base):
     _interface_name = 'org.bluez.obex.AgentManager1'
+    _obj_path = '/org/bluez/obex'
 
     def __init__(self) -> None:
-        super().__init__(interface_name=self._interface_name, obj_path='/org/bluez/obex')
+        super().__init__(interface_name=self._interface_name, obj_path=self._obj_path)
 
     def register_agent(self, agent_path: str) -> None:
         def on_registered() -> None:

--- a/blueman/bluez/obex/Client.py
+++ b/blueman/bluez/obex/Client.py
@@ -14,9 +14,10 @@ class Client(Base):
     }
 
     _interface_name = 'org.bluez.obex.Client1'
+    _obj_path = '/org/bluez/obex'
 
     def __init__(self) -> None:
-        super().__init__(interface_name=self._interface_name, obj_path='/org/bluez/obex')
+        super().__init__(interface_name=self._interface_name, obj_path=self._obj_path)
 
     def create_session(self, dest_addr: str, source_addr: str = "00:00:00:00:00:00", pattern: str = "opp") -> None:
         def on_session_created(session_path: str) -> None:

--- a/blueman/bluez/obex/Client.py
+++ b/blueman/bluez/obex/Client.py
@@ -17,7 +17,7 @@ class Client(Base):
     _obj_path = '/org/bluez/obex'
 
     def __init__(self) -> None:
-        super().__init__(interface_name=self._interface_name, obj_path=self._obj_path)
+        super().__init__(obj_path=self._obj_path)
 
     def create_session(self, dest_addr: str, source_addr: str = "00:00:00:00:00:00", pattern: str = "opp") -> None:
         def on_session_created(session_path: str) -> None:

--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -49,7 +49,7 @@ class Manager(GObject.GObject, metaclass=SingletonGObjectMeta):
 
         if transfer_proxy:
             logging.info(object_path)
-            transfer = Transfer(object_path)
+            transfer = Transfer(obj_path=object_path)
             transfer.connect_signal('completed', self._on_transfer_completed, True)
             transfer.connect_signal('error', self._on_transfer_completed, False)
             self.__transfers[object_path] = transfer

--- a/blueman/bluez/obex/ObjectPush.py
+++ b/blueman/bluez/obex/ObjectPush.py
@@ -18,7 +18,7 @@ class ObjectPush(Base):
     _interface_name = 'org.bluez.obex.ObjectPush1'
 
     def __init__(self, obj_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
+        super().__init__(obj_path=obj_path)
 
     def send_file(self, file_path: str) -> None:
         def on_transfer_started(transfer_path: str, props: Dict[str, str]) -> None:

--- a/blueman/bluez/obex/ObjectPush.py
+++ b/blueman/bluez/obex/ObjectPush.py
@@ -17,8 +17,8 @@ class ObjectPush(Base):
 
     _interface_name = 'org.bluez.obex.ObjectPush1'
 
-    def __init__(self, session_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=session_path)
+    def __init__(self, obj_path: str):
+        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
 
     def send_file(self, file_path: str) -> None:
         def on_transfer_started(transfer_path: str, props: Dict[str, str]) -> None:

--- a/blueman/bluez/obex/Session.py
+++ b/blueman/bluez/obex/Session.py
@@ -6,7 +6,7 @@ class Session(Base):
     _interface_name = 'org.bluez.obex.Session1'
 
     def __init__(self, obj_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
+        super().__init__(obj_path=obj_path)
 
     @property
     def address(self) -> str:

--- a/blueman/bluez/obex/Session.py
+++ b/blueman/bluez/obex/Session.py
@@ -5,8 +5,8 @@ from blueman.bluez.obex.Base import Base
 class Session(Base):
     _interface_name = 'org.bluez.obex.Session1'
 
-    def __init__(self, session_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=session_path)
+    def __init__(self, obj_path: str):
+        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
 
     @property
     def address(self) -> str:

--- a/blueman/bluez/obex/Transfer.py
+++ b/blueman/bluez/obex/Transfer.py
@@ -17,8 +17,8 @@ class Transfer(Base):
 
     _interface_name = 'org.bluez.obex.Transfer1'
 
-    def __init__(self, transfer_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=transfer_path)
+    def __init__(self, obj_path: str):
+        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
 
     @property
     def filename(self) -> Optional[str]:

--- a/blueman/bluez/obex/Transfer.py
+++ b/blueman/bluez/obex/Transfer.py
@@ -18,7 +18,7 @@ class Transfer(Base):
     _interface_name = 'org.bluez.obex.Transfer1'
 
     def __init__(self, obj_path: str):
-        super().__init__(interface_name=self._interface_name, obj_path=obj_path)
+        super().__init__(obj_path=obj_path)
 
     @property
     def filename(self) -> Optional[str]:

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -121,7 +121,7 @@ class DeviceList(GenericList):
         if signal_name == 'device-created':
             tree_iter = self.find_device_by_path(path)
             if tree_iter is None:
-                dev = Device(path)
+                dev = Device(obj_path=path)
                 self.device_add_event(dev)
 
         if signal_name == 'device-removed':

--- a/blueman/gui/MessageArea.py
+++ b/blueman/gui/MessageArea.py
@@ -64,7 +64,7 @@ class MessageArea(Gtk.InfoBar):
 
     def _show_message(self, text, bt=None, icon="dialog-warning"):
         def on_finished(anim):
-            anim.disconnect_by_func(on_finished)
+            anim.disconnect(sig)
             anim.freeze()
 
         self.text = text
@@ -81,12 +81,12 @@ class MessageArea(Gtk.InfoBar):
             self.hl_anim.color = Gdk.RGBA(0, 0, 1, 1)
 
         if not self.props.visible:
-            self.anim.connect("animation-finished", on_finished)
+            sig = self.anim.connect("animation-finished", on_finished)
             self.anim.thaw()
             self.show()
             self.anim.animate(start=0.0, end=1.0, duration=500)
         else:
-            self.hl_anim.connect("animation-finished", on_finished)
+            sig = self.hl_anim.connect("animation-finished", on_finished)
             self.hl_anim.thaw()
             self.hl_anim.animate(start=0.7, end=1.0, duration=1000)
 

--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -154,8 +154,8 @@ class PluginDialog(Gtk.Window):
 
         self.populate()
 
-        self.applet.Plugins.connect("plugin-loaded", self.plugin_state_changed, True)
-        self.applet.Plugins.connect("plugin-unloaded", self.plugin_state_changed, False)
+        self.sig_a: int = self.applet.Plugins.connect("plugin-loaded", self.plugin_state_changed, True)
+        self.sig_b: int = self.applet.Plugins.connect("plugin-unloaded", self.plugin_state_changed, False)
         self.connect("delete-event", self._on_close)
 
         self.list.set_cursor(0)
@@ -179,8 +179,8 @@ class PluginDialog(Gtk.Window):
                 return 1
 
     def _on_close(self, *args, **kwargs):
-        self.applet.Plugins.disconnect_by_func(self.plugin_state_changed, True)
-        self.applet.Plugins.disconnect_by_func(self.plugin_state_changed, False)
+        self.applet.Plugins.disconnect(self.sig_a)
+        self.applet.Plugins.disconnect(self.sig_b)
 
     def on_selection_changed(self, selection):
         model, tree_iter = selection.get_selected()

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -235,11 +235,13 @@ class ManagerDeviceList(DeviceList):
     def device_add_event(self, device):
         self.add_device(device)
 
-    def make_caption(self, name, klass, address):
+    @staticmethod
+    def make_caption(name, klass, address):
         return "<span size='x-large'>%(0)s</span>\n<span size='small'>%(1)s</span>\n<i>%(2)s</i>" \
                % {"0": html.escape(name), "1": klass.capitalize(), "2": address}
 
-    def get_device_class(self, device):
+    @staticmethod
+    def get_device_class(device):
         klass = get_minor_class(device['Class'])
         if klass != "uncategorized":
             return get_minor_class(device['Class'], True)

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -237,7 +237,7 @@ class ManagerMenu:
                 self.blueman.List.set_adapter(adapter_path)
 
     def on_adapter_added(self, _manager, adapter_path):
-        adapter = Adapter(adapter_path)
+        adapter = Adapter(obj_path=adapter_path)
         menu = self.item_adapter.get_submenu()
         object_path = adapter.get_object_path()
 

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -245,8 +245,8 @@ class ManagerMenu:
         item.show()
         self._adapters_group = item.get_group()
 
-        item.connect("activate", self.on_adapter_selected, object_path)
-        adapter.connect_signal("property-changed", self.on_adapter_property_changed)
+        self._itemhandler = item.connect("activate", self.on_adapter_selected, object_path)
+        self._adapterhandler = adapter.connect_signal("property-changed", self.on_adapter_property_changed)
 
         menu.insert(item, self._insert_adapter_item_pos)
         self._insert_adapter_item_pos += 1
@@ -263,8 +263,8 @@ class ManagerMenu:
         item, adapter = self.adapter_items.pop(adapter_path)
         menu = self.item_adapter.get_submenu()
 
-        item.disconnect_by_func(self.on_adapter_selected, adapter.get_object_path())
-        adapter.disconnect_by_func(self.on_adapter_property_changed)
+        item.disconnect(self._itemhandler)
+        adapter.disconnect(self._adapterhandler)
 
         menu.remove(item)
         self._insert_adapter_item_pos -= 1

--- a/blueman/main/Adapter.py
+++ b/blueman/main/Adapter.py
@@ -98,7 +98,7 @@ class BluemanAdapters(Gtk.Window):
     def on_adapter_added(self, _manager, adapter_path):
         hci_dev = os.path.basename(adapter_path)
         if hci_dev not in self._adapters:
-            self._adapters[hci_dev] = Adapter(adapter_path)
+            self._adapters[hci_dev] = Adapter(obj_path=adapter_path)
 
         self._adapters[hci_dev].connect_signal("property-changed", self.on_property_changed)
         self.add_to_notebook(self._adapters[hci_dev])

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -198,11 +198,13 @@ class Blueman(Gtk.Window):
         s1 = self.List.connect("discovery-progress", on_progress)
         s2 = self.List.connect("adapter-property-changed", prop_changed)
 
-    def setup(self, device):
+    @staticmethod
+    def setup(device):
         command = "blueman-assistant --device=%s" % device['Address']
         launch(command, None, False, "blueman", _("Bluetooth Assistant"))
 
-    def bond(self, device):
+    @staticmethod
+    def bond(device):
         def error_handler(e):
             logging.exception(e)
             message = 'Pairing failed for:\n%s (%s)' % (device['Alias'], device['Address'])
@@ -210,10 +212,12 @@ class Blueman(Gtk.Window):
 
         device.pair(error_handler=error_handler)
 
-    def adapter_properties(self):
+    @staticmethod
+    def adapter_properties():
         launch("blueman-adapters", None, False, "blueman", _("Adapter Preferences"))
 
-    def toggle_trust(self, device):
+    @staticmethod
+    def toggle_trust(device):
         device['Trusted'] = not device['Trusted']
 
     def send(self, device, f=None):

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -66,7 +66,7 @@ class Sender(Gtk.Dialog):
         self.pb.props.text = _("Connecting")
 
         self.device = device
-        self.adapter = Adapter(adapter_path)
+        self.adapter = Adapter(obj_path=adapter_path)
         self.manager = Manager()
         self.files: List[Gio.File] = []
         self.num_files = 0
@@ -166,7 +166,7 @@ class Sender(Gtk.Dialog):
         self._last_bytes = 0
         self.transferred = 0
 
-        self.transfer = Transfer(transfer_path)
+        self.transfer = Transfer(obj_path=transfer_path)
         self.transfer.connect("error", self.on_transfer_error)
         self.transfer.connect("progress", self.on_transfer_progress)
         self.transfer.connect("completed", self.on_transfer_completed)
@@ -268,7 +268,7 @@ class Sender(Gtk.Dialog):
             self.error_dialog = d
 
     def on_session_added(self, _manager, session_path):
-        self.object_push = ObjectPush(session_path)
+        self.object_push = ObjectPush(obj_path=session_path)
         self.object_push_handlers.append(self.object_push.connect("transfer-started", self.on_transfer_started))
         self.object_push_handlers.append(self.object_push.connect("transfer-failed", self.on_transfer_failed))
         self.process_queue()

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -139,14 +139,14 @@ class BluezAgent(DbusService):
         return dialog, pin_entry
 
     def get_device_string(self, device_path):
-        device = Device(device_path)
+        device = Device(obj_path=device_path)
         return "<b>%s</b> (%s)" % (escape(device["Alias"]), device["Address"])
 
     def _lookup_default_pin(self, device_path):
         if not self._db:
             self._db = ElementTree.parse(os.path.join(PKGDATA_DIR, 'pin-code-database.xml'))
 
-        device = Device(device_path)
+        device = Device(obj_path=device_path)
         lookup_dict = {
             'name': device['Name'],
             'type': bt_class_to_string(device['Class']),
@@ -241,7 +241,7 @@ class BluezAgent(DbusService):
 
     def _on_display_passkey(self, device, passkey, _entered):
         logging.info('DisplayPasskey (%s, %d)' % (device, passkey))
-        dev = Device(device)
+        dev = Device(obj_path=device)
         self._devhandlerids[device] = dev.connect_signal("property-changed", self._on_device_property_changed)
 
         notify_message = _("Pairing passkey for") + " %s: %s" % (self.get_device_string(device), passkey)
@@ -250,7 +250,7 @@ class BluezAgent(DbusService):
 
     def _on_display_pin_code(self, device, pin_code):
         logging.info('DisplayPinCode (%s, %s)' % (device, pin_code))
-        dev = Device(device)
+        dev = Device(obj_path=device)
         self._devhandlerids[device] = dev.connect_signal("property-changed", self._on_device_property_changed)
 
         notify_message = _("Pairing PIN code for") + " %s: %s" % (self.get_device_string(device), pin_code)
@@ -282,7 +282,7 @@ class BluezAgent(DbusService):
             logging.info(action)
 
             if action == "always":
-                device = Device(n._device)
+                device = Device(obj_path=n._device)
                 device.set("Trusted", True)
             if action == "always" or action == "accept":
                 ok()

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -44,14 +44,14 @@ class DBusService(AppletPlugin):
             self.parent.Plugins.RecentConns.notify(object_path, uuid)
 
         if uuid == '00000000-0000-0000-0000-000000000000':
-            device = Device(object_path)
+            device = Device(obj_path=object_path)
             device.connect(reply_handler=ok, error_handler=err)
         else:
             def cb(_inst, ret):
                 if ret:
                     raise StopException
 
-            service = get_service(Device(object_path), uuid)
+            service = get_service(Device(obj_path=object_path), uuid)
             assert service is not None
 
             if isinstance(service, SerialService) and 'NMDUNSupport' in self.parent.Plugins.get_loaded():
@@ -74,14 +74,14 @@ class DBusService(AppletPlugin):
 
     def _disconnect_service(self, object_path, uuid, port, ok, err):
         if uuid == '00000000-0000-0000-0000-000000000000':
-            device = Device(object_path)
+            device = Device(obj_path=object_path)
             device.disconnect(reply_handler=ok, error_handler=err)
         else:
             def cb(_inst, ret):
                 if ret:
                     raise StopException
 
-            service = get_service(Device(object_path), uuid)
+            service = get_service(Device(obj_path=object_path), uuid)
             assert service is not None
 
             if isinstance(service, SerialService) and 'NMDUNSupport' in self.parent.Plugins.get_loaded():

--- a/blueman/plugins/applet/GameControllerWakelock.py
+++ b/blueman/plugins/applet/GameControllerWakelock.py
@@ -31,7 +31,7 @@ class GameControllerWakelock(AppletPlugin):
 
     def on_device_property_changed(self, path, key, value):
         if key == "Connected":
-            klass = Device(path)["Class"] & 0x1fff
+            klass = Device(obj_path=path)["Class"] & 0x1fff
 
             if klass == 0x504 or klass == 0x508:
                 if value:

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -313,7 +313,7 @@ class NetUsage(AppletPlugin, GObject.GObject):
 
     def _on_network_property_changed(self, _network, key, value, path):
         if key == "Interface" and value != "":
-            d = Device(path)
+            d = Device(obj_path=path)
             self.monitor_interface(Monitor, d, value)
 
     def activate_ui(self):

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -118,9 +118,10 @@ class Dialog:
         cr1 = Gtk.CellRendererText()
         cr1.props.ellipsize = Pango.EllipsizeMode.END
 
-        plugin.connect("monitor-added", self.monitor_added),
-        plugin.connect("monitor-removed", self.monitor_removed),
-        plugin.connect("stats", self.on_stats)
+        self._handlerids: List[int] = []
+        self._handlerids.append(plugin.connect("monitor-added", self.monitor_added))
+        self._handlerids.append(plugin.connect("monitor-removed", self.monitor_removed))
+        self._handlerids.append(plugin.connect("stats", self.on_stats))
 
         cr2 = Gtk.CellRendererText()
         cr2.props.sensitive = False
@@ -189,9 +190,9 @@ class Dialog:
         self.dialog.show()
 
     def on_response(self, dialog, response):
-        self.plugin.disconnect_by_func(self.monitor_added)
-        self.plugin.disconnect_by_func(self.monitor_removed)
-        self.plugin.disconnect_by_func(self.on_stats)
+        for sigid in self._handlerids:
+            self.plugin.disconnect(sigid)
+        self._handlerids = []
         Dialog.running = False
         self.dialog.destroy()
 

--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -50,7 +50,7 @@ class Networking(AppletPlugin):
 
     def on_unload(self):
         for adapter_path in self._registered:
-            s = NetworkServer(adapter_path)
+            s = NetworkServer(obj_path=adapter_path)
             s.unregister("nap")
 
         self._registered = {}
@@ -75,7 +75,7 @@ class Networking(AppletPlugin):
 
                 registered = self._registered.setdefault(object_path, False)
 
-                s = NetworkServer(object_path)
+                s = NetworkServer(obj_path=object_path)
                 if on and not registered:
                     s.register("nap", "pan1")
                     self._registered[object_path] = True

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -201,5 +201,5 @@ class PowerManager(AppletPlugin):
             return "blueman-disabled", "blueman-disabled"
 
     def on_adapter_added(self, path):
-        adapter = Adapter(path)
+        adapter = Adapter(obj_path=path)
         adapter.set("Powered", self.adapter_state)

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -188,7 +188,7 @@ class RecentConns(AppletPlugin):
         self.initialize()
 
     def notify(self, object_path, uuid):
-        device = Device(object_path)
+        device = Device(obj_path=object_path)
         logging.info("%s %s" % (device, uuid))
         item = {}
         try:

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -53,7 +53,7 @@ class SerialManager(AppletPlugin):
 
     def on_device_property_changed(self, path, key, value):
         if key == "Connected" and not value:
-            device = Device(path)
+            device = Device(obj_path=path)
             self.terminate_all_scripts(device["Address"])
             self.on_device_disconnect(device)
 

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -83,8 +83,8 @@ class Agent(DbusService):
             else:
                 err(ObexErrorRejected("Rejected"))
 
-        transfer = Transfer(transfer_path)
-        session = Session(transfer.session)
+        transfer = Transfer(obj_path=transfer_path)
+        session = Session(obj_path=transfer.session)
         root = session.root
         address = session.address
         filename = transfer.name

--- a/blueman/services/meta/NetworkService.py
+++ b/blueman/services/meta/NetworkService.py
@@ -10,7 +10,7 @@ from blueman.bluez.errors import BluezDBusException
 class NetworkService(Service):
     def __init__(self, device: Device, uuid: str):
         super().__init__(device, uuid)
-        self._service = Network(device.get_object_path())
+        self._service = Network(obj_path=device.get_object_path())
 
     @property
     def available(self) -> bool:

--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -78,7 +78,8 @@ class SerialService(Service):
                 raise error
 
         try:
-            port_id = create_rfcomm_device(Adapter(self.device["Adapter"])['Address'], self.device["Address"], channel)
+            port_id = create_rfcomm_device(Adapter(obj_path=self.device["Adapter"])['Address'], self.device["Address"],
+                                           channel)
             filename = '/dev/rfcomm%d' % port_id
             logging.info('Starting rfcomm watcher as root')
             Mechanism().OpenRFCOMM('(d)', port_id)


### PR DESCRIPTION
Needs some proper testing but this looks to me like the best solution to have properly type-checked code. Supersedes  #1142

* Only allow keyword arguments
* Only use obj_path keyword
* Still fallback on the class _interface_name
* Fixes Optional mypy error for obj_path and interface_name