### PR TITLE
Assistant: Fix PyGTKDeprecationWarnings for Gtk.Button constructor

### DIFF
--- a/apps/blueman-assistant.in
+++ b/apps/blueman-assistant.in
@@ -209,14 +209,14 @@ class Assistant:
             rbs = []
 
             for service in services:
-                rbs.append(Gtk.RadioButton(service.name))
+                rbs.append(Gtk.RadioButton(label=service.name))
                 rbs[-1].connect("toggled", self.on_service_toggled, service)
                 self.svc_vbox.pack_start(rbs[-1], False, False, 0)
 
                 if len(rbs) > 1:
                     rbs[-1].join_group(rbs[0])
 
-            rbs.append(Gtk.RadioButton(_("Don't connect")))
+            rbs.append(Gtk.RadioButton(label=_("Don't connect")))
             rbs[-1].join_group(rbs[0])
             rbs[-1].connect("toggled", self.on_service_toggled, None)
             self.svc_vbox.pack_start(rbs[-1], False, False, 8)

--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -50,7 +50,7 @@ class SettingsWidget(Gtk.Box):
             return params["widget"](self.inst, opt, params)
 
         elif params["type"] == bool:
-            c = Gtk.CheckButton(params["name"])
+            c = Gtk.CheckButton(label=params["name"])
 
             c.props.active = self.inst.get_option(opt)
             c.connect("toggled", self.handle_change, opt, params, "active")

--- a/blueman/main/Services.py
+++ b/blueman/main/Services.py
@@ -33,8 +33,8 @@ class BluemanServices(Gtk.Window):
         button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, halign=Gtk.Align.END, visible=True)
         grid.add(button_box)
 
-        self.b_apply = Gtk.Button("_Apply", receives_default=True, use_underline=True, sensitive=False, visible=True,
-                                  width_request=80)
+        self.b_apply = Gtk.Button(label="_Apply", receives_default=True, use_underline=True,
+                                  sensitive=False, visible=True, width_request=80)
         button_box.add(self.b_apply)
 
         self.viewport = Gtk.Viewport(visible=True, width_request=120)


### PR DESCRIPTION
When clicking on Setup... in blueman-manager:

/usr/bin/blueman-assistant:212: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated.
Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  rbs.append(Gtk.RadioButton(service.name))
/usr/bin/blueman-assistant:219: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated.
Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  rbs.append(Gtk.RadioButton(_("Don't connect")))