### PR TITLE
Handle missing __author__ or __description__ in plugins

### DIFF
--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -189,8 +189,8 @@ class PluginDialog(Gtk.Window):
         cls = self.applet.Plugins.get_classes()[name]
         self.plugin_name.props.label = "<b>" + name + "</b>"
         self.icon.props.icon_name = cls.__icon__
-        self.author_txt.props.label = cls.__author__ or _("Unspecified")
-        self.description.props.label = cls.__description__ or _("Unspecified")
+        self.author_txt.props.label = cls.__author__
+        self.description.props.label = cls.__description__
 
         if cls.__depends__:
             self.depends_hdr.props.visible = True

--- a/blueman/plugins/BasePlugin.py
+++ b/blueman/plugins/BasePlugin.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import logging
 import weakref
+from gettext import gettext as _
 from typing import List, TYPE_CHECKING, Dict, Tuple, Any
 
 from blueman.main.Config import Config
@@ -33,8 +34,8 @@ class BasePlugin(object):
     __conflicts__: List[str] = []
     __priority__ = 0
 
-    __description__: str
-    __author__: str
+    __description__: str = _("Unspecified")
+    __author__: str = _("Unspecified")
 
     __unloadable__ = True
     __autoload__ = True


### PR DESCRIPTION
It could be done with hasattr() but this would be ugly so instead have
a default on the BasePlugin class

```
Traceback (most recent call last):
  File "/home/sander/repos/blueman/blueman/gui/applet/PluginDialog.py", line 192, in on_selection_changed
    self.author_txt.props.label = cls.__author__ or _("Unspecified")
AttributeError: type object 'AutoConnect' has no attribute '__author__'
```