### PR TITLE
Call the right method when pulseaudio crashes

### DIFF
--- a/blueman/main/PulseAudioUtils.py
+++ b/blueman/main/PulseAudioUtils.py
@@ -210,7 +210,7 @@ class PulseAudioUtils(GObject.GObject, metaclass=SingletonGObjectMeta):
 
         if self.prev_state == PA_CONTEXT_READY and state == PA_CONTEXT_FAILED:
             logging.info("Pulseaudio probably crashed, restarting in 5s")
-            GLib.timeout_add(5000, self.connect_rfcomm)
+            GLib.timeout_add(5000, self.connect_pulseaudio)
 
         self.prev_state = state
 


### PR DESCRIPTION
This is @nico202 patch rebased against master so that CI passes. I'll open a PR for stable as well that  contains this and the cython langversion commit.