### PR TITLE
Simplify autotools check for systemd paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -215,25 +215,10 @@ AC_ARG_ENABLE([appindicator],
 
 AM_CONDITIONAL([HAVE_APPINDICATOR], [test "x$use_appindicator" = "xyes"])
 
-AC_ARG_WITH([systemdsystemunitdir],
-  AS_HELP_STRING([--with-systemdsystemunitdir=PATH],
-    [Directory for systemd system unit files]
-    [[default=/usr/lib/systemd/system]]),
-  [systemd_system_unit_dir="$withval"],
-  [PKG_CHECK_VAR([systemd_system_unit_dir], [systemd], [systemdsystemunitdir],
-   [], [systemd_system_unit_dir='/usr/lib/systemd/system'])])
-AC_SUBST([systemd_system_unit_dir])
-AM_CONDITIONAL([SYSTEMD_SYSTEM_UNIT_DIR], [test "x$systemd_system_unit_dir" != "xno"])
-
-AC_ARG_WITH([systemduserunitdir],
-  AS_HELP_STRING([--with-systemduserunitdir=PATH],
-    [Directory for systemd user unit files]
-    [[default=/usr/lib/systemd/user]]),
-  [systemd_user_unit_dir="$withval"],
-  [PKG_CHECK_VAR([systemd_user_unit_dir], [systemd], [systemduserunitdir],
-   [], [systemd_user_unit_dir='/usr/lib/systemd/user'])])
-AC_SUBST([systemd_user_unit_dir])
-AM_CONDITIONAL([SYSTEMD_USER_UNIT_DIR], [test "x$systemd_user_unit_dir" != "xno"])
+PKG_CHECK_VAR([SYSTEMD_SYSTEM_UNIT_DIR], [systemd], [systemdsystemunitdir], [], [systemd_system_unit_dir='/usr/lib/systemd/system'])
+AM_CONDITIONAL([HAS_SYSTEMD_SYSTEM_UNIT_DIR], [test "x$systemd_system_unit_dir" != "x"])
+PKG_CHECK_VAR([SYSTEMD_USER_UNIT_DIR], [systemd], [systemduserunitdir], [], [systemd_user_unit_dir='/usr/lib/systemd/user'])
+AM_CONDITIONAL([HAS_SYSTEMD_USER_UNIT_DIR], [test "x$systemd_user_unit_dir" != "x"])
 
 # GSettings related settings
 GLIB_GSETTINGS

--- a/data/configs/Makefile.am
+++ b/data/configs/Makefile.am
@@ -7,13 +7,13 @@ dbus_services_DATA = org.blueman.Mechanism.service
 dbus_sessdir = $(datadir)/dbus-1/services
 dbus_sess_DATA = org.blueman.Applet.service
 
-if SYSTEMD_SYSTEM_UNIT_DIR
-systemd_systemdir = $(systemd_system_unit_dir)
+if HAS_SYSTEMD_SYSTEM_UNIT_DIR
+systemd_systemdir = $(SYSTEMD_SYSTEM_UNIT_DIR)
 systemd_system_DATA = blueman-mechanism.service
 endif
 
-if SYSTEMD_USER_UNIT_DIR
-systemd_userdir = $(systemd_user_unit_dir)
+if HAS_SYSTEMD_USER_UNIT_DIR
+systemd_userdir = $(SYSTEMD_USER_UNIT_DIR)
 systemd_user_DATA = blueman-applet.service
 endif
 


### PR DESCRIPTION
PKG_CHECK_VAR already provides a way to overwrite the checked result using
an environment variable (preferably passed as an argument to ./configure).

Dropping the --with-systemd*unitdir parameters simplifies configure.ac,
makes the output of ./configure --help less confusing -- it had

	Optional Packages:
	  --with-systemdsystemunitdir=PATH
	                          Directory for systemd system unit files
	                          [default=/usr/lib/systemd/system]
	  --with-systemduserunitdir=PATH
	                          Directory for systemd user unit files
	                          [default=/usr/lib/systemd/user]

	Some influential environment variables:
	...
	  systemd_system_unit_dir
	              value of systemdsystemunitdir for systemd, overriding pkg-config
	  systemd_user_unit_dir
	              value of systemduserunitdir for systemd, overriding pkg-config

before -- and stops providing two ways to overwrite systemd's pkg-config
information.

For consistency with other variables use uppercase variable names.

The user visible change is that --with-systemd*unitdir doesn't exist any
more and instead of

	./configure --with-systemdsystemunitdir=/some/path

you have to use

	./configure SYSTEMD_SYSTEM_UNIT_DIR=/some/path

and to disable use:

	./configure SYSTEMD_SYSTEM_UNIT_DIR=''

.