### PR TITLE
NetworkManager: Fix disconnecting NMDevice

### DIFF
--- a/blueman/main/NetworkManager.py
+++ b/blueman/main/NetworkManager.py
@@ -8,7 +8,7 @@ try:
 except ValueError:
     raise ImportError('NM python bindings not found.')
 
-from gi.repository import GLib, NM
+from gi.repository import GLib, GObject, NM
 from blueman.main.Config import Config
 
 
@@ -80,7 +80,7 @@ class NMConnectionBase(object):
             return  # Keep checking the state changes
 
         # We are done with state changes
-        device.disconnect(self._statehandler)
+        GObject.signal_handler_disconnect(device, self._statehandler)
         if error_msg is None:
             self._return_or_reply_handler(reply_msg)
         else:


### PR DESCRIPTION
NMDevice.disconnect shadows the signal handler disconnect

Traceback (most recent call last):
  File "/home/sander/repos/blueman/blueman/main/NetworkManager.py", line 83, in _on_device_state_changed
    device.disconnect(self._statehandler)
TypeError: argument cancellable: Expected Gio.Cancellable, but got int