### PR TITLE
Do not use exitcode 1 when we expect to fail

### DIFF
--- a/apps/blueman-assistant.in
+++ b/apps/blueman-assistant.in
@@ -21,7 +21,8 @@ from blueman.Functions import (
     set_proc_title,
     check_bluetooth_status,
     create_logger,
-    create_parser
+    create_parser,
+    bmexit
 )
 
 from blueman.Constants import UI_PATH
@@ -49,7 +50,7 @@ class Assistant:
     def __init__(self, parsed_args):
         setup_icon_path()
 
-        check_bluetooth_status(_("Bluetooth needs to be turned on for the Bluetooth assistant to work"), lambda: exit())
+        check_bluetooth_status(_("Bluetooth needs to be turned on for the Bluetooth assistant to work"), bmexit)
 
         self.Manager = Manager()
         self.Device = None
@@ -99,7 +100,7 @@ class Assistant:
         if not self.dev_widget.List.is_valid_adapter():
             d = ErrorDialog(_("No adapters found"), icon_name="blueman", title="Blueman Assistant")
             d.run()
-            exit(1)
+            bmexit()
 
         self.assistant.show()
 
@@ -108,7 +109,7 @@ class Assistant:
                 self.Adapter = self.Manager.get_adapter()
             except ValueError:
                 logging.error("Error: No Adapters present")
-                exit(1)
+                bmexit()
             self.Device = self.Manager.find_device(parsed_args.device, self.Adapter.get_object_path())
             if self.Device['Paired']:
                 self.assistant.set_current_page(PAGE_CONNECT)

--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -32,7 +32,7 @@ class SendTo:
     def __init__(self, parsed_args):
         setup_icon_path()
 
-        check_bluetooth_status(_("Bluetooth needs to be turned on for file sending to work"), lambda: exit())
+        check_bluetooth_status(_("Bluetooth needs to be turned on for file sending to work"), bmexit)
 
         if not parsed_args.files:
             self.files = self.select_files()
@@ -47,7 +47,7 @@ class SendTo:
 
         if len(adapters) == 0:
             logging.error("Error: No Adapters present")
-            exit()
+            bmexit()
 
         if parsed_args.source is not None:
             try:
@@ -72,14 +72,14 @@ class SendTo:
 
         if parsed_args.device is None:
             if not self.select_device():
-                exit()
+                bmexit()
 
             self.do_send()
 
         else:
             d = manager.find_device(parsed_args.device, self.adapter_path)
             if d is None:
-                exit("Unknown bluetooth device")
+                bmexit("Unknown bluetooth device")
 
             self.device = d
             self.do_send()
@@ -87,7 +87,7 @@ class SendTo:
     def do_send(self):
         if not self.files:
             logging.warning("No files to send")
-            exit()
+            bmexit()
 
         sender = Sender(self.device, self.adapter_path, self.files)
 

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -53,7 +53,7 @@ from gi.repository import GLib
 from gi.repository import Gio
 
 
-__all__ = ["check_bluetooth_status", "launch", "setup_icon_path", "adapter_path_to_name", "e_",
+__all__ = ["check_bluetooth_status", "launch", "setup_icon_path", "adapter_path_to_name", "e_", "bmexit",
            "format_bytes", "create_menuitem", "get_lockfile", "get_pid", "is_running", "check_single_instance", "kill",
            "have", "set_proc_title", "create_logger", "create_parser", "open_rfcomm", "get_local_interfaces"]
 
@@ -272,7 +272,7 @@ def check_single_instance(name: str, unhide_func: Optional[Callable[[int], Any]]
                     f.write("%s\n%s" % (str(pid), str(time)))
 
                 os.kill(pid, signal.SIGUSR1)
-                exit()
+                bmexit()
         else:
             os.remove(lockfile)
 
@@ -283,7 +283,7 @@ def check_single_instance(name: str, unhide_func: Optional[Callable[[int], Any]]
         os.close(fd)
     except OSError:
         print("There is an instance already running")
-        exit()
+        bmexit()
 
     atexit.register(lambda: os.remove(lockfile))
 
@@ -424,3 +424,7 @@ def get_local_interfaces() -> Dict[str, Tuple[str, Optional[str]]]:
         return {}
 
     return ip_dict
+
+
+def bmexit(msg: Optional[Union[str, int]] = None) -> None:
+    raise SystemExit(msg)

--- a/blueman/main/Adapter.py
+++ b/blueman/main/Adapter.py
@@ -61,12 +61,12 @@ class BluemanAdapters(Gtk.Window):
 
         check_single_instance("blueman-adapters", lambda time: self.present_with_time(time))
 
-        check_bluetooth_status(_("Bluetooth needs to be turned on for the adapter manager to work"), lambda: exit())
+        check_bluetooth_status(_("Bluetooth needs to be turned on for the adapter manager to work"), bmexit)
 
         adapters = self.manager.get_adapters()
         if not adapters:
             logging.error('No adapter(s) found')
-            exit(1)
+            bmexit()
 
         self.manager.connect_signal('adapter-added', self.on_adapter_added)
         self.manager.connect_signal('adapter-removed', self.on_adapter_removed)

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -108,7 +108,7 @@ class Blueman(Gtk.Window):
                 self.Applet = AppletService()
             except DBusProxyFailed:
                 print("Blueman applet needs to be running")
-                exit()
+                bmexit()
 
             check_bluetooth_status(_("Bluetooth needs to be turned on for the device manager to function"),
                                    lambda: Gtk.main_quit())
@@ -122,7 +122,7 @@ class Blueman(Gtk.Window):
                     manager.get_adapter(None)
                 except DBusNoSuchAdapterError:
                     logging.error('No adapter(s) found, exiting')
-                    exit(1)
+                    bmexit()
 
             self._applethandlerid = self.Applet.connect('g-signal', on_applet_signal)
 

--- a/blueman/main/PluginManager.py
+++ b/blueman/main/PluginManager.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Type, Union
 
 from gi.repository import GObject
 
+from blueman.Functions import bmexit
 from blueman.gui.CommonUi import ErrorDialog
 from blueman.main.Config import Config
 from blueman.plugins.AppletPlugin import AppletPlugin
@@ -161,7 +162,7 @@ class PluginManager(GObject.GObject):
         except Exception:
             logging.error("Failed to load %s" % cls.__name__, exc_info=True)
             if not cls.__unloadable__:
-                os._exit(1)
+                bmexit()
 
             raise  # NOTE TO SELF: might cause bugs
 


### PR DESCRIPTION
Passing an exitcode will trigger distributions crash handlers. We really
are expecting to fail so there is no abnormal situation for us.

Also wrap "raise SystemExit" in a function and use it everywhere.