### PR TITLE
Gettext translation maintanance

### DIFF
--- a/.github/workflows/weblate.yml
+++ b/.github/workflows/weblate.yml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get install gettext curl
-      - run: /usr/bin/xgettext --default-domain=blueman --directory=.. --from-code=UTF-8 --add-comments --files-from=./POTFILES.in --output=blueman.pot
         working-directory: po
       - env:
           TOKEN: ${{ secrets.WEBLATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 /po/quot.sed
 /po/remove-potcdate.sin
 /po/Rules-quot
-/po/blueman.pot
 /po/boldquot.sed
 /po/*.header
 /po/stamp-po

--- a/po/af.po
+++ b/po/af.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Afrikaans (http://www.transifex.com/mate/MATE/language/af/)\n"
@@ -1442,21 +1442,12 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
-msgstr ""
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
 msgstr ""
 
 #: data/blueman-manager.desktop.in:3

--- a/po/am.po
+++ b/po/am.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Amharic (http://www.transifex.com/mate/MATE/language/am/)\n"
@@ -1473,40 +1473,26 @@ msgstr "የ ማስተላለፊያ ግልጋሎት ተሰኪ አፕሌት ተሰ�
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "የ ብሉቱዝ አዳፕተሮች"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "አፕሌት"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman is a GTK+ የ ብሉቱዝ አስተዳዳሪ"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "ብሉቱዝ ተችሏል"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "የ ብሉቱዝ አካሎች"
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -14,8 +14,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1500,40 +1500,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "محولات بلوتوث"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "بريمج"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "فُعّل البلوتوث"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "فُعّل البلوتوث"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "أجهزة البلوتوث"
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Asturian (http://www.transifex.com/mate/MATE/language/ast/)\n"
@@ -1471,40 +1471,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adautadores Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth habilitáu"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth habilitáu"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Preseos Bluetooth"
 

--- a/po/be.po
+++ b/po/be.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Belarusian (http://www.transifex.com/mate/MATE/language/be/)\n"
@@ -1505,40 +1505,26 @@ msgstr "Плагін службы перадачы аплета адключан
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth-адаптары"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "аплет"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth уключаны"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth уключаны"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Прылады Bluetooth"
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Bulgarian (http://www.transifex.com/mate/MATE/language/bg/)\n"
@@ -1504,40 +1504,26 @@ msgstr "Приставката за трансфер на аплета е изк
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Адаптери за блутут"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "аплет"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "„Blueman“ е мениджър на устройства с блутут, базиран на GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Блутут е включен"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Устройства с блутут"
 

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -1,55 +1,50 @@
-# Romanian translation for blueman.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Copyright © 2008 - 2020 blueman project
 # This file is distributed under the same license as the blueman package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-# Translators:
-# Daniel <danny3@tutanota.com>, 2015-2016
-# Daniel <danny3@tutanota.com>, 2017
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
-# sorinn <nemes.sorin@gmail.com>, 2014
-# Octi <octi@writeme.com>, 2014
-# sidro <slacky2005@gmail.com>, 2014
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: blueman-project\n"
+"Project-Id-Version: blueman 2.2\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
 "POT-Creation-Date: 2020-06-19 20:58+0200\n"
-"PO-Revision-Date: 2020-04-14 10:14+0000\n"
-"Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
-"Language-Team: Romanian (http://www.transifex.com/mate/MATE/language/ro/)\n"
-"Language: ro\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
-"2:1));\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: data/ui/adapters-tab.ui:29
 msgid "<b>Visibility Setting</b>"
-msgstr "<b>Configurări vizibilitate</b>"
+msgstr ""
 
 #: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
 msgid "Hidden"
-msgstr "Ascuns"
+msgstr ""
 
 #: data/ui/adapters-tab.ui:54
 msgid "Always visible"
-msgstr "Vizibil întotdeauna"
+msgstr ""
 
 #: data/ui/adapters-tab.ui:70
 msgid "Temporarily visible"
-msgstr "Vizibil temporar"
+msgstr ""
 
 #: data/ui/adapters-tab.ui:101
 msgid "<b>Friendly Name</b>"
-msgstr "<b>Nume prietenos</b>"
+msgstr ""
 
 #: data/ui/applet-passkey.ui:8
 msgid "Pairing request"
-msgstr "Cerere de asociere"
+msgstr ""
 
 #: data/ui/applet-passkey.ui:91
 msgid "Pairing request for device:"
-msgstr "Cerere de asociere pentru „%s”"
+msgstr ""
 
 #: data/ui/applet-passkey.ui:120
 msgid "This should be overwritten"
@@ -57,106 +52,106 @@ msgstr ""
 
 #: data/ui/applet-passkey.ui:140
 msgid "Show input"
-msgstr "Intrare formular"
+msgstr ""
 
 #: data/ui/manager-main.ui:53
 msgid "_Adapter"
-msgstr "_Adaptor"
+msgstr ""
 
 #: data/ui/manager-main.ui:61
 msgid "_Device"
-msgstr "_Dispozitiv"
+msgstr ""
 
 #: data/ui/manager-main.ui:69
 msgid "_View"
-msgstr "_Vizualizare"
+msgstr ""
 
 #: data/ui/manager-main.ui:77
 msgid "_Help"
-msgstr "_Ajutor"
+msgstr ""
 
 #: data/ui/manager-main.ui:96
 msgid "Search for nearby devices"
-msgstr "Caută dispozitive în apropiere"
+msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
 #: data/ui/manager-main.ui:98
 msgid "Search"
-msgstr "Caută"
+msgstr ""
 
 #: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:328
 msgid "Create pairing with the device"
-msgstr "Creează asociere cu dispozitivul"
+msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
 #: data/ui/manager-main.ui:122
 msgid "Pair"
-msgstr "Asociază"
+msgstr ""
 
 #: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:346
 msgid "Mark/Unmark this device as trusted"
-msgstr "Marchează / Demarchează acest dispozitiv ca fiind de încredere"
+msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
 #: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:30
 #: blueman/gui/manager/ManagerToolbar.py:95
 msgid "Trust"
-msgstr "De încredere"
+msgstr ""
 
 #: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Run the setup assistant for this device"
-msgstr "Rulează asistentul de instalare pentru acest dispozitiv"
+msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
 #: data/ui/manager-main.ui:151
 msgid "Setup..."
-msgstr "Instalare..."
+msgstr ""
 
 #: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:387
 msgid "Remove this device from the known devices list"
-msgstr "Elimină acest dispozitiv din lista de dispozitive cunoscute"
+msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
 #: data/ui/manager-main.ui:165
 msgid "Remove"
-msgstr "Elimină"
+msgstr ""
 
 #: data/ui/manager-main.ui:187
 msgid "Send file(s) to the device"
-msgstr "Trimiteți fișier(e) dispozitivului"
+msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
 #: data/ui/manager-main.ui:189
 msgid "Send File"
-msgstr "Send Files"
+msgstr ""
 
 #: data/ui/rename-device.ui:8
 msgid "Rename device"
-msgstr "Redenumire dispozitiv"
+msgstr ""
 
 #: data/ui/services-network.ui:37
 msgid "Network Access Point (NAP)"
-msgstr "Punct de acces rețea (NAP)"
+msgstr ""
 
 #: data/ui/services-network.ui:57
 msgid "<b>Services</b>"
-msgstr "<b>Servicii</b>"
+msgstr ""
 
 #: data/ui/services-network.ui:87
 msgid "DHCP server type:"
-msgstr "Tip servitor DHCP:"
+msgstr ""
 
 #: data/ui/services-network.ui:114
 msgid "Recommended"
-msgstr "Recomandat"
+msgstr ""
 
 #: data/ui/services-network.ui:138
 msgid "IP Address:"
-msgstr "Adresă IP:"
+msgstr ""
 
 #: data/ui/services-network.ui:181
 msgid "<b>No DHCP servers installed</b>"
-msgstr "<b>Nu este instalat niciun servitor DHCP</b>"
+msgstr ""
 
 #: data/ui/services-network.ui:199
 msgid "udhcpd"
@@ -164,52 +159,51 @@ msgstr ""
 
 #: data/ui/services-network.ui:218
 msgid "<b>NAP Settings</b>"
-msgstr "<b>Stabiliri NAP</b>"
+msgstr ""
 
 #: data/ui/services-network.ui:282
 msgid "<b>PAN Support</b>"
-msgstr "<b>Capabilitate PAN</b>"
+msgstr ""
 
 #: data/ui/services-network.ui:357
 msgid "<b>DUN Support</b>"
-msgstr "<b>Capabilitate DUN</b>"
+msgstr ""
 
 #: data/ui/services-network.ui:391
 msgid "<b>Network Settings</b>"
-msgstr "<b>Stabiliri rețea</b>"
+msgstr ""
 
 #: data/ui/services-transfer.ui:24
 msgid "<b>File Receiving (Object Push)</b>"
-msgstr "<b>Primire fișier (Împingere obiect)</b>"
+msgstr ""
 
 #: data/ui/services-transfer.ui:37
 msgid "Incoming Folder:"
-msgstr "Dosar primire:"
+msgstr ""
 
 #: data/ui/services-transfer.ui:49
 msgid "Select folder for incoming file transfers"
-msgstr "Selctați dosarul pentru primirea fișierelor"
+msgstr ""
 
 #: data/ui/services-transfer.ui:58
 msgid "Accept files from trusted devices"
-msgstr "Acceptă fișiere de la dispozitive de încredere"
+msgstr ""
 
 #: data/ui/services-transfer.ui:96
 msgid "<b>Transfer Settings</b>"
-msgstr "<b>Stabiliri transfer</b>"
+msgstr ""
 
 #: data/ui/send-dialog.ui:32
 msgid "<span weight=\"bold\" size=\"large\">Sending files via Bluetooth</span>"
 msgstr ""
-"<span weight=\"bold\" size=\"large\">Se trimit fișiere prin Bluetooth</span>"
 
 #: data/ui/send-dialog.ui:68
 msgid "<b>To:</b>"
-msgstr "<b>Către:</b>"
+msgstr ""
 
 #: data/ui/send-dialog.ui:106
 msgid "<b>File:</b>"
-msgstr "<b>Fișier:</b>"
+msgstr ""
 
 #: data/ui/assistant.ui:16
 msgid ""
@@ -219,24 +213,18 @@ msgid ""
 "It will walk you through the process of configuring and connecting to your "
 "Bluetooth enabled devices."
 msgstr ""
-"<b>Bine ați venit la asistentul de configurare al serviciului Bluetooth. </"
-"b>\n"
-"\n"
-"\n"
-"Acesta vă va ajuta în procesul de configururare și conectare a "
-"dispozitivelor dumneavoastră cu capabilitate de comunicare prin Bluetooth."
 
 #: data/ui/assistant.ui:25
 msgid "Introduction"
-msgstr "Introducere"
+msgstr ""
 
 #: data/ui/assistant.ui:38
 msgid "Device"
-msgstr "Dispozitiv"
+msgstr ""
 
 #: data/ui/assistant.ui:54
 msgid "<b>Select pairing method to use:</b>"
-msgstr "<b>Selectați metoda de asociere de utilizat:</b>"
+msgstr ""
 
 #: data/ui/assistant.ui:65
 msgid "Pair Device"
@@ -244,114 +232,114 @@ msgstr ""
 
 #: data/ui/assistant.ui:81
 msgid "Proceed Without Pairing"
-msgstr "Continuă fără asociere"
+msgstr ""
 
 #: data/ui/assistant.ui:97 data/ui/assistant.ui:111
 msgid "Pairing"
-msgstr "Se asociază"
+msgstr ""
 
 #: data/ui/assistant.ui:128
 msgid "<b>Connect to:</b>"
-msgstr "<b>Conectare la:</b>"
+msgstr ""
 
 #: data/ui/assistant.ui:154
 msgid "Connect"
-msgstr "Conectează"
+msgstr ""
 
 #: data/ui/assistant.ui:161
 msgid "<b>Please wait...</b>"
-msgstr "<b>Așteptați...</b>"
+msgstr ""
 
 #: data/ui/assistant.ui:166 blueman/gui/manager/ManagerDeviceMenu.py:124
 #: blueman/gui/manager/ManagerDeviceMenu.py:179
 msgid "Connecting..."
-msgstr "Se conectează..."
+msgstr ""
 
 #: data/ui/assistant.ui:173
 msgid "<b>Congratulations, device successfully added</b>"
-msgstr "<b>Felicitări, dispozitivul a fost adăugat cu succes</b>"
+msgstr ""
 
 #: data/ui/assistant.ui:180
 msgid "Finished"
-msgstr "Finalizată"
+msgstr ""
 
 #: data/ui/applet-plugins-widget.ui:69
 msgid "Configuration"
-msgstr "Configurație"
+msgstr ""
 
 #: data/ui/applet-plugins-widget.ui:73
 msgid "Configure selected plugin's preferences"
-msgstr "Configurați preferințele modulului selectat"
+msgstr ""
 
 #: data/ui/applet-plugins-widget.ui:115
 msgid "<b>Plugin description:</b>"
-msgstr "<b>Descriere modul:</b>"
+msgstr ""
 
 #: data/ui/applet-plugins-widget.ui:130
 msgid "Not specified"
-msgstr "Nespecificat"
+msgstr ""
 
 #: data/ui/applet-plugins-widget.ui:146
 msgid "<b>Author:</b>"
-msgstr "<b>Autor:</b>"
+msgstr ""
 
 #: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:385
 #: blueman/plugins/applet/NetUsage.py:215
 #: blueman/plugins/applet/NetUsage.py:216
 msgid "Unknown"
-msgstr "Necunoscut"
+msgstr ""
 
 #: data/ui/applet-plugins-widget.ui:174
 msgid "<b>Depends on:</b>"
-msgstr "<b>Depinde de:</b>"
+msgstr ""
 
 #: data/ui/applet-plugins-widget.ui:202
 msgid "<b>Conflicts with:</b>"
-msgstr "<b>În conflict cu:</b>"
+msgstr ""
 
 #: data/ui/gsm-settings.ui:34
 msgid "<b>GSM settings</b>"
-msgstr "<b>Stabiliri GSM</b>"
+msgstr ""
 
 #: data/ui/gsm-settings.ui:55
 msgid "Number:"
-msgstr "Număr:"
+msgstr ""
 
 #: data/ui/gsm-settings.ui:78
 msgid "APN:"
-msgstr "APN:"
+msgstr ""
 
 #: data/ui/net-usage.ui:14
 msgid "Traffic statistics"
-msgstr "Statistici transfer"
+msgstr ""
 
 #: data/ui/net-usage.ui:33
 msgid "_Close"
-msgstr "În_chide"
+msgstr ""
 
 #: data/ui/net-usage.ui:79
 msgid "<b>Downloaded:</b>"
-msgstr "<b>Descărcat:</b>"
+msgstr ""
 
 #: data/ui/net-usage.ui:119
 msgid "<b>Uploaded:</b>"
-msgstr "<b>Încărcat:</b>"
+msgstr ""
 
 #: data/ui/net-usage.ui:159
 msgid "<b>Total:</b>"
-msgstr "<b>Total:</b>"
+msgstr ""
 
 #: data/ui/net-usage.ui:196
 msgid "<b>Log started:</b>"
-msgstr "<b>Jurnal pornit:</b>"
+msgstr ""
 
 #: data/ui/net-usage.ui:209
 msgid "<b>Log duration:</b>"
-msgstr "<b>Durată jurnal:</b>"
+msgstr ""
 
 #: data/ui/net-usage.ui:243
 msgid "_Reset"
-msgstr "_Restabilește"
+msgstr ""
 
 #: data/ui/note.ui:8
 msgid "Send note"
@@ -359,43 +347,38 @@ msgstr ""
 
 #: blueman/main/Adapter.py:35 data/blueman-adapters.desktop.in:3
 msgid "Bluetooth Adapters"
-msgstr "Adaptoare bluetooth"
+msgstr ""
 
 #: blueman/main/Adapter.py:64
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
-"Serviciul Bluetooth trebuie să fie pornit pentru ca administratorul de "
-"adaptoare să funcționeze"
 
 #: blueman/main/Adapter.py:142
 msgid "Always"
-msgstr "Întotdeauna"
+msgstr ""
 
 #: blueman/main/Adapter.py:146
 #, python-format
 msgid "%d Minute"
 msgid_plural "%d Minutes"
-msgstr[0] "%d minut"
-msgstr[1] "%d minute"
-msgstr[2] "%d de minute"
+msgstr[0] ""
+msgstr[1] ""
 
 #: blueman/main/Adapter.py:212
 msgid "Adapter"
-msgstr "Adaptor"
+msgstr ""
 
 #: blueman/main/Manager.py:31
 msgid "Bluetooth Devices"
-msgstr "Dispozitive Bluetooth"
+msgstr ""
 
 #: blueman/main/Manager.py:73 blueman/main/Manager.py:113
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
-"Serviciul Bluetooth trebuie să fie pornit pentru ca administratorul de "
-"dispozitive să funcționeze"
 
 #: blueman/main/Manager.py:92
 msgid "Connection to BlueZ failed"
-msgstr "Conectarea la BlueZ a eșuat"
+msgstr ""
 
 #: blueman/main/Manager.py:93
 msgid ""
@@ -403,38 +386,35 @@ msgid ""
 "This probably means that there were no Bluetooth adapters detected or "
 "Bluetooth daemon was not started."
 msgstr ""
-"Demonul Bluez nu rulează, blueman-manager nu poate continua.\n"
-"Aceasta probabil înseamnă că nu au fost detectate adaptoare Bluetooth  sau "
-"demonul Bluetooth nu a fost pornit."
 
 #: blueman/main/Manager.py:190
 msgid "Searching"
-msgstr "Se caută"
+msgstr ""
 
 #: blueman/main/Manager.py:204 blueman/plugins/applet/StandardItems.py:71
 msgid "Bluetooth Assistant"
-msgstr "Asistent Bluetooth"
+msgstr ""
 
 #: blueman/main/Manager.py:217 blueman/plugins/applet/StandardItems.py:83
 msgid "Adapter Preferences"
-msgstr "Preferințe adaptor"
+msgstr ""
 
 #: blueman/main/Manager.py:229 blueman/gui/manager/ManagerDeviceList.py:135
 #: blueman/plugins/applet/StandardItems.py:74
 msgid "File Sender"
-msgstr "Expeditor fișier"
+msgstr ""
 
 #: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
-msgstr "Transfer de fișiere prin Bluetooth"
+msgstr ""
 
 #: blueman/main/Sendto.py:66 blueman/gui/manager/ManagerProgressbar.py:25
 msgid "Connecting"
-msgstr "Se conectează"
+msgstr ""
 
 #: blueman/main/Sendto.py:118
 msgid "obexd not available"
-msgstr "obexd nu este disponibil"
+msgstr ""
 
 #: blueman/main/Sendto.py:118
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
@@ -442,118 +422,116 @@ msgstr ""
 
 #: blueman/main/Sendto.py:147
 msgid "Cancelling"
-msgstr "Se renunță"
+msgstr ""
 
 #: blueman/main/Sendto.py:158 blueman/main/Sendto.py:200
 msgid "Sending File"
-msgstr "Se trimite un fișier"
+msgstr ""
 
 #: blueman/main/Sendto.py:158 blueman/main/Sendto.py:200
 msgid "ETA:"
-msgstr "Timp estimat de recepționare:"
+msgstr ""
 
 #: blueman/main/Sendto.py:194
 #, python-format
 msgid "%.0f Minute"
 msgid_plural "%.0f Minutes"
-msgstr[0] "%.0f minut"
-msgstr[1] "%.0f minute"
-msgstr[2] "%.0f de minute"
+msgstr[0] ""
+msgstr[1] ""
 
 #: blueman/main/Sendto.py:196
 #, python-format
 msgid "%.0f Second"
 msgid_plural "%.0f Seconds"
-msgstr[0] "%.0f secundă"
-msgstr[1] "%.0f secunde"
-msgstr[2] "%.0f de secunde"
+msgstr[0] ""
+msgstr[1] ""
 
 #: blueman/main/Sendto.py:230
 #, python-format
 msgid "Error occurred while sending file %s"
-msgstr "A intervenit o eroare la trimiterea fișierului %s"
+msgstr ""
 
 #: blueman/main/Sendto.py:234
 msgid "Skip"
-msgstr "Omite"
+msgstr ""
 
 #: blueman/main/Sendto.py:235
 msgid "Retry"
-msgstr "Reîncearcă"
+msgstr ""
 
 #: blueman/main/Sendto.py:284
 msgid "Error occurred"
-msgstr "A apărut o eroare"
+msgstr ""
 
 #: blueman/main/Services.py:20
 msgid "Local Services"
-msgstr "Servicii locale"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:180
 #, python-format
 msgid "Pairing request for %s"
-msgstr "Cerere de asociere pentru %s"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:192 blueman/main/applet/BluezAgent.py:299
 msgid "Bluetooth Authentication"
-msgstr "Autentificare Bluetooth"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:220
 msgid "Enter PIN code for authentication:"
-msgstr "Introduceți codul PIN pentru autentificare:"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:221
 msgid "Enter PIN code"
-msgstr "Introduceți cod PIN"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:234
 msgid "Enter passkey for authentication:"
-msgstr "Introduceți parola pentru autentificare:"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:235
 msgid "Enter passkey"
-msgstr "Introduceți parola"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:245
 msgid "Pairing passkey for"
-msgstr "Parolă de asociere pentru"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:254
 msgid "Pairing PIN code for"
-msgstr "Pairing PIN de asociere pentru"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing request for:"
-msgstr "Cerere de asociere pentru:"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:269
 msgid "Confirm value for authentication:"
-msgstr "Confirmați valoarea pentru autentificare:"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:270
 msgid "Confirm"
-msgstr "Confirmă"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:270 blueman/main/applet/BluezAgent.py:297
 msgid "Deny"
-msgstr "Refuză"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:294
 msgid "Authorization request for:"
-msgstr "Cerere de autorizare pentru:"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:294
 msgid "Service:"
-msgstr "Serviciu:"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:295
 msgid "Always accept"
-msgstr "Acceptă întotdeauna"
+msgstr ""
 
 #: blueman/main/applet/BluezAgent.py:296
 #: blueman/plugins/applet/TransferService.py:118
 msgid "Accept"
-msgstr "Acceptă"
+msgstr ""
 
 #: blueman/main/PluginManager.py:69
 msgid ""
@@ -564,7 +542,7 @@ msgstr ""
 
 #: blueman/Functions.py:77
 msgid "Bluetooth Turned Off"
-msgstr "Bluetooth oprit"
+msgstr ""
 
 #: blueman/Functions.py:78
 msgid "Exit"
@@ -572,7 +550,7 @@ msgstr ""
 
 #: blueman/Functions.py:79
 msgid "Enable Bluetooth"
-msgstr "Pornește Bluetooth"
+msgstr ""
 
 #: blueman/Functions.py:98
 msgid "Shall bluetooth get enabled automatically?"
@@ -580,63 +558,63 @@ msgstr ""
 
 #: blueman/Functions.py:99
 msgid "Yes"
-msgstr "Da"
+msgstr ""
 
 #: blueman/Functions.py:100
 msgid "No"
-msgstr "Nu"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:41
 msgid "_Report a Problem"
-msgstr "_Raportare problemă"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:53
 #: blueman/plugins/applet/StandardItems.py:80
 msgid "Device Manager"
-msgstr "Gestionar de dispozitive"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:60
 msgid "Show _Toolbar"
-msgstr "Arată bara de _unelte"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:65
 msgid "Show _Statusbar"
-msgstr "Arată bara de _stare"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:75
 msgid "S_ort By"
-msgstr "S_ortează după"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:82
 msgid "_Name"
-msgstr "_Nume"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:87
 msgid "_Added"
-msgstr "_Adugat"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:101
 msgid "_Descending"
-msgstr "_Descendent"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:114
 #: blueman/plugins/applet/StandardItems.py:48
 msgid "_Plugins"
-msgstr "_Module"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:119
 #: blueman/plugins/applet/StandardItems.py:41
 msgid "_Local Services"
-msgstr "Servicii _locale"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:120
 #: blueman/plugins/applet/StandardItems.py:86
 msgid "Service Preferences"
-msgstr "Preferințe serviciu"
+msgstr ""
 
 #: blueman/gui/manager/ManagerMenu.py:128
 msgid "_Search"
-msgstr "_Caută"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
@@ -648,69 +626,69 @@ msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
-msgstr "<b>De încredere</b>"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
-msgstr "Slab"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:464
 #: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
-msgstr "Sub-optim"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:466
 #: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
-msgstr "Optim"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
-msgstr "Mult"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
-msgstr "Prea mult"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
-msgstr "Scăzut"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
-msgstr "Ridicat"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
-msgstr "Foarte ridicat"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:107
 #: blueman/gui/manager/ManagerDeviceMenu.py:172
 msgid "Success!"
-msgstr "Succes!"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:110
 #, python-format
 msgid "Serial port connected to %s"
-msgstr "Port serial conectat la %s"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:117
 #: blueman/gui/manager/ManagerDeviceMenu.py:165
 msgid "Failed"
-msgstr "Eșuat"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:122
 #: blueman/gui/manager/ManagerDeviceMenu.py:168
 msgid "Connection Failed: "
-msgstr "Conexiune eșuată: "
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:145
 msgid "Disconnection Failed: "
-msgstr "Deconenectare eșuată: "
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:186
 msgid "Disconnecting..."
-msgstr "Se deconectează..."
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:244
 msgid "_<b>Connect</b>"
@@ -726,31 +704,31 @@ msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:251
 msgid "Forcefully disconnect the device"
-msgstr "Deconectează forțat dispozitivul"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:282
 msgid "<b>Connect To:</b>"
-msgstr "<b>Conectare la:</b>"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:294
 msgid "<b>Disconnect:</b>"
-msgstr "<b>Deconectare:</b>"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:314
 msgid "Send a _File..."
-msgstr "Trimite un _fișier..."
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:327
 msgid "_Pair"
-msgstr "_Asociază"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:337
 msgid "_Trust"
-msgstr "Este de încredere"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:342
 msgid "_Untrust"
-msgstr "_Nu este de încredere"
+msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Set up…"
@@ -758,70 +736,61 @@ msgstr ""
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:383
 msgid "_Remove..."
-msgstr "_Elimină..."
+msgstr ""
 
 #: blueman/gui/manager/ManagerProgressbar.py:42
 msgid "Cancel Operation"
-msgstr "Renunță la operațiune"
+msgstr ""
 
 #: blueman/gui/manager/ManagerStats.py:30
 #: blueman/gui/manager/ManagerStats.py:33
 msgid "Data activity indication"
-msgstr "Indicator activitate date"
+msgstr ""
 
 #: blueman/gui/manager/ManagerStats.py:35
 #: blueman/gui/manager/ManagerStats.py:45
 msgid "Total data received and rate of transmission"
-msgstr "Totalul datelor recepţionate și rata transmisiei"
+msgstr ""
 
 #: blueman/gui/manager/ManagerStats.py:39
 #: blueman/gui/manager/ManagerStats.py:43
 msgid "Total data sent and rate of transmission"
-msgstr "Totalul datelor trimise și rata transmisiei"
+msgstr ""
 
 #: blueman/gui/manager/ManagerToolbar.py:28
 #: blueman/gui/manager/ManagerToolbar.py:89
 msgid "Untrust"
-msgstr "Nu mai este de încredere"
+msgstr ""
 
 #: blueman/gui/DeviceSelectorDialog.py:12
 msgid "Select Device"
-msgstr "Selectați un dispozitiv"
+msgstr ""
 
 #: blueman/gui/MessageArea.py:38
 msgid "More"
-msgstr "Mai multe"
+msgstr ""
 
 #: blueman/gui/CommonUi.py:41
 msgid "translator-credits"
 msgstr ""
-"Transifex:\n"
-"Daniel Alămiță <danny3@tutanota.com>\n"
-"Launchpad:\n"
-"  Adi Roiban https://launchpad.net/~adiroiban\n"
-"  Alex Eftimie https://launchpad.net/~alexeftimie\n"
-"  Bisericaru Sebastian https://launchpad.net/~tweety\n"
-"  Chisu Vasile Marius https://launchpad.net/~111979vasile\n"
-"  Ionuț Jula https://launchpad.net/~ionutjula\n"
-"  Ovidiu Nitan https://launchpad.net/~nitanovidiu"
 
 #: blueman/gui/CommonUi.py:46
 msgid "Blueman is a GTK+ Bluetooth manager"
-msgstr "Blueman este un gestionar de Bluetooth GTK+"
+msgstr ""
 
 #: blueman/gui/GsmSettings.py:28
 msgid "GSM Settings"
-msgstr "Stabiliri GSM"
+msgstr ""
 
 #: blueman/gui/applet/PluginDialog.py:92
 #: blueman/plugins/applet/StandardItems.py:92
 msgid "Plugins"
-msgstr "Module"
+msgstr ""
 
 #: blueman/gui/applet/PluginDialog.py:284
 #: blueman/gui/applet/PluginDialog.py:306
 msgid "Dependency issue"
-msgstr "Problemă de dependență"
+msgstr ""
 
 #: blueman/gui/applet/PluginDialog.py:286
 #, python-format
@@ -830,9 +799,6 @@ msgid ""
 "also unload <b>\"%(0)s\"</b>.\n"
 "Proceed?"
 msgstr ""
-"Modulul <b>\"%(0)s\"</b> depinde de <b>%(1)s</b>. Dezactivarea <b>%(1)s</b> "
-"va dezactiva și <b>\"%(0)s\"</b>.\n"
-"Continuați?"
 
 #: blueman/gui/applet/PluginDialog.py:308
 #, python-format
@@ -841,119 +807,116 @@ msgid ""
 "unload <b>%(0)s</b>.\n"
 "Proceed?"
 msgstr ""
-"Modulul <b>%(0)s</b> este în conflict cu <b>%(1)s</b>. Activarea <b>%(1)s</"
-"b> va dezctiva <b>%(0)s</b>.\n"
-"Continuați?"
 
 #: blueman/gui/DeviceSelectorWidget.py:38
 msgid "Adapter selection"
-msgstr "Selectare adaptor"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:40 blueman/DeviceClass.py:64
 msgid "uncategorized"
-msgstr "Necategorizat"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:42
 msgid "desktop"
-msgstr "desktop"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:44
 msgid "server"
-msgstr "servitor"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:46
 msgid "laptop"
-msgstr "laptop"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:48
 msgid "handheld"
-msgstr "Dispozitiv de mână"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:50
 msgid "palm"
-msgstr "palm"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:66
 msgid "cellular"
-msgstr "celular"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:68
 msgid "cordless"
-msgstr "fără fir"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:70
 msgid "smart phone"
-msgstr "smart phone"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:72
 msgid "modem"
-msgstr "modern"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:74
 msgid "isdn"
-msgstr "isdn"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:111
 msgid "headset"
-msgstr "headset"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:113
 msgid "handsfree"
-msgstr "Mâini libere"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:115 blueman/DeviceClass.py:247
 #: blueman/DeviceClass.py:311
 msgid "unknown"
-msgstr "necunoscut"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:117
 msgid "microphone"
-msgstr "microfon"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:142
 msgid "keyboard"
-msgstr "tastatură"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:144
 msgid "pointing"
-msgstr "Dispozitiv de indicat"
+msgstr ""
 
 #: blueman/Sdp.py:127
 msgid "Dialup Networking (DUN)"
-msgstr "Rețea Dialup (DUN)"
+msgstr ""
 
 #: blueman/Sdp.py:134
 msgid "Audio Source"
-msgstr "Sursă audio"
+msgstr ""
 
 #: blueman/Sdp.py:135
 msgid "Audio Sink"
-msgstr "Sincronizare Audio"
+msgstr ""
 
 #: blueman/Sdp.py:146
 msgid "Network Access Point"
-msgstr "Punct de acces rețea"
+msgstr ""
 
 #: blueman/Sdp.py:147
 msgid "Group Network"
-msgstr "Grupare rețea"
+msgstr ""
 
 #: blueman/Sdp.py:387
 msgid "Auto connect profiles"
@@ -961,23 +924,23 @@ msgstr ""
 
 #: blueman/Sdp.py:389
 msgid "Proprietary"
-msgstr "Proprietar"
+msgstr ""
 
 #: blueman/plugins/manager/Info.py:15
 msgid "yes"
-msgstr "da"
+msgstr ""
 
 #: blueman/plugins/manager/Info.py:15
 msgid "no"
-msgstr "nu"
+msgstr ""
 
 #: blueman/plugins/manager/Info.py:115
 msgid "_Info"
-msgstr "_Informații"
+msgstr ""
 
 #: blueman/plugins/manager/Info.py:116
 msgid "Show device information"
-msgstr "Arată informații dispozitiv"
+msgstr ""
 
 #: blueman/plugins/manager/Notes.py:53
 msgid "Send _note"
@@ -990,42 +953,42 @@ msgstr ""
 #: blueman/plugins/manager/PulseAudioProfile.py:88
 #, python-format
 msgid "Failed to change profile to %s"
-msgstr "Schimbare profil în %s nereușită"
+msgstr ""
 
 #: blueman/plugins/manager/PulseAudioProfile.py:129
 msgid "Audio Profile"
-msgstr "Profil Audio"
+msgstr ""
 
 #: blueman/plugins/manager/PulseAudioProfile.py:130
 msgid "Select audio profile for PulseAudio"
-msgstr "Selectectați profilul audio pentru PulseAudio"
+msgstr ""
 
 #: blueman/plugins/manager/Services.py:72
 #, python-format
 msgid "Serial Port %s"
-msgstr "Port serial %s"
+msgstr ""
 
 #: blueman/plugins/manager/Services.py:85
 msgid "Renew IP Address"
-msgstr "Reînnoiește adresa IP"
+msgstr ""
 
 #: blueman/plugins/manager/Services.py:102
 msgid "Dialup Settings"
-msgstr "Stabiliri dialup"
+msgstr ""
 
 #: blueman/plugins/manager/Services.py:111
 msgid "Serial Ports"
-msgstr "Porturi seriale"
+msgstr ""
 
 #: blueman/plugins/BasePlugin.py:37 blueman/plugins/BasePlugin.py:38
 msgid "Unspecified"
-msgstr "Nespecificat"
+msgstr ""
 
 #: blueman/plugins/applet/AutoConnect.py:36
 #: blueman/plugins/applet/RecentConns.py:232
 #: blueman/plugins/applet/PPPSupport.py:52
 msgid "Connected"
-msgstr "Connectat"
+msgstr ""
 
 #: blueman/plugins/applet/AutoConnect.py:36
 #, python-format
@@ -1036,172 +999,156 @@ msgstr ""
 #: blueman/plugins/applet/NetUsage.py:269
 #: blueman/plugins/applet/NetUsage.py:274
 msgid "Connected:"
-msgstr "Conectat"
+msgstr ""
 
 #: blueman/plugins/applet/NetUsage.py:174
 #: blueman/plugins/applet/NetUsage.py:284
 msgid "Not Connected"
-msgstr "Neconectat"
+msgstr ""
 
 #: blueman/plugins/applet/NetUsage.py:180
 msgid ""
 "No usage statistics are available yet. Try establishing a connection first "
 "and then check this page."
 msgstr ""
-"Deocamdată nu sunt disponibile statistici de utilizare. Încercați să "
-"stabiliți o conexiune prima dată și apoi să verificați această pagină."
 
 #: blueman/plugins/applet/NetUsage.py:208
 msgid "day"
 msgid_plural "days"
-msgstr[0] "zi"
-msgstr[1] "zile"
-msgstr[2] "de zile"
+msgstr[0] ""
+msgstr[1] ""
 
 #: blueman/plugins/applet/NetUsage.py:209
 msgid "hour"
 msgid_plural "hours"
-msgstr[0] "oră"
-msgstr[1] "ore"
-msgstr[2] "ore"
+msgstr[0] ""
+msgstr[1] ""
 
 #: blueman/plugins/applet/NetUsage.py:210
 msgid "minute"
 msgid_plural "minutes"
-msgstr[0] "minut"
-msgstr[1] "minute"
-msgstr[2] "de minute"
+msgstr[0] ""
+msgstr[1] ""
 
 #: blueman/plugins/applet/NetUsage.py:212
 #, python-format
 msgid "%d %s %d %s and %d %s"
-msgstr "%d %s %d %s și %d %s"
+msgstr ""
 
 #: blueman/plugins/applet/NetUsage.py:246
 msgid "Are you sure you want to reset the counter?"
-msgstr "Sigur doriți să restabiliți contorul?"
+msgstr ""
 
 #: blueman/plugins/applet/NetUsage.py:291
 msgid ""
 "Allows you to monitor your (mobile broadband) network traffic usage. Useful "
 "for limited data access plans. This plugin tracks every device seperately."
 msgstr ""
-"Vă permite să vă monitorizați utilizarea traficului (mobil) în rețea. "
-"Folositor pentru planurile cu aces limitat de date. Acest modul urmărește "
-"fiecare dispozitiv separat."
 
 #: blueman/plugins/applet/NetUsage.py:311
 msgid "Network _Usage"
-msgstr " _Utilizare rețea"
+msgstr ""
 
 #: blueman/plugins/applet/NetUsage.py:312
 msgid "Shows network traffic usage"
-msgstr "Arată traficul utilizat în rețea"
+msgstr ""
 
 #: blueman/plugins/applet/StatusIcon.py:32
 #: blueman/plugins/applet/StatusIcon.py:54
 #: blueman/plugins/applet/ShowConnected.py:60
 #: blueman/plugins/applet/ShowConnected.py:62
 msgid "Bluetooth Enabled"
-msgstr "Bluetooth pornit"
+msgstr ""
 
 #: blueman/plugins/applet/StatusIcon.py:57
 msgid "Bluetooth Disabled"
-msgstr "Bluetooth oprit"
+msgstr ""
 
 #: blueman/plugins/applet/Networking.py:16
 msgid "Manages local network services, like NAP bridges"
-msgstr "Administrează serviciile din rețeaua locală, cum ar fi punțiile NAP"
+msgstr ""
 
 #: blueman/plugins/applet/NMDUNSupport.py:14
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
-"Oferă capabilitate rețea Dial Up (DUN) pentru ModemManager și NetworkManager"
 
 #: blueman/plugins/applet/RecentConns.py:57
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
-"Oferă un element de meniu care conține ultimele conexiuni utilizate pentru "
-"acces rapid"
 
 #. the maximum number of items RecentConns menu will display
 #: blueman/plugins/applet/RecentConns.py:68
 msgid "Maximum items"
-msgstr "Maximum de elemente"
+msgstr ""
 
 #: blueman/plugins/applet/RecentConns.py:69
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
-"Numărul maxim de elemente pe care meniul de conexiuni recente îl va afișa."
 
 #: blueman/plugins/applet/RecentConns.py:80
 msgid "Recent _Connections"
-msgstr "_Connexiuni recente"
+msgstr ""
 
 #: blueman/plugins/applet/RecentConns.py:232
 #, python-format
 msgid "Connected to %s"
-msgstr "Conectat la %s"
+msgstr ""
 
 #: blueman/plugins/applet/RecentConns.py:238
 msgid "Failed to connect"
-msgstr "Conectarea a eșuat"
+msgstr ""
 
 #: blueman/plugins/applet/RecentConns.py:257
 #, python-format
 msgid "%(service)s on %(device)s"
-msgstr "%(service)s pe %(device)s"
+msgstr ""
 
 #: blueman/plugins/applet/RecentConns.py:261
 msgid "Adapter for this connection is not available"
-msgstr "Adaptorul pentru această conexiune nu este disponibil"
+msgstr ""
 
 #: blueman/plugins/applet/NMPANSupport.py:14
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
-"Oferă suport pentru rețea zonă personală (PAN) introdudusă în NetworkManager "
-"0.8"
 
 #: blueman/plugins/applet/DBusService.py:17
 msgid "Provides DBus API for other Blueman components"
-msgstr "Oferă API DBus pentru alte componente Blueman"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:115
 msgid "Incoming file over Bluetooth"
-msgstr "Primire fișier prin Bluetooth"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:116
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
-msgstr "Primire fișier %(0)s de la %(1)s"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:118
 msgid "Reject"
-msgstr "Refuză"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:125
 msgid "Receiving file"
-msgstr "Se primește un fișier"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:126
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
-msgstr "Se primește fișierul %(0)s de la %(1)s"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:145
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
-"Oferă capabilitatatea de a utiliza protocolul OBEX pentru transferul "
-"fișierelor"
 
 #: blueman/plugins/applet/TransferService.py:168
 msgid "Configured directory for incoming files does not exist"
-msgstr "Directorul configurat pentru primirea fișierelor nu există"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:169
 #, python-format
@@ -1212,42 +1159,40 @@ msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:299
 msgid "File received"
-msgstr "Fișier primit"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:300
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
-msgstr "Fișierul %(0)s de la %(1)s a fost primit cu succes"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:308
 msgid "Transfer failed"
-msgstr "Transferul a eșuat"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:309
 #, python-format
 msgid "Transfer of file %(0)s failed"
-msgstr "Transferul fișierului %(0)s a eșuat"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:328
 #: blueman/plugins/applet/TransferService.py:337
 msgid "Files received"
-msgstr "Fișiere primite"
+msgstr ""
 
 #: blueman/plugins/applet/TransferService.py:329
 #, python-format
 msgid "Received %d file in the background"
 msgid_plural "Received %d files in the background"
-msgstr[0] "S-a primit %d fișier pe fundal"
-msgstr[1] "S-au primit %d fișiere pe fundal"
-msgstr[2] "S-au primit %d de fișiere pe fundal"
+msgstr[0] ""
+msgstr[1] ""
 
 #: blueman/plugins/applet/TransferService.py:338
 #, python-format
 msgid "Received %d more file in the background"
 msgid_plural "Received %d more files in the background"
-msgstr[0] "S-a primit încă %d fișier pe fundal"
-msgstr[1] "S-au primit încă %d fișiere pe fundal"
-msgstr[2] "S-au primit încă %d de fișiere pe fundal"
+msgstr[0] ""
+msgstr[1] ""
 
 #: blueman/plugins/applet/KillSwitch.py:38
 msgid ""
@@ -1255,14 +1200,10 @@ msgid ""
 "(Useless with USB dongles) and makes sure a status icon is shown if there is "
 "a bluetooth killswitch but no adapter."
 msgstr ""
-"Comută un comutator de întrerupere al platformei Bluetooth când starea "
-"limentării Bluetooth se schimbă (Inutil pentru dispozitivele USB) și se "
-"asigură că o pictogramă de stare este afișată dacă există un comutator de "
-"întrerupere bluetooth dar niciun adaptor."
 
 #: blueman/plugins/applet/StandardItems.py:17
 msgid "Adds standard menu items to the status icon menu"
-msgstr "Adaugă elemente de meniu standrd la meniul pictogramei de stare"
+msgstr ""
 
 #: blueman/plugins/applet/StandardItems.py:25
 msgid "_Set Up New Device"
@@ -1270,48 +1211,47 @@ msgstr ""
 
 #: blueman/plugins/applet/StandardItems.py:30
 msgid "Send _Files to Device"
-msgstr "Trimite _fișiere dispozitivului"
+msgstr ""
 
 #: blueman/plugins/applet/StandardItems.py:35
 msgid "_Devices"
-msgstr "_Dispozitive"
+msgstr ""
 
 #: blueman/plugins/applet/StandardItems.py:38
 msgid "Adap_ters"
-msgstr "Adap_toare"
+msgstr ""
 
 #: blueman/plugins/applet/StandardItems.py:89
 msgid "applet"
-msgstr "miniaplicație"
+msgstr ""
 
 #: blueman/plugins/applet/AuthAgent.py:9
 msgid "Provides passkey, authentication services for BlueZ daemon"
 msgstr ""
-"Oferă protecție prin parolă, servicii de autentificare pentru daemonul BlueZ"
 
 #: blueman/plugins/applet/ExitItem.py:12
 msgid "Adds an exit menu item to quit the applet"
-msgstr "Adaugă un element de ieșire la meniu pentru a ieși din miniaplicație"
+msgstr ""
 
 #: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
-msgstr "Oferă un client dhcp de bază pentru conexiunile PAN Bluetooth."
+msgstr ""
 
 #: blueman/plugins/applet/DhcpClient.py:45
 #: blueman/plugins/applet/DhcpClient.py:53
 #: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
-msgstr "Rețea Bluetooth"
+msgstr ""
 
 #: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
-msgstr "Interfața %(0)s legată de adresa IP %(1)s"
+msgstr ""
 
 #: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
-msgstr "Eșuare la obținerea adresei IP pe %s"
+msgstr ""
 
 #: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
@@ -1325,48 +1265,43 @@ msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
-"Adaugă o indicație pe pictograma de stare când serviciul Bluetooth este "
-"activ și arată numărul de conexiuni într-o fereastră informativă."
 
 #: blueman/plugins/applet/ShowConnected.py:48
 msgid "Bluetooth Active"
-msgstr "Bluetooth activ"
+msgstr ""
 
 #: blueman/plugins/applet/ShowConnected.py:49
 #, python-format
 msgid "<b>%d Active Connection</b>"
 msgid_plural "<b>%d Active Connections</b>"
-msgstr[0] "<b>%d conexiune activă</b>"
-msgstr[1] "<b>%d conexiuni active</b>"
-msgstr[2] "<b>%d de conexiuni active</b>"
+msgstr[0] ""
+msgstr[1] ""
 
 #: blueman/plugins/applet/AppIndicator.py:15
 msgid "Uses libappindicator to show a statusicon"
-msgstr "Utilizează libappindicator pentru a afișa o pictogramă de stare"
+msgstr ""
 
 #: blueman/plugins/applet/DiscvManager.py:15
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
-"Oferă un element de meniu pentru facerea adaptorului implicit temporar "
-"vizibil când este stabilit ca ascuns impliicit"
 
 #: blueman/plugins/applet/DiscvManager.py:25
 msgid "Discoverable timeout"
-msgstr "Limită de timp mod vizibil"
+msgstr ""
 
 #: blueman/plugins/applet/DiscvManager.py:26
 msgid "Amount of time in seconds discoverable mode will last"
-msgstr "Durata de timp a modului vizibil"
+msgstr ""
 
 #: blueman/plugins/applet/DiscvManager.py:32
 msgid "_Make Discoverable"
-msgstr "Activează modul _vizibil"
+msgstr ""
 
 #: blueman/plugins/applet/DiscvManager.py:33
 msgid "Make the default adapter temporarily visible"
-msgstr "Faceți adaptorul implicit temporar vizibil"
+msgstr ""
 
 #: blueman/plugins/applet/DiscvManager.py:57
 #, python-format
@@ -1377,8 +1312,6 @@ msgstr ""
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
-"Oferă un meniu pentru miniaplicație și un API de manipulat de către "
-"celelalte module"
 
 #: blueman/plugins/applet/PPPSupport.py:49
 #, python-format
@@ -1386,24 +1319,19 @@ msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
-"Conectat cu succes la serviciul <b>DUN</b> pe <b>%(0)s.</b>\n"
-"Rețeaua este de acum disponibilă prin <b>%(1)s</b>"
 
 #: blueman/plugins/applet/PPPSupport.py:57
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
-"Oferă capabilitatea de bază pentru conectarea la internet prin profil DUN."
 
 #: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
-"Operator conexiune profil SPP standard, permite executarea de acțiune "
-"particularizate"
 
 #: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
-msgstr "Script de executat la conectare"
+msgstr ""
 
 #: blueman/plugins/applet/SerialManager.py:32
 msgid ""
@@ -1415,30 +1343,20 @@ msgid ""
 "\n"
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
-"<span size=\"small\">Următoarele argumente vor fi transferate:\n"
-"Addresă, Nume,  nume serviciu, uuid16s,  nod rfcomm\n"
-"De exemplu:\n"
-"AA:BB:CC:DD:EE:FF, Telefon, serviciu DUN, 0x1103, /dev/rfcomm0\n"
-"uuid16s sunt întoarse ca o listă separată prin virgule\n"
-"\n"
-"La deconectarea dispozitivului, scriptului îi va fi trimis un semnal HUP</"
-"span>"
 
 #: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
-msgstr "Port serial conectat"
+msgstr ""
 
 #: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
-"Serviciu de port serial pe dispozitivul <b>%s</b> va fi disponibil de acum "
-"prin <b>%s</b>"
 
 #: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
-msgstr "Scriptul de conectare port serial a eșuat"
+msgstr ""
 
 #: blueman/plugins/applet/SerialManager.py:115
 #, python-format
@@ -1446,60 +1364,56 @@ msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
-"A intervenit o eroare la lansarea scriptului %s\n"
-"%s"
 
 #: blueman/plugins/applet/PowerManager.py:15
 msgid "Controls Bluetooth adapter power states"
-msgstr "Controlează stările de energie ale adaptorului Bluetooth"
+msgstr ""
 
 #: blueman/plugins/applet/PowerManager.py:28
 msgid "Auto power-on"
-msgstr "Pornire automată"
+msgstr ""
 
 #: blueman/plugins/applet/PowerManager.py:29
 msgid "Automatically power on adapters"
-msgstr "Pornește automat adaptoare"
+msgstr ""
 
 #: blueman/plugins/applet/PowerManager.py:38
 #: blueman/plugins/applet/PowerManager.py:166
 msgid "<b>Turn Bluetooth _Off</b>"
-msgstr "<b>_Oprește Bluetooth</b>"
+msgstr ""
 
 #: blueman/plugins/applet/PowerManager.py:39
 #: blueman/plugins/applet/PowerManager.py:168
 msgid "Turn off all adapters"
-msgstr "Oprește toate adaptoarele"
+msgstr ""
 
 #: blueman/plugins/applet/PowerManager.py:157
 msgid "<b>Turn Bluetooth _On</b>"
-msgstr "<b>P_ornește Bluetooth</b>"
+msgstr ""
 
 #: blueman/plugins/applet/PowerManager.py:159
 msgid "Turn on all adapters"
-msgstr "Pornește toate adaptoarele"
+msgstr ""
 
 #: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
-"Suspendă temporar protecorul ecran când este conectată o manetă prin "
-"bluetooth."
 
 #: blueman/plugins/services/Network.py:24
 #: blueman/plugins/services/Network.py:49
 msgid "Network"
-msgstr "Rețea"
+msgstr ""
 
 #: blueman/plugins/services/Network.py:99
 msgid "Invalid IP address"
-msgstr "Adresa IP nu este validă"
+msgstr ""
 
 #: blueman/plugins/services/Network.py:104
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
-msgstr "Adresa IP este în conflict cu interfața %s care are aceeași adresă"
+msgstr ""
 
 #: blueman/plugins/services/Network.py:112
 #, python-format
@@ -1512,64 +1426,59 @@ msgstr ""
 #: blueman/plugins/services/Network.py:239
 #: blueman/plugins/services/Network.py:248
 msgid "Not currently supported with this setup"
-msgstr "Nu este momentan compatibil cu această configurare"
+msgstr ""
 
 #: blueman/plugins/services/Transfer.py:17
 msgid "Transfer"
-msgstr "Transfer"
+msgstr ""
 
 #: blueman/plugins/services/Transfer.py:33
 msgid "Applet's transfer service plugin is disabled"
-msgstr "Modulul serviciu de transfer al miniaplicației este dezactivat"
+msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
-#, fuzzy
 msgid "Set Bluetooth Adapter Properties"
-msgstr "Adaptoare bluetooth"
+msgstr ""
 
 #: data/blueman.desktop.in:3
-#, fuzzy
 msgid "Blueman Applet"
-msgstr "miniaplicație"
+msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
-#, fuzzy
 msgid "Blueman Bluetooth Manager"
-msgstr "Blueman este un gestionar de Bluetooth GTK+"
+msgstr ""
 
 #: data/blueman-manager.desktop.in:3
-#, fuzzy
 msgid "Bluetooth Manager"
-msgstr "Bluetooth pornit"
+msgstr ""
 
 #: data/thunar-sendto-blueman.desktop.in:5
-#, fuzzy
 msgid "Bluetooth Device"
-msgstr "Dispozitive Bluetooth"
+msgstr ""
 
 #: data/configs/org.blueman.policy.in:10
 msgid "Configure Bluetooth Network"
-msgstr "Configurare rețea Bluetooth"
+msgstr ""
 
 #: data/configs/org.blueman.policy.in:11
 msgid "Configuring networking requires privileges"
-msgstr "Configurarea rețelei necesită privilegii"
+msgstr ""
 
 #: data/configs/org.blueman.policy.in:19
 msgid "Launch DHCP client"
-msgstr "Lansează client DHCP"
+msgstr ""
 
 #: data/configs/org.blueman.policy.in:20
 msgid "Launching DHCP client requires privileges"
-msgstr "Lansarea clientului DHCP necesită privilegii"
+msgstr ""
 
 #: data/configs/org.blueman.policy.in:28
 msgid "Launch PPP daemon"
-msgstr "Lansează daemonul PPP"
+msgstr ""
 
 #: data/configs/org.blueman.policy.in:29
 msgid "Launching PPP daemon requires privileges"
-msgstr "Lansarea daemonului PPP necesită privilegii"
+msgstr ""
 
 #: data/configs/org.blueman.policy.in:37
 msgid "Set RfKill State"
@@ -1578,44 +1487,3 @@ msgstr ""
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr ""
-
-#~ msgid "Bluetooth needs to be turned on for file sending to work"
-#~ msgstr ""
-#~ "Rețeaua Bluetooth trebuie să fie pornită pentru ca trimiterea fișierelor "
-#~ "să funcționeze"
-
-#~ msgid "Select files to send"
-#~ msgstr "Selectați fișierele de trimis"
-
-#~ msgid "Send files to this device"
-#~ msgstr "Trimite fișiere dispozitivului acesta"
-
-#~ msgid "Source adapter. Takes address or adapter's name eg. hci0"
-#~ msgstr ""
-#~ "Adaptor sursă. Acceptă o adresă sau numele adaptorului, de ex.: hci0"
-
-#~ msgid "Delete files on exit"
-#~ msgstr "Șterge fișierele la ieșire"
-
-#~ msgid "Files to be send to the bluetooth device"
-#~ msgstr "Fișiere de trimis dispozitivului bluetooth"
-
-#~ msgid "Bluetooth needs to be turned on for the Bluetooth assistant to work"
-#~ msgstr ""
-#~ "Rețeaua Bluetooth trebuie să fie pornită pentru ca asistentul Bluetooth "
-#~ "să funcționeze"
-
-#~ msgid "No adapters found"
-#~ msgstr "Nu a fost găsit niciun adaptor"
-
-#~ msgid "<b>Pairing in progress...</b>"
-#~ msgstr "<b>Asociere în curs...</b>"
-
-#~ msgid "<b>Failed to add device</b>"
-#~ msgstr "<b>Adăugarea dispozitivului a eșuat</b>"
-
-#~ msgid "Don't connect"
-#~ msgstr "Nu te conecta"
-
-#~ msgid "Start configuration assistant for this device"
-#~ msgstr "Pornește asistentul de configurare pentru acest dispozitiv"

--- a/po/bs.po
+++ b/po/bs.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Bosnian (http://www.transifex.com/mate/MATE/language/bs/)\n"
@@ -1452,40 +1452,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Adapteri"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "aplet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth Osposobljen"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Osposobljen"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth Uređaji"
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-12 09:11+0000\n"
 "Last-Translator: Sergi Almacellas Abellana <sergi@koolpi.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1519,40 +1519,26 @@ msgstr "El connector de transferència de la miniaplicació està inhabilitat"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptadors Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "miniaplicació"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman és un gestor de Bluetooth GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth habilitat"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Dispositius Bluetooth"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -20,8 +20,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Czech (http://www.transifex.com/mate/MATE/language/cs/)\n"
@@ -1548,40 +1548,26 @@ msgstr "Applet má zakázaný plugin pro přenos souborů"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth adaptéry"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman je správce Bluetooth založený na GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth povoleno"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Zařízení bluetooth"
 

--- a/po/da.po
+++ b/po/da.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Danish (http://www.transifex.com/mate/MATE/language/da/)\n"
@@ -1507,40 +1507,26 @@ msgstr "Panelprogrammets udvidelsesmodul for overførseltjeneste er deaktiveret"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth-adaptere"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "panelprogram"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman er en GTK+ Bluetooth-håndtering"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth er aktiveret"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth-enheder"
 

--- a/po/de.po
+++ b/po/de.po
@@ -17,8 +17,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-12 06:08+0000\n"
 "Last-Translator: Christopher Schramm <github@cschramm.eu>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1559,40 +1559,26 @@ msgstr "Die Erweiterung für den Datentransferservice ist deaktiviert"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth-Adapter"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "Applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman ist eine GTK+-basierte Bluetooth-Verwaltung"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth aktiviert"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth-Geräte"
 

--- a/po/el.po
+++ b/po/el.po
@@ -15,8 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: george k <norhorn@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/blueman/blueman/el/"
@@ -1545,10 +1545,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Ρύθμιση προσαρμογέα Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "συσκευή-blueman"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Εφαρμογή blueman"
@@ -1556,11 +1552,6 @@ msgstr "Εφαρμογή blueman"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Διαχειριστής bluetooth του blueman"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1601,6 +1592,12 @@ msgstr "Ορισμός κατάστασης RfKill"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "Η ρύθμιση κατάστασης RfKill απαιτεί δικαιώματα"
+
+#~ msgid "blueman-device"
+#~ msgstr "συσκευή-blueman"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr ""

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-03-28 10:09+0000\n"
 "Last-Translator: Jeannette L <j.lavoie@net-c.ca>\n"
 "Language-Team: English (Australia) <https://hosted.weblate.org/projects/"
@@ -1497,40 +1497,26 @@ msgstr "Applet's transfer service plugin is disabled"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Adaptors"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman is a GTK+ Bluetooth manager"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Enabled"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth Devices"
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-03-28 10:09+0000\n"
 "Last-Translator: Jeannette L <j.lavoie@net-c.ca>\n"
 "Language-Team: English (United Kingdom) <https://hosted.weblate.org/projects/"
@@ -716,7 +716,6 @@ msgstr "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 
 #: blueman/gui/manager/ManagerDeviceMenu.py:250
 #, fuzzy
-#| msgid "<b>Disconnect:</b>"
 msgid "_<b>Disconnect</b>"
 msgstr "<b>Disconnect:</b>"
 
@@ -1509,40 +1508,26 @@ msgstr "Applet's transfer service plug-in is disabled"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Adaptors"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman is a GTK+ Bluetooth manager"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Enabled"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth Devices"
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,8 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-03 17:38+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1530,40 +1530,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptadores Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "miniaplicación"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman es un gestor de conexiones Bluetooth basado en GTK"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth activado"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Dispositivos Bluetooth"
 

--- a/po/et.po
+++ b/po/et.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Estonian (http://www.transifex.com/mate/MATE/language/et/)\n"
@@ -1472,40 +1472,26 @@ msgstr "Rakendite ülekandeteenuse plugin on keelatud"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth'i adapterid"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "rakend"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman on GTK+ Bluetooth haldur"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth on lubatud"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetoothi seadmed"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Basque (http://www.transifex.com/mate/MATE/language/eu/)\n"
@@ -1443,40 +1443,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth-egokigailuak"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet-a"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth gaituta"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth gaituta"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth gailuak"
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Persian (http://www.transifex.com/mate/MATE/language/fa/)\n"
@@ -1444,13 +1444,8 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "سازگار کننده‌ی بلوتوث"
-
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
 
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
@@ -1458,24 +1453,16 @@ msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Blueman Bluetooth Manager"
 msgstr "سازگار کننده‌ی بلوتوث"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Bluetooth Manager"
 msgstr "سازگار کننده‌ی بلوتوث"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "بلوتوث ها"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -10,8 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Tuomas Lähteenmäki <lahtis@gmail.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1523,10 +1523,6 @@ msgstr "Appletin siirtopalveluliitännäinen on poistettu käytöstä"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Aseta Bluetooth-sovittimen ominaisuudet"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-laite"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman-sovelma"
@@ -1534,11 +1530,6 @@ msgstr "Blueman-sovelma"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman bluetooth-hallinta"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1579,6 +1570,12 @@ msgstr "Aseta RfKill-tila"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "RfKill-tilan asettaminen vaatii lisäoikeuksia"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-laite"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -22,8 +22,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: J. Lavoie <j.lavoie@net-c.ca>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1566,10 +1566,6 @@ msgstr "Le plugin d'applet de service de transfert est désactivé"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Définir les propriétés de l'adaptateur Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Applet Blueman"
@@ -1577,11 +1573,6 @@ msgstr "Applet Blueman"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Gestionnaire Bluetooth Blueman"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1626,6 +1617,12 @@ msgstr "Définir l'état RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 "Des permissions supplémentaires sont nécessaires pour modifier l'état RfKill"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Galician (http://www.transifex.com/mate/MATE/language/gl/)\n"
@@ -1510,40 +1510,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptadores de Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "miniaplicación"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman é un xestor GTK+ do Bluetooth"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooh activado"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Dispositivos de Bluetooth"
 

--- a/po/he.po
+++ b/po/he.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Hebrew (http://www.transifex.com/mate/MATE/language/he/)\n"
@@ -1463,13 +1463,8 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "מתאמי Bluetooth"
-
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
 
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
@@ -1477,24 +1472,16 @@ msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman הוא מנהל Bluetooth לסביבתGTK+ ‎"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth פעיל"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "התקני Bluetooth"
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Hindi (http://www.transifex.com/mate/MATE/language/hi/)\n"
@@ -1441,40 +1441,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "ब्लूटूथ एडाप्टर"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "एप्पलेट"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Blueman Bluetooth Manager"
 msgstr "ब्लूटूथ एडाप्टर"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Bluetooth Manager"
 msgstr "ब्लूटूथ एडाप्टर"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "ब्लूटूथ यन्त्र"
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-09 12:59+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1529,10 +1529,6 @@ msgstr "Priključak za programčić prijenosa usluge je isključen"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Postavi svojstva Bluetooth adaptera"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-uređaj"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman programčić"
@@ -1540,11 +1536,6 @@ msgstr "Blueman programčić"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Bluetooth upravljač"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1585,6 +1576,12 @@ msgstr "Postavi RfKill stanje"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "Postavljanje RfKill stanja zahtijeva dozvole"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-uređaj"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Bluetooth mora biti uključen kako bi slanje datoteka radilo"

--- a/po/hu.po
+++ b/po/hu.po
@@ -13,8 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Hungarian (http://www.transifex.com/mate/MATE/language/hu/)\n"
@@ -1538,40 +1538,26 @@ msgstr "A kisalkalmazás átviteli szolgáltatásának bővítménye letiltva"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth csatolók"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "kisalkalmazás"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "A Blueman egy GTK+ alapú Bluetooth-kezelő"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth engedélyezve"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth eszközök"
 

--- a/po/id.po
+++ b/po/id.po
@@ -13,8 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Indonesian (http://www.transifex.com/mate/MATE/language/id/)\n"
@@ -1503,40 +1503,26 @@ msgstr "Plugin layanan transfer Applet nonaktif"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adapter Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman adalah sebuah manajer Bluetooth GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Aktif"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Perangkat bluetooth"
 

--- a/po/it.po
+++ b/po/it.po
@@ -15,8 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-09 12:59+0000\n"
 "Last-Translator: Edoardo Facchinelli <silpheel@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1553,10 +1553,6 @@ msgstr "Il plugin del servizio di trasferimento dell'applet è disabilitato"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Imposta le Proprietà di un Adattatore Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "dispositivo-blueman"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman Applet"
@@ -1564,11 +1560,6 @@ msgstr "Blueman Applet"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Gestore Bluetooth"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1609,6 +1600,12 @@ msgstr "Imposta lo stato RfKill"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "Impostare lo stato RfKill richiede privilegi"
+
+#~ msgid "blueman-device"
+#~ msgstr "dispositivo-blueman"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Il Bluetooth deve essere acceso per inviare file"

--- a/po/ja.po
+++ b/po/ja.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-03-28 10:09+0000\n"
 "Last-Translator: Takuya Ohe <hi@tohe.xyz>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1501,40 +1501,26 @@ msgstr "アプレットの転送サービスプラグインは無効化されて
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth アダプター"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "アプレット"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman は GTK+ の Bluetooth マネージャーです"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth が有効"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth デバイス"
 

--- a/po/kk.po
+++ b/po/kk.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Kazakh (http://www.transifex.com/mate/MATE/language/kk/)\n"
@@ -1442,21 +1442,12 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
-msgstr ""
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
 msgstr ""
 
 #: data/blueman-manager.desktop.in:3

--- a/po/ko.po
+++ b/po/ko.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Korean (http://www.transifex.com/mate/MATE/language/ko/)\n"
@@ -1487,40 +1487,26 @@ msgstr "애플릿 전송 서비스 플러그인을 비활성화했습니다"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "블루투스 어댑터"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "애플릿"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "블루맨은 GTK+ 블루투스 관리자입니다"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "블루투스 켜짐"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "블루투스 장치"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-05-15 18:08+0000\n"
 "Last-Translator: Andrius Majauskas <komitetas@gmail.com>\n"
 "Language-Team: Lithuanian <https://hosted.weblate.org/projects/blueman/"
@@ -1521,40 +1521,26 @@ msgstr "Programėlės failų persiuntimo įskiepis yra išjungtas"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "„Bluetooth“ adapteriai"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "įskiepis"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman yra GTK+ Bluetooth tvarkytuvė"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth įjungtas"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "„Bluetooth“ įrenginiai"
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Latvian (http://www.transifex.com/mate/MATE/language/lv/)\n"
@@ -1458,40 +1458,26 @@ msgstr "Sīkrīka pārsūtīšanas servisa spraudnis ir atslēgts"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Adapteri"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "sīklietotne"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth Ieslēgts"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Ieslēgts"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth Iekārtas"
 

--- a/po/mk.po
+++ b/po/mk.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Macedonian (http://www.transifex.com/mate/MATE/language/mk/)\n"
@@ -1480,40 +1480,26 @@ msgstr "Плагинот на аплетот за пренос сервис е �
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Блутут адаптери"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "аплет"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Блутутот е овозможен"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Блутутот е овозможен"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Блутут уреди"
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Marathi (http://www.transifex.com/mate/MATE/language/mr/)\n"
@@ -1453,40 +1453,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth अडॅप्टर"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr " एप्लेट"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "ब्लूटूथ कार्यान्वीत आहे"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "ब्लूटूथ कार्यान्वीत आहे"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth साधन"
 

--- a/po/ms.po
+++ b/po/ms.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Malay (http://www.transifex.com/mate/MATE/language/ms/)\n"
@@ -1494,40 +1494,26 @@ msgstr "Pemalam perkhidmatan pemindahan aplet dilumpuhkan"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Penyesuai Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "aplet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman merupakan pengurus Bluetooth GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Dibenarkan"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Peranti Bluetooth"
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -14,8 +14,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/blueman/"
@@ -1547,10 +1547,6 @@ msgstr "Panelprogrammet utvidelsesprogramtillegg for overføring er avskrudd"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Velg egenskaper for Blåtannsadaptere"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman-panelprogram"
@@ -1558,11 +1554,6 @@ msgstr "Blueman-panelprogram"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Blåtannsbehandler"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1605,6 +1596,12 @@ msgstr "Sett RfKill-tilstand"
 #, fuzzy
 msgid "Setting RfKill State requires privileges"
 msgstr "Setting av RfKill-tilstand krever rettigheter"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Blåtann må være påslått for at filoverføring skal fungere"

--- a/po/nds.po
+++ b/po/nds.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Low German (http://www.transifex.com/mate/MATE/language/"
@@ -1443,21 +1443,12 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
-msgstr ""
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
 msgstr ""
 
 #: data/blueman-manager.desktop.in:3

--- a/po/nl.po
+++ b/po/nl.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-09 12:59+0000\n"
 "Last-Translator: simonborgithub <mail@simonbor.nl>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/blueman/blueman/nl/"
@@ -1533,10 +1533,6 @@ msgstr "Applets invoegtoepassing voor overdrachtfunctie is uitgeschakeld"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Zet Bluetooth-adapters eigenschappen"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman Applet"
@@ -1544,11 +1540,6 @@ msgstr "Blueman Applet"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman is een Bluetooth-beheerder"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1589,6 +1580,12 @@ msgstr "RfKill status instellen"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "U heeft rechten nodig om de status van RfKill in te stellen"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -17,8 +17,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-05-14 16:55+0000\n"
 "Last-Translator: Szylu <chipolade@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1559,40 +1559,26 @@ msgstr "Wtyczka usługi transferu apletu jest wyłączona"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptery Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "aplet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman jest zarządcą Bluetooth napisanym w GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth włączony"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Urządzenia Bluetooth"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -15,8 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Portuguese (http://www.transifex.com/mate/MATE/language/pt/)\n"
@@ -1523,40 +1523,26 @@ msgstr "Suplemento do serviço de transferência do applet está desativado"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptadores Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman é um Gestor de Bluetooth GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Ativado"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Dispositivos Bluetooth"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -21,8 +21,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Samuel Carvalho de Araújo <samuelnegro12345@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1523,10 +1523,6 @@ msgstr "Plugin de serviço de transferência do applet está desabilitado"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Definir propriedades do adaptador de Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-dispositivo"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Applet Blueman"
@@ -1534,11 +1530,6 @@ msgstr "Applet Blueman"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Gerenciador de Bluetooth Blueman"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1579,6 +1570,12 @@ msgstr "Definir Estado do RfKill"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "Definir Estado do RfKill requer privilégios"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-dispositivo"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Bluetooth precisa estar ligado para o envio de arquivos funcionar"

--- a/po/ru.po
+++ b/po/ru.po
@@ -16,8 +16,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Alex <theavganec@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1550,10 +1550,6 @@ msgstr "Плагин сервиса передачи апплета отключ
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Установить свойства адаптера Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "Устройство с Bluetooth"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Приложение для работы с Bluetooth"
@@ -1561,11 +1557,6 @@ msgstr "Приложение для работы с Bluetooth"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman — это менеджер Bluetooth"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "сервис работы с bluetooth"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1606,6 +1597,12 @@ msgstr "Установить состояние RfKill"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "Установка состояния RfKill требует соответствующих привилегий"
+
+#~ msgid "blueman-device"
+#~ msgstr "Устройство с Bluetooth"
+
+#~ msgid "blueman"
+#~ msgstr "сервис работы с bluetooth"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Чтобы работала передача файлов, нужно включить Bluetooth"

--- a/po/sk.po
+++ b/po/sk.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Juraj Liso <lisojuraj@gmail.com>\n"
 "Language-Team: Slovak <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1532,10 +1532,6 @@ msgstr "Modul pre prenosnú službu apletu je vypnutý"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Nastavenie vlastnosti bluetooth adaptéra"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman Applet"
@@ -1543,11 +1539,6 @@ msgstr "Blueman Applet"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Správca Bluetooth Blueman"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1588,6 +1579,12 @@ msgstr "Nastavenie stavu RfKill"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "Nastavenie stavu RfKill vyžaduje práva"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Bluetooth musí byť pre odosielanie súborov zapnutý"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Slovenian (http://www.transifex.com/mate/MATE/language/sl/)\n"
@@ -1510,40 +1510,26 @@ msgstr "Apletov vstavek storitve prenosa je onemogočen"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adapter bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "aplet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman je upravljalnik Bluetootha, osnovan na GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth je omogočen"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Naprave Bluetooth"
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Albanian (http://www.transifex.com/mate/MATE/language/sq/)\n"
@@ -1443,10 +1443,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
@@ -1455,20 +1451,13 @@ msgstr ""
 msgid "Blueman Bluetooth Manager"
 msgstr ""
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Manager"
 msgstr "Pajisjet Bluetooth"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Pajisjet Bluetooth"
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Serbian (http://www.transifex.com/mate/MATE/language/sr/)\n"
@@ -1521,40 +1521,26 @@ msgstr "Прикључак услуге преноса програмчета ј
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Примопредајници Блутута"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "програмче"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Блумен је блутут управник за Гтк+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Блутут је укључен"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Уређаји Блутута"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -13,8 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Luna Jernberg <droidbittin@gmail.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1519,13 +1519,8 @@ msgstr "Panelprogrammets överföringstjänst är inaktiverad"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Blåtandsadaptrar"
-
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
 
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
@@ -1534,11 +1529,6 @@ msgstr "Blueman panelprogram"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Bluetooth hanterare"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1579,6 +1569,9 @@ msgstr "Ange RfKill tillstånd"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "Ändra status för RfKill kräver privilegier"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Bluetooth behöver aktiveras för att filöverföringar ska fungera"

--- a/po/sw.po
+++ b/po/sw.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Swahili (http://www.transifex.com/mate/MATE/language/sw/)\n"
@@ -1440,13 +1440,8 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adapta za Bluetooth"
-
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
 
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
@@ -1454,24 +1449,16 @@ msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Blueman Bluetooth Manager"
 msgstr "Adapta za Bluetooth"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Bluetooth Manager"
 msgstr "Adapta za Bluetooth"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Mitambo ya Bluetooth"
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Tamil (http://www.transifex.com/mate/MATE/language/ta/)\n"
@@ -1444,10 +1444,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
@@ -1456,20 +1452,13 @@ msgstr ""
 msgid "Blueman Bluetooth Manager"
 msgstr ""
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Bluetooth Manager"
 msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Bluetooth Device"
 msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Oğuz Ersen <oguzersen@protonmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -1523,10 +1523,6 @@ msgstr "Uygulamanın aktarım hizmeti eklentisi devre dışı"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Bağdaştırıcısı Özelliklerini Ayarla"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman Uygulaması"
@@ -1534,11 +1530,6 @@ msgstr "Blueman Uygulaması"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Bluetooth Yöneticisi"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1579,6 +1570,12 @@ msgstr "RfKill Durumunu Ayarla"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "RfKill durumunu ayarlamak özel haklar gerektirir"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Dosya gönderebilmek için bluetooth açılmalı"

--- a/po/uk.po
+++ b/po/uk.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/blueman/"
@@ -1550,10 +1550,6 @@ msgstr "Програмний втулок передачі файлів вимк
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Встановити властивості адаптера Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Аплет Blueman"
@@ -1561,11 +1557,6 @@ msgstr "Аплет Blueman"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman — засіб керування Bluetooth"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -1606,6 +1597,12 @@ msgstr "Встановити стан RfKill"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "Встановлення стану RfKill потребує відповідних привілеїв"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Для надсилання файлів необхідно увімкнути bluetooth"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/mate/MATE/language/vi/)\n"
@@ -1435,10 +1435,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
@@ -1447,20 +1443,13 @@ msgstr ""
 msgid "Blueman Bluetooth Manager"
 msgstr ""
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Manager"
 msgstr "Các thiết bị Bluetooth"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Các thiết bị Bluetooth"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -14,8 +14,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/mate/MATE/language/"
@@ -1497,40 +1497,26 @@ msgstr "小程序的传输服务插件被禁用"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "蓝牙适配器"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman 是基于 GTK+ 的蓝牙管理器"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "蓝牙已启用"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "蓝牙设备"
 

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Chinese (Hong Kong) (http://www.transifex.com/mate/MATE/"
@@ -1434,13 +1434,8 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "藍牙適配器"
-
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
 
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
@@ -1448,24 +1443,16 @@ msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Blueman Bluetooth Manager"
 msgstr "藍牙適配器"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Bluetooth Manager"
 msgstr "藍牙適配器"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "藍牙裝置"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-05 12:28+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-06-19 20:58+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/mate/MATE/language/"
@@ -1474,40 +1474,26 @@ msgstr "小程式的傳送服務已關閉"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "藍牙配接器"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "小程式"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman 是一個 GTK+ 的藍牙管理軟體"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "藍牙開啟"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "藍牙裝置"
 


### PR DESCRIPTION
This is my attempt to stop the loop we are in with weblate. 

Running ``make -C po/ blueman.pot-update`` does not update the ``POT-Creation-Date`` which hopefully fixes weblate trying to update it on every commit.

This does mean that we need to update ``blueman.pot`` when we do string changes with ``make -C po/ blueman.pot-update`` followed by ``make -C po/ update-po``.