### PR TITLE
Drop bind_textdomain_codeset

### DIFF
--- a/apps/blueman-assistant.in
+++ b/apps/blueman-assistant.in
@@ -4,8 +4,6 @@ import os
 import sys
 import signal
 import logging
-from gettext import bind_textdomain_codeset
-
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
@@ -60,7 +58,6 @@ class Assistant:
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
-        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/assistant.ui")
         self.assistant = self.Builder.get_object("assistant")
         self.assistant.set_title(_("Bluetooth Assistant"))

--- a/blueman/gui/GsmSettings.py
+++ b/blueman/gui/GsmSettings.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from gettext import gettext as _, bind_textdomain_codeset
+from gettext import gettext as _
 
 from blueman.main.Config import Config
 from blueman.Constants import *
@@ -18,7 +18,6 @@ class GsmSettings(Gtk.Dialog):
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
-        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/gsm-settings.ui")
 
         gsm_grid = self.Builder.get_object("gsm_grid")

--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 from gettext import gettext as _
 import logging
-from gettext import bind_textdomain_codeset
-
 from blueman.Constants import *
 from blueman.gui.GenericList import GenericList
 
@@ -102,7 +100,6 @@ class PluginDialog(Gtk.Window):
         self.applet = applet
 
         self.Builder = Gtk.Builder(translation_domain="blueman")
-        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/applet-plugins-widget.ui")
 
         self.description = self.Builder.get_object("description")

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 import logging
-from gettext import gettext as _, bind_textdomain_codeset
+from gettext import gettext as _
 from operator import itemgetter
 from typing import Dict, List, Tuple, Optional
 
@@ -361,7 +361,6 @@ class ManagerDeviceMenu(Gtk.Menu):
 
             builder = Gtk.Builder()
             builder.set_translation_domain("blueman")
-            bind_textdomain_codeset("blueman", "UTF-8")
             builder.add_from_file(UI_PATH + "/rename-device.ui")
             dialog = builder.get_object("dialog")
             dialog.set_transient_for(self.Blueman)

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 import logging
-from gettext import gettext as _, bind_textdomain_codeset
+from gettext import gettext as _
 from typing import Optional
 
 from blueman.bluez.Manager import Manager
@@ -34,7 +34,6 @@ class Blueman(Gtk.Window):
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
-        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/manager-main.ui")
 
         grid = self.Builder.get_object("grid")

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -2,7 +2,6 @@
 from gettext import gettext as _
 import time
 import logging
-from gettext import bind_textdomain_codeset
 from gettext import ngettext
 from typing import List
 
@@ -52,7 +51,6 @@ class Sender(Gtk.Dialog):
         self.b_cancel.connect("clicked", self.on_cancel)
 
         self.Builder = Gtk.Builder(translation_domain="blueman")
-        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/send-dialog.ui")
 
         grid = self.Builder.get_object("sendto")

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 import os.path
 import logging
-from gettext import bind_textdomain_codeset
 from gettext import gettext as _
 from html import escape
 import random
@@ -113,7 +112,6 @@ class BluezAgent(DbusService):
         builder = Gtk.Builder()
         builder.add_from_file(UI_PATH + "/applet-passkey.ui")
         builder.set_translation_domain("blueman")
-        bind_textdomain_codeset("blueman", "UTF-8")
         dialog = builder.get_object("dialog")
 
         dialog.props.icon_name = "blueman"

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -5,7 +5,6 @@ import time
 import datetime
 from gettext import gettext as _, ngettext
 import logging
-from gettext import bind_textdomain_codeset
 from typing import List
 
 from blueman.Functions import *
@@ -111,7 +110,6 @@ class Dialog:
         builder = Gtk.Builder()
         builder.add_from_file(UI_PATH + "/net-usage.ui")
         builder.set_translation_domain("blueman")
-        bind_textdomain_codeset("blueman", "UTF-8")
 
         self.dialog = builder.get_object("dialog")
         self.dialog.connect("response", self.on_response)

--- a/blueman/plugins/manager/Notes.py
+++ b/blueman/plugins/manager/Notes.py
@@ -1,5 +1,5 @@
 import datetime
-from gettext import gettext as _, bind_textdomain_codeset
+from gettext import gettext as _
 from tempfile import NamedTemporaryFile
 
 from blueman.Constants import UI_PATH
@@ -36,7 +36,6 @@ def send_note_cb(dialog, response_id, device_address, text_view):
 def send_note(device, parent):
     builder = Gtk.Builder()
     builder.set_translation_domain('blueman')
-    bind_textdomain_codeset('blueman', 'UTF-8')
     builder.add_from_file(UI_PATH + '/note.ui')
     dialog = builder.get_object('dialog')
     dialog.set_transient_for(parent)

--- a/blueman/plugins/services/Network.py
+++ b/blueman/plugins/services/Network.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from gettext import gettext as _
 from random import randint
-from gettext import bind_textdomain_codeset
 import logging
 import ipaddress
 from typing import List, Tuple, cast
@@ -27,7 +26,6 @@ class Network(ServicePlugin):
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
-        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/services-network.ui")
         self.widget = self.Builder.get_object("network_frame")
 

--- a/blueman/plugins/services/Transfer.py
+++ b/blueman/plugins/services/Transfer.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 from gettext import gettext as _
-from gettext import bind_textdomain_codeset
 import logging
 
 from blueman.Constants import *
@@ -20,7 +19,6 @@ class Transfer(ServicePlugin):
 
         self.Builder = Gtk.Builder()
         self.Builder.set_translation_domain("blueman")
-        bind_textdomain_codeset("blueman", "UTF-8")
         self.Builder.add_from_file(UI_PATH + "/services-transfer.ui")
         self.widget = self.Builder.get_object("transfer")
 


### PR DESCRIPTION
This method is deprecated in Python 3.8 and 3.9, will be removed in 3.10, and appears to be unnecessary in 3.6 and 3.7. The calls got added in https://github.com/blueman-project/blueman/pull/332 to fix an issue where GtkBuilder otherwise uses gettext with the environments' encoding and passes the results to g_markup_escape_text which always expects UTF-8.

The original report reffered to Python 2.7 and a blueman version that used PyGTK, so PyGTK must have called the *Python* gettext() family of functions for the setting to have an effect. When we fixed it, we already used PyGObject and currently we depend on Python 3 which changed the effect to only the lgettext() family of functions, so to still see this PyGObject would have to call the Python lgettext() family of functions. I could not verify that this is not the case as I did not spot *any* Python gettext calls in PyGTK and PyGObject at all, so I'm a little puzzled how it even happend in the first place with Python 2.7 and PyGTK.