### PR TITLE
Fix #1296

### DIFF
--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -250,15 +250,9 @@ class LockFileHandle(object):
 
     def get_pid(self) -> Optional[int]:
         with self as f:
-            # `return f.get_data[0]` is enough,
-            # but mypy can't infer the correct return type.
-            pid = f.get_data()[0]
-            if pid:
-                return int(pid)
-            else:
-                return None
+            return f.get_data()[0]
 
-    def __enter__(self):
+    def __enter__(self) -> LockFile:
         logging.debug("locking file %s" % self._filename)
         fcntl.flock(self._file.fileno(), fcntl.LOCK_EX)
         return self.LockFile(self._file)

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -300,9 +300,13 @@ def check_single_instance(name: str, unhide_func: Optional[Callable[[int], Any]]
                 print("Stale PID, overwriting")
             else:
                 print("There is an instance already running")
-                time = os.getenv("BLUEMAN_EVENT_TIME") or 0
+                env_time = os.getenv("BLUEMAN_EVENT_TIME")
+                if env_time:
+                    timestamp = int(env_time)
+                else:
+                    timestamp = int(time.clock_gettime(time.CLOCK_MONOTONIC_RAW) * 1000)
 
-                f.set_data(pid, time)
+                f.set_data(pid, timestamp)
 
                 os.kill(pid, signal.SIGUSR1)
                 bmexit()

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -245,7 +245,7 @@ class LockFileHandle(object):
 
     def get_pid(self) -> int:
         with self as f:
-            return f.get_data()[0]
+            return int(f.get_data()[0])
 
     def __enter__(self):
         logging.debug("locking file %s" % self._filename)
@@ -271,7 +271,7 @@ class LockFileHandle(object):
             else:
                 return (None, None)
 
-        def set_data(self, pid: int, time: int):
+        def set_data(self, pid: int, time: int) -> None:
             self._file.seek(0)
             self._file.truncate(0)
             self._file.write("%s\n%s" % (str(pid), str(time)))

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -237,6 +237,26 @@ class LockFileHandle(object):
     _filename: str
     _file: TextIO
 
+    class LockFile(object):
+        _file: TextIO
+
+        def __init__(self, file: TextIO):
+            self._file = file
+
+        def get_data(self) -> Tuple[Optional[int], Optional[int]]:
+            self._file.seek(0)
+            lines = self._file.readlines()
+            if lines:
+                return (int(lines[0]), int(lines[1]))
+            else:
+                return (None, None)
+
+        def set_data(self, pid: int, time: int) -> None:
+            self._file.seek(0)
+            self._file.truncate(0)
+            self._file.write("%s\n%s" % (str(pid), str(time)))
+            self._file.flush()
+
     def __init__(self, name: str):
         cachedir = GLib.get_user_cache_dir()
         if not os.path.exists(cachedir):
@@ -261,26 +281,6 @@ class LockFileHandle(object):
         logging.debug("unlocking file %s" % self._filename)
         fcntl.flock(self._file.fileno(), fcntl.LOCK_UN)
         return False
-
-    class LockFile(object):
-        _file: TextIO
-
-        def __init__(self, file: TextIO):
-            self._file = file
-
-        def get_data(self) -> Tuple[Optional[int], Optional[int]]:
-            self._file.seek(0)
-            lines = self._file.readlines()
-            if lines:
-                return (int(lines[0]), int(lines[1]))
-            else:
-                return (None, None)
-
-        def set_data(self, pid: int, time: int) -> None:
-            self._file.seek(0)
-            self._file.truncate(0)
-            self._file.write("%s\n%s" % (str(pid), str(time)))
-            self._file.flush()
 
 
 def check_single_instance(name: str, unhide_func: Optional[Callable[[int], Any]] = None) -> None:

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -241,9 +241,9 @@ class LockFileHandle(object):
         self._filename = os.path.join(cachedir, "%s-%s" % (name, os.getuid()))
         self._file = os.fdopen(os.open(self._filename, os.O_RDWR | os.O_CREAT), 'r+')
 
-    def get_pid(self) -> int:
+    def get_pid(self) -> Optional[int]:
         with self as f:
-            return int(f.get_data()[0])
+            return f.get_data()[0]
 
     def __enter__(self):
         logging.debug("locking file %s" % self._filename)

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -243,7 +243,13 @@ class LockFileHandle(object):
 
     def get_pid(self) -> Optional[int]:
         with self as f:
-            return f.get_data()[0]
+            # `return f.get_data[0]` is enough,
+            # but mypy can't infer the correct return type.
+            pid = f.get_data()[0]
+            if pid:
+                return int(pid)
+            else:
+                return None
 
     def __enter__(self):
         logging.debug("locking file %s" % self._filename)

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -112,6 +112,7 @@ def launch(
     icon_name: Optional[str] = None,
     name: str = "blueman",
     sn: bool = True,
+    launched_cb: Optional[Callable[[Gio.AppLaunchContext, Gio.AppInfo, GLib.Variant], None]] = None
 ) -> bool:
     """Launch a gui app with starup notification"""
 
@@ -140,6 +141,9 @@ def launch(
 
     if icon_name:
         context.set_icon_name(icon_name)
+
+    if launched_cb:
+        context.connect('launched', launched_cb)
 
     appinfo = Gio.AppInfo.create_from_commandline(cmd, name, flags)
     launched: bool = appinfo.launch(files, context)

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -23,7 +23,6 @@ from types import FrameType
 import re
 import os
 import signal
-import atexit
 import sys
 import errno
 from gettext import gettext as _
@@ -36,7 +35,6 @@ import fcntl
 import struct
 import socket
 import array
-import time
 
 import cairo
 

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -25,6 +25,7 @@ import os
 import signal
 import sys
 import errno
+import time
 from gettext import gettext as _
 import logging
 import logging.handlers
@@ -114,7 +115,13 @@ def launch(
 ) -> bool:
     """Launch a gui app with starup notification"""
 
-    timestamp = Gtk.get_current_event_time()
+    gtktimestamp = Gtk.get_current_event_time()
+    if gtktimestamp == 0:
+        # clock_gettime() returns time in seconds as a floating point value,
+        # but timestamps are ints representing milliseconds.
+        timestamp = int(time.clock_gettime(time.CLOCK_MONOTONIC_RAW) * 1000)
+    else:
+        timestamp = gtktimestamp
     display = Gdk.Display.get_default()
     context = display.get_app_launch_context()
     context.set_timestamp(timestamp)

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -114,16 +114,11 @@ def launch(
     sn: bool = True,
 ) -> bool:
     """Launch a gui app with starup notification"""
-    context = None
-    gtktimestamp = Gtk.get_current_event_time()
-    if gtktimestamp == 0:
-        logging.info("Gtk eventtime is 0, not using LaunchContext")
-        timestamp = int(time.clock_gettime(time.CLOCK_MONOTONIC_RAW))
-    else:
-        timestamp = gtktimestamp
-        display = Gdk.Display.get_default()
-        context = display.get_app_launch_context()
-        context.set_timestamp(timestamp)
+
+    timestamp = Gtk.get_current_event_time()
+    display = Gdk.Display.get_default()
+    context = display.get_app_launch_context()
+    context.set_timestamp(timestamp)
 
     if sn:
         flags = Gio.AppInfoCreateFlags.SUPPORTS_STARTUP_NOTIFICATION
@@ -143,7 +138,7 @@ def launch(
     else:
         files = None
 
-    if icon_name and context is not None:
+    if icon_name:
         context.set_icon_name(icon_name)
 
     appinfo = Gio.AppInfo.create_from_commandline(cmd, name, flags)

--- a/blueman/plugins/applet/StandardItems.py
+++ b/blueman/plugins/applet/StandardItems.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from gettext import gettext as _
 
-from blueman.Functions import launch, get_lockfile, get_pid, kill
+from blueman.Functions import launch, kill, LockFileHandle
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.gui.CommonUi import show_about_dialog
 from blueman.gui.applet.PluginDialog import PluginDialog
@@ -74,8 +74,7 @@ class StandardItems(AppletPlugin):
         launch("blueman-sendto", name=_("File Sender"))
 
     def on_devices(self):
-        lockfile = get_lockfile('blueman-manager')
-        pid = get_pid(lockfile)
+        pid = LockFileHandle('blueman-manager').get_pid()
         if not pid or not kill(pid, 'blueman-manager'):
             launch("blueman-manager", name=_("Device Manager"))
 

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -126,8 +126,10 @@ class StatusIcon(AppletPlugin, GObject.GObject):
                 # to wait for a non-child process to exit on Linux, and the tray process is not always
                 # a child of the applet process.
                 kill(pid, 'blueman-tray')
+
             def launched_cb(_context, _appinfo, platform_data):
                 self._tray_pid = platform_data['pid']
+
             launch('blueman-tray', icon_name='blueman', sn=False, launched_cb=launched_cb)
 
     def _get_status_icon_implementation(self):

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -122,6 +122,9 @@ class StatusIcon(AppletPlugin, GObject.GObject):
             else:
                 pid = self._tray_pid
             if pid:
+                # XXX: We should probably wait for the process to exit, but there's no easy way
+                # to wait for a non-child process to exit on Linux, and the tray process is not always
+                # a child of the applet process.
                 kill(pid, 'blueman-tray')
             def launched_cb(_context, _appinfo, platform_data):
                 self._tray_pid = platform_data['pid']

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -4,7 +4,7 @@ from gettext import gettext as _
 
 from gi.repository import GObject, GLib
 
-from blueman.Functions import launch, kill, get_pid, get_lockfile
+from blueman.Functions import launch, kill, LockFileHandle
 from blueman.main.PluginManager import StopException
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.typing import GSignals
@@ -115,7 +115,7 @@ class StatusIcon(AppletPlugin, GObject.GObject):
         implementation = self._get_status_icon_implementation()
         if not self._implementation or self._implementation != implementation:
             self._implementation = implementation
-            pid = get_pid(get_lockfile('blueman-tray'))
+            pid = LockFileHandle('blueman-tray').get_pid()
             if pid:
                 kill(pid, 'blueman-tray')
             launch('blueman-tray', icon_name='blueman', sn=False)


### PR DESCRIPTION
This is my attempt at fixing #1296. It does two things:
- Serializes accesses to the same lock file from different processes using `fcntl.flock`
- Stores the PID of the tray application in the `StatusIcon` class

I'm open to feedback, especially since I don't have a lot of experience writing GTK/Python code.