### PR TITLE
Use Gio/Gtk.application and drop check_single_instanced

### DIFF
--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -4,9 +4,6 @@ import sys
 import signal
 import logging
 
-import gi
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 
 # support running uninstalled
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -43,5 +40,5 @@ if __name__ == '__main__':
 
     set_proc_title()
 
-    blueman_adapters = BluemanAdapters(args.adapter, args.socket_id)
-    Gtk.main()
+    app = blueman_adapters = BluemanAdapters(args.adapter, args.socket_id)
+    app.run()

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -38,4 +38,5 @@ if __name__ == '__main__':
     create_logger(log_level, "blueman-applet", syslog=args.syslog)
 
     set_proc_title()
-    BluemanApplet()
+    app = BluemanApplet()
+    app.run()

--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -4,10 +4,6 @@ import os
 import signal
 import logging
 
-import gi
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
-
 # support running uninstalled
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if 'BLUEMAN_SOURCE' in os.environ:
@@ -40,6 +36,6 @@ if __name__ == '__main__':
 
     create_logger(log_level, "blueman-manager", syslog=args.syslog)
 
-    manager = Blueman()
+    app = Blueman()
     set_proc_title()
-    Gtk.main()
+    app.run()

--- a/apps/blueman-services.in
+++ b/apps/blueman-services.in
@@ -3,10 +3,7 @@
 import os
 import sys
 import logging
-
-import gi
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
+import signal
 
 # support running uninstalled
 _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -16,6 +13,11 @@ if 'BLUEMAN_SOURCE' in os.environ:
 
 from blueman.Functions import set_proc_title, setup_icon_path, create_logger, create_parser
 from blueman.main.Services import BluemanServices
+
+# Workaround introspection bug, gnome bug 622084
+signal.signal(signal.SIGINT, signal.SIG_DFL)
+signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
 
 if __name__ == '__main__':
     parser = create_parser()
@@ -37,6 +39,6 @@ if __name__ == '__main__':
     create_logger(log_level, "blueman-services", syslog=args.syslog)
 
     setup_icon_path()
-    services = BluemanServices()
     set_proc_title()
-    Gtk.main()
+    app = BluemanServices()
+    app.run()

--- a/apps/blueman-tray.in
+++ b/apps/blueman-tray.in
@@ -36,4 +36,5 @@ if __name__ == '__main__':
     create_logger(log_level, "blueman-tray", syslog=args.syslog)
 
     set_proc_title()
-    BluemanTray()
+    app = BluemanTray()
+    app.run()

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -20,7 +20,6 @@ from time import sleep
 from typing import Optional, Dict, Tuple, List, Callable, Iterable, Union, Any
 import re
 import os
-import signal
 import sys
 import errno
 from gettext import gettext as _
@@ -50,8 +49,8 @@ from gi.repository import GdkPixbuf
 from gi.repository import Gio
 
 __all__ = ["check_bluetooth_status", "launch", "setup_icon_path", "adapter_path_to_name", "e_", "bmexit",
-           "format_bytes", "create_menuitem", "is_running", "kill", "have", "set_proc_title", "create_logger",
-           "create_parser", "open_rfcomm", "get_local_interfaces"]
+           "format_bytes", "create_menuitem", "have", "set_proc_title", "create_logger", "create_parser", "open_rfcomm",
+           "get_local_interfaces"]
 
 
 def check_bluetooth_status(message: str, exitfunc: Callable[[], Any]) -> None:
@@ -214,22 +213,6 @@ def create_menuitem(
     item.show_all()
 
     return item
-
-
-def is_running(name: str, pid: int) -> bool:
-    if not os.path.exists(f"/proc/{pid}"):
-        return False
-
-    with open(f"/proc/{pid}/cmdline") as f:
-        return name in f.readline().replace("\0", " ")
-
-
-def kill(pid: int, name: str) -> bool:
-    if pid and is_running(name, pid):
-        print('Terminating ' + name)
-        os.kill(pid, signal.SIGTERM)
-        return True
-    return False
 
 
 def have(t: str) -> Optional[str]:

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -362,7 +362,7 @@ class ManagerDeviceMenu(Gtk.Menu):
             builder.set_translation_domain("blueman")
             builder.add_from_file(UI_PATH + "/rename-device.ui")
             dialog = builder.get_object("dialog")
-            dialog.set_transient_for(self.Blueman)
+            dialog.set_transient_for(self.Blueman.window)
             dialog.props.icon_name = "blueman"
             alias_entry = builder.get_object("alias_entry")
             alias_entry.set_text(device['Alias'])

--- a/blueman/gui/manager/ManagerProgressbar.py
+++ b/blueman/gui/manager/ManagerProgressbar.py
@@ -66,10 +66,10 @@ class ManagerProgressbar(GObject.GObject):
 
     def _on_enter(self, evbox, event):
         c = Gdk.Cursor.new(Gdk.CursorType.HAND2)
-        self.Blueman.get_window().set_cursor(c)
+        self.Blueman.window.get_window().set_cursor(c)
 
     def _on_leave(self, evbox, event):
-        self.Blueman.get_window().set_cursor(None)
+        self.Blueman.window.get_window().set_cursor(None)
 
     def _on_clicked(self, evbox, event):
         self.eventbox.props.sensitive = False
@@ -102,7 +102,7 @@ class ManagerProgressbar(GObject.GObject):
         if not self.finalized:
             self.hide()
             self.stop()
-            self.Blueman.get_window().set_cursor(None)
+            self.Blueman.window.get_window().set_cursor(None)
             self.hbox.remove(self.eventbox)
             self.hbox.remove(self.progressbar)
             # self.hbox.remove(self.seperator)

--- a/blueman/main/Applet.py
+++ b/blueman/main/Applet.py
@@ -28,7 +28,7 @@ class BluemanApplet:
         self.Manager.connect_signal('device-created', self.on_device_created)
         self.Manager.connect_signal('device-removed', self.on_device_removed)
 
-        self.DbusSvc = DbusService("org.blueman.Applet", "org.blueman.Applet", "/org/blueman/applet",
+        self.DbusSvc = DbusService("org.blueman.Applet", "org.blueman.Applet", "/org/blueman/Applet",
                                    Gio.BusType.SESSION)
         self.DbusSvc.register()
 

--- a/blueman/main/Applet.py
+++ b/blueman/main/Applet.py
@@ -6,21 +6,18 @@ import blueman.plugins.applet
 from blueman.main.PluginManager import PersistentPluginManager
 from blueman.main.DbusService import DbusService
 from blueman.plugins.AppletPlugin import AppletPlugin
+from gi.repository import Gio
 import logging
 
-import gi
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gio
 
-
-class BluemanApplet:
+class BluemanApplet(Gio.Application):
     def __init__(self):
+        super().__init__(application_id="org.blueman.Applet", flags=Gio.ApplicationFlags.FLAGS_NONE)
         setup_icon_path()
-
-        check_single_instance("blueman-applet")
 
         self.plugin_run_state_changed = False
         self.manager_state = False
+        self._active = False
 
         self.Manager = Manager()
         self.Manager.connect_signal('adapter-added', self.on_adapter_added)
@@ -45,7 +42,10 @@ class BluemanApplet:
         self._any_device = AnyDevice()
         self._any_device.connect_signal('property-changed', self._on_device_property_changed)
 
-        Gtk.main()
+    def do_activate(self):
+        if not self._active:
+            self.hold()
+            self._active = True
 
     def _on_dbus_name_appeared(self, _connection, name, owner):
         logging.info(f"{name} {owner}")

--- a/blueman/main/DBusProxies.py
+++ b/blueman/main/DBusProxies.py
@@ -38,4 +38,4 @@ class Mechanism(ProxyBase):
 class AppletService(ProxyBase):
     def __init__(self):
         super().__init__(name='org.blueman.Applet', interface_name='org.blueman.Applet',
-                         object_path="/org/blueman/applet")
+                         object_path="/org/blueman/Applet")

--- a/blueman/main/DBusProxies.py
+++ b/blueman/main/DBusProxies.py
@@ -8,7 +8,7 @@ class DBusProxyFailed(Exception):
 
 
 class ProxyBase(Gio.DBusProxy, metaclass=SingletonGObjectMeta):
-    def __init__(self, name, interface_name, object_path='/', systembus=False, *args, **kwargs):
+    def __init__(self, name, interface_name, object_path='/', systembus=False, flags=0, *args, **kwargs):
         if systembus:
             bustype = Gio.BusType.SYSTEM
         else:
@@ -19,7 +19,7 @@ class ProxyBase(Gio.DBusProxy, metaclass=SingletonGObjectMeta):
             g_interface_name=interface_name,
             g_object_path=object_path,
             g_bus_type=bustype,
-            g_flags=Gio.DBusProxyFlags.NONE,
+            g_flags=flags,
             *args, **kwargs
         )
 

--- a/blueman/main/DBusProxies.py
+++ b/blueman/main/DBusProxies.py
@@ -39,3 +39,23 @@ class AppletService(ProxyBase):
     def __init__(self):
         super().__init__(name='org.blueman.Applet', interface_name='org.blueman.Applet',
                          object_path="/org/blueman/Applet")
+
+
+class ManagerService(ProxyBase):
+    def __init__(self):
+        super().__init__(name="org.blueman.Manager", interface_name="org.freedesktop.Application",
+                         object_path="/org/blueman/Manager",
+                         flags=Gio.DBusProxyFlags.DO_NOT_AUTO_START_AT_CONSTRUCTION)
+
+    def _call_action(self, name: str) -> None:
+        def call_finish(proxy, resp):
+            proxy.call_finish(resp)
+
+        param = GLib.Variant('(sava{sv})', (name, [], {}))
+        self.call('ActivateAction', param, Gio.DBusProxyFlags.NONE, -1, None, call_finish)
+
+    def startstop(self):
+        if self.get_name_owner() is None:
+            self._call_action("Activate")
+        else:
+            self._call_action("Quit")

--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -7,16 +7,33 @@ from pickle import UnpicklingError
 from tempfile import mkstemp
 from time import sleep
 import logging
+import signal
 from typing import List, Tuple
 
 from blueman.Constants import DHCP_CONFIG_FILE
-from blueman.Functions import have, is_running, kill
+from blueman.Functions import have
 from _blueman import create_bridge, destroy_bridge, BridgeException
 from subprocess import call, Popen, PIPE
 
 
 class NetworkSetupError(Exception):
     pass
+
+
+def is_running(name: str, pid: int) -> bool:
+    if not os.path.exists(f"/proc/{pid}"):
+        return False
+
+    with open(f"/proc/{pid}/cmdline") as f:
+        return name in f.readline().replace("\0", " ")
+
+
+def kill(pid: int, name: str) -> bool:
+    if pid and is_running(name, pid):
+        print('Terminating ' + name)
+        os.kill(pid, signal.SIGTERM)
+        return True
+    return False
 
 
 def read_pid_file(fname):

--- a/blueman/main/Tray.py
+++ b/blueman/main/Tray.py
@@ -1,25 +1,36 @@
 from importlib import import_module
 import logging
-
-from blueman.Functions import check_single_instance
+import os
+import sys
 from blueman.main.DBusProxies import AppletService
-
-import gi
-gi.require_version('Gtk', '3.0')
-from gi.repository import GLib, Gio
+from gi.repository import Gio
 
 
-class BluemanTray:
+class BluemanTray(Gio.Application):
     def __init__(self):
-        check_single_instance("blueman-tray")
+        super().__init__(application_id="org.blueman.Tray", flags=Gio.ApplicationFlags.FLAGS_NONE)
+        self._active = False
+
+    def do_startup(self):
+        Gio.Application.do_startup(self)
+
+        quit_action = Gio.SimpleAction.new("Quit", None)
+        quit_action.connect("activate", self.quit)
+        self.add_action(quit_action)
+
+    def do_activate(self):
+        if self._active:
+            logging.info("Already running, restarting instance")
+            os.execv(sys.argv[0], sys.argv)
+
+        Gio.bus_watch_name(Gio.BusType.SESSION, 'org.blueman.Applet', Gio.BusNameWatcherFlags.NONE,
+                           self._on_name_appeared, self._on_name_vanished)
+        self.hold()
+
+    def _on_name_appeared(self, _connection, name, _owner):
+        logging.debug("Applet started on name %s, showing indicator" % name)
 
         applet = AppletService()
-
-        main_loop = GLib.MainLoop()
-
-        Gio.bus_watch_name(Gio.BusType.SESSION, 'org.blueman.Applet',
-                           Gio.BusNameWatcherFlags.NONE, None, lambda _connection, _name: main_loop.quit())
-
         indicator_name = applet.GetStatusIconImplementation()
         logging.info(f'Using indicator "{indicator_name}"')
         indicator_class = getattr(import_module('blueman.main.indicators.' + indicator_name), indicator_name)
@@ -31,7 +42,11 @@ class BluemanTray:
         self.indicator.set_visibility(applet.GetVisibility())
         self.indicator.set_menu(applet.GetMenu())
 
-        main_loop.run()
+        self._active = True
+
+    def _on_name_vanished(self, _connection, _name):
+        logging.debug("Applet shutdown or not available at startup")
+        self.quit()
 
     def _activate_menu_item(self, *indexes):
         return AppletService().ActivateMenuItem('(ai)', indexes)

--- a/blueman/plugins/applet/ExitItem.py
+++ b/blueman/plugins/applet/ExitItem.py
@@ -1,8 +1,4 @@
 from gettext import gettext as _
-
-import gi
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 from blueman.plugins.AppletPlugin import AppletPlugin
 
 
@@ -13,7 +9,8 @@ class ExitItem(AppletPlugin):
     __icon__ = "application-exit"
 
     def on_load(self):
-        self.parent.Plugins.Menu.add(self, 100, text=_("_Exit"), icon_name='application-exit', callback=Gtk.main_quit)
+        self.parent.Plugins.Menu.add(self, 100, text=_("_Exit"), icon_name='application-exit',
+                                     callback=self.parent.quit)
 
     def on_unload(self):
         self.parent.Plugins.Menu.unregister(self)

--- a/blueman/plugins/applet/StandardItems.py
+++ b/blueman/plugins/applet/StandardItems.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 
-from blueman.Functions import launch, get_lockfile, get_pid, kill
+from blueman.Functions import launch
+from blueman.main.DBusProxies import ManagerService
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.gui.CommonUi import show_about_dialog
 from blueman.gui.applet.PluginDialog import PluginDialog
@@ -73,10 +74,8 @@ class StandardItems(AppletPlugin):
         launch("blueman-sendto", name=_("File Sender"))
 
     def on_devices(self):
-        lockfile = get_lockfile('blueman-manager')
-        pid = get_pid(lockfile)
-        if not pid or not kill(pid, 'blueman-manager'):
-            launch("blueman-manager", name=_("Device Manager"))
+        m = ManagerService()
+        m.startstop()
 
     def on_adapters(self):
         launch("blueman-adapters", name=_("Adapter Preferences"))

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -2,7 +2,7 @@ from gettext import gettext as _
 
 from gi.repository import GObject, GLib
 
-from blueman.Functions import launch, kill, get_pid, get_lockfile
+from blueman.Functions import launch
 from blueman.main.PluginManager import StopException
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.typing import GSignals
@@ -115,9 +115,6 @@ class StatusIcon(AppletPlugin, GObject.GObject):
         implementation = self._get_status_icon_implementation()
         if not self._implementation or self._implementation != implementation:
             self._implementation = implementation
-            pid = get_pid(get_lockfile('blueman-tray'))
-            if pid:
-                kill(pid, 'blueman-tray')
 
         if self.parent.manager_state:
             launch('blueman-tray', icon_name='blueman', sn=False)

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -22,7 +22,7 @@ class Services(ManagerPlugin):
 
     def _make_x_icon(self, icon_name, size):
         scale = self.parent.get_scale_factor()
-        window = self.parent.get_window()
+        window = self.parent.window.get_window()
 
         target = self.icon_theme.load_surface(icon_name, size, scale, window, Gtk.IconLookupFlags.FORCE_SIZE)
         bmx = self.icon_theme.load_surface("blueman-x", size, scale, window, Gtk.IconLookupFlags.FORCE_SIZE)

--- a/configure.ac
+++ b/configure.ac
@@ -320,6 +320,7 @@ data/man/Makefile
 data/configs/blueman-applet.service
 data/configs/blueman-mechanism.service
 data/configs/org.blueman.Applet.service
+data/configs/org.blueman.Manager.service
 data/configs/org.blueman.Mechanism.service
 module/Makefile
 po/Makefile.in

--- a/data/configs/Makefile.am
+++ b/data/configs/Makefile.am
@@ -7,6 +7,9 @@ dbus_services_DATA = org.blueman.Mechanism.service
 dbus_sessdir = $(datadir)/dbus-1/services
 dbus_sess_DATA = org.blueman.Applet.service
 
+dbus_managerdir = $(datadir)/dbus-1/services
+dbus_manager_DATA = org.blueman.Manager.service
+
 if SYSTEMD_SYSTEM_UNIT_DIR
 systemd_systemdir = $(systemd_system_unit_dir)
 systemd_system_DATA = blueman-mechanism.service
@@ -35,6 +38,7 @@ EXTRA_DIST = \
 	blueman-mechanism.service.in		\
 	org.blueman.Mechanism.conf		\
 	org.blueman.Applet.service.in		\
+	org.blueman.Manager.service.in	\
 	org.blueman.Mechanism.service.in	\
 	org.blueman.policy.in			\
 	blueman.rules
@@ -42,6 +46,7 @@ EXTRA_DIST = \
 CLEANFILES =		\
 	blueman-applet.service		\
 	blueman-mechanism.service	\
+	org.blueman.Manager.service \
 	org.blueman.Mechanism.service	\
 	org.blueman.Applet.service		\
 	org.blueman.policy		\

--- a/data/configs/org.blueman.Manager.service.in
+++ b/data/configs/org.blueman.Manager.service.in
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.blueman.Manager
+Exec=@BINDIR@/blueman-manager
+SystemdService=blueman-manager.service


### PR DESCRIPTION
Apologies for the delay, I started this 2 years ago already :roll_eyes: .

This ports most of the application to use Gio/Gtk.Application. I did the minimal needed so not to break things. But Gtk.Application has lots of benefits which can be used at some later date.

I left the the following as is,
* blueman-sendto: There is no need for uniqueness AFAICS and I rather have it get a redesign.
* blueman-mechanism: We access it through dbus and uses a basic GLib.MainLoop. If the need arises this should be fairly easy to port.
* blueman-assistant: Gtk.Assistant is itself not a Gtk.ApplicationWindow, perhaps in Gtk+4. I could wrap it in a simple Gio/Gtk.Application but we need to think about if we need uniqueness (we currently don't enforce anything, should we?) 

It needs a proper testing to find the bugs hiding in the dark corners of blueman. Also I think mypy fails, I'll fix that :smile:.