### PR TITLE
Use mapping keys for messages with plural forms

### DIFF
--- a/blueman/main/Adapter.py
+++ b/blueman/main/Adapter.py
@@ -143,7 +143,7 @@ class BluemanAdapters(Gtk.Window):
                 else:
                     return _("Hidden")
             else:
-                return gettext.ngettext("%d Minute", "%d Minutes", value) % value
+                return gettext.ngettext("%(minutes)d Minute", "%(minutes)d Minutes", value) % {"minutes": value}
 
         def on_scale_value_changed(scale):
             val = scale.get_value()

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -189,9 +189,9 @@ class Sender(Gtk.Dialog):
                 x = ((self.total_bytes - self.total_transferred) / spd) + 1
                 if x > 60:
                     x /= 60
-                    eta = ngettext("%.0f Minute", "%.0f Minutes", round(x)) % x
+                    eta = ngettext("%(minutes)d Minute", "%(minutes)d Minutes", round(x)) % {"minutes": round(x)}
                 else:
-                    eta = ngettext("%.0f Second", "%.0f Seconds", round(x)) % x
+                    eta = ngettext("%(seconds)d Second", "%(seconds)d Seconds", round(x)) % {"seconds": round(x)}
             except ZeroDivisionError:
                 eta = "∞"
 

--- a/blueman/plugins/applet/ShowConnected.py
+++ b/blueman/plugins/applet/ShowConnected.py
@@ -46,9 +46,11 @@ class ShowConnected(AppletPlugin):
     def update_statusicon(self):
         if self.num_connections > 0:
             self.parent.Plugins.StatusIcon.set_text_line(0, _("Bluetooth Active"))
-            self.parent.Plugins.StatusIcon.set_text_line(1, ngettext("<b>%d Active Connection</b>",
-                                                                     "<b>%d Active Connections</b>",
-                                                                     self.num_connections) % self.num_connections)
+            self.parent.Plugins.StatusIcon.set_text_line(
+                1,
+                ngettext("<b>%(connections)d Active Connection</b>",
+                         "<b>%(connections)d Active Connections</b>",
+                         self.num_connections) % {"connections": self.num_connections})
         else:
             self.parent.Plugins.StatusIcon.set_text_line(1, None)
             # bluetooth should be always enabled if powermanager is not loaded

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -326,18 +326,18 @@ class TransferService(AppletPlugin):
         share_path, ignored = self._make_share_path()
         if self._normal_transfers == 0:
             self._notification = Notification(_("Files received"),
-                                              ngettext("Received %d file in the background",
-                                                       "Received %d files in the background",
-                                                       self._silent_transfers) % self._silent_transfers,
+                                              ngettext("Received %(files)d file in the background",
+                                                       "Received %(files)d files in the background",
+                                                       self._silent_transfers) % {"files": self._silent_transfers},
                                               **self._notify_kwargs)
 
             self._add_open(self._notification, "Open Location", share_path)
             self._notification.show()
         else:
             self._notification = Notification(_("Files received"),
-                                              ngettext("Received %d more file in the background",
-                                                       "Received %d more files in the background",
-                                                       self._silent_transfers) % self._silent_transfers,
+                                              ngettext("Received %(files)d more file in the background",
+                                                       "Received %(files)d more files in the background",
+                                                       self._silent_transfers) % {"files": self._silent_transfers},
                                               **self._notify_kwargs)
             self._add_open(self._notification, "Open Location", share_path)
             self._notification.show()


### PR DESCRIPTION
msgfmt --check-format does not require format specifications with message keys to be used in the translation, so this gives more flexibility like using "one" instead of an argument containing 1.