### PR TITLE
Add a test job with Python 3.9

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,7 +64,8 @@ jobs:
           - 3.6
           - 3.7
           - 3.8
-    runs-on: ubuntu-latest
+          - 3.9-rc
+    runs-on: ubuntu-20.04
     container:
       image: python:${{ matrix.python }}
     steps:


### PR DESCRIPTION
It needs at least cython 0.29.10, so Ubuntu 18.04 is insufficient.