### PR TITLE
Improve workflow job dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
-      - run: sudo apt-get install -y -qq --no-install-recommends sudo automake autoconf libglib2.0-dev libtool intltool python3-dev python-gi python-gi-dev cython dh-autoreconf libbluetooth-dev gtk-update-icon-cache python3-pip
+      - run: sudo apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext cython libglib2.0-dev python3-dev python-gi-dev libbluetooth-dev
       - run: ./autogen.sh
       - run: make
       - run: make distcheck
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
-      - run: sudo apt-get install -y -qq --no-install-recommends build-essential meson sudo intltool libglib2.0-dev python3-dev python-gi python-gi-dev cython libbluetooth-dev gtk-update-icon-cache python3-pip
+      - run: sudo apt-get install -y -qq --no-install-recommends meson gettext cython libglib2.0-dev python3-dev python-gi-dev libbluetooth-dev
       - run: meson --warnlevel 3 --buildtype debug -Druntime_deps_check=false builddebug
       - run: ninja -v -C builddebug/
 
@@ -50,9 +50,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: apt-get update
-      - run: apt-get install -y -qq --no-install-recommends sudo automake autoconf libglib2.0-dev libtool intltool python3-dev python-gi python-gi-dev cython dh-autoreconf libbluetooth-dev gtk-update-icon-cache python3-pip
+      - run: apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext libglib2.0-dev python-gi-dev libbluetooth-dev
+      - run: python3 -m pip install cython mypy==0.740
       - run: ./autogen.sh
-      - run: python3 -m pip install --user mypy==0.740
       - run: python3 -m mypy -p blueman --ignore-missing-imports --warn-unused-configs --disallow-any-generics --disallow-incomplete-defs --check-untyped-defs --disallow-untyped-decorators --no-implicit-optional --warn-redundant-casts --warn-unused-ignores --warn-return-any --no-implicit-reexport
         env:
           MYPYPATH: ${{ github.workspace }}/stubs
@@ -64,14 +64,15 @@ jobs:
           - 3.6
           - 3.7
           - 3.8
+          - 3.9-rc
     runs-on: ubuntu-latest
     container:
       image: python:${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2
       - run: apt-get update
-      - run: apt-get install -y -qq --no-install-recommends sudo automake autoconf libglib2.0-dev libtool intltool python3-dev python-gi python-gi-dev cython dh-autoreconf libbluetooth-dev gtk-update-icon-cache python3-pip libgirepository1.0-dev gir1.2-gtk-3.0 libpulse0 libpulse-mainloop-glib0
+      - run: apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext libglib2.0-dev python-gi-dev libbluetooth-dev libgirepository1.0-dev gir1.2-gtk-3.0 libpulse0 libpulse-mainloop-glib0
+      - run: python3 -m pip install cython pygobject
       - run: ./autogen.sh
       - run: make -C module
-      - run: python3 -m pip install --user pygobject
       - run: PYTHONPATH=module/.libs python3 -m unittest

--- a/Dependencies.md
+++ b/Dependencies.md
@@ -24,16 +24,15 @@
 * [BlueZ 5](http://www.bluez.org/)
 * [Cython](http://www.cython.org/)
 * [GLib 2](http://www.gtk.org/) (>= 2.32)
-* [intltool](http://freedesktop.org/wiki/Software/intltool/)
-* [libtool](http://www.gnu.org/software/libtool/)
+* [gettext](https://www.gnu.org/software/gettext/)
 * [PyGObject 3](https://wiki.gnome.org/PyGObject) (>= 3.27.2)
 * [Python](http://www.python.org/) (>= 3.6)
 
 ## Additional dependencies for VCS version
 
-* [autogen](https://www.gnu.org/software/autogen/)
 * [automake](https://www.gnu.org/software/automake/)
 * [autoconf](https://www.gnu.org/software/autoconf/)
+* [libtool](http://www.gnu.org/software/libtool/)
 
 [1] There is a known issue with GTK+ <= 3.10.6, possibly in conjuction with specific themes or similar conditions. If it is present and a message is to be displayed in blueman-manager's message area the application will crash with
 


### PR DESCRIPTION
* Do not install sudo, python-gi, dh-autoreconf, gtk-update-icon-cache, python3-pip
* Replace intltool with gettext (and autopoint) (also in Dependencies.md)
* Do not install python3-dev in python containers
* Install cython from PyPI