### PR TITLE
Add type hints to service connection handling

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: apt-get update
-      - run: apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext libglib2.0-dev python-gi-dev libbluetooth-dev libgirepository1.0-dev gir1.2-gtk-3.0 libpulse0 libpulse-mainloop-glib0
+      - run: apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext libglib2.0-dev python-gi-dev libbluetooth-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-nm-1.0 libpulse0 libpulse-mainloop-glib0
       - run: python3 -m pip install cython pygobject
       - run: ./autogen.sh
       - run: make -C module

--- a/apps/blueman-assistant.in
+++ b/apps/blueman-assistant.in
@@ -231,12 +231,12 @@ class Assistant:
         elif num == PAGE_CONNECTING:
             logging.info("connect")
 
-            def success(*args):
+            def success(_obj: AppletService, _result: None, _user_data: None) -> None:
                 pages[PAGE_FINISH].set_markup(_("<b>Device added and connected successfully</b>"))
                 self.assistant.set_page_complete(pages[PAGE_CONNECTING], True)
                 self.assistant.set_current_page(PAGE_FINISH)
 
-            def fail(*args):
+            def fail(_obj: AppletService, _result: GLib.Error, _user_data: None) -> None:
                 pages[PAGE_FINISH].set_markup(_("<b>Device added successfully, but failed to connect</b>"))
                 self.assistant.set_page_complete(pages[PAGE_CONNECTING], True)
                 self.assistant.set_current_page(PAGE_FINISH)

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -101,14 +101,11 @@ class ManagerDeviceMenu(Gtk.Menu):
     def on_connect(self, _item, service):
         device = service.device
 
-        def success(obj, result, _user_data):
+        def success(_obj, _result, _user_data):
             logging.info("success")
             prog.message(_("Success!"))
 
-            if isinstance(service, SerialPort) and SERIAL_PORT_SVCLASS_ID == service.short_uuid:
-                MessageArea.show_message(_("Serial port connected to %s") % result, None, "dialog-information")
-            else:
-                MessageArea.close()
+            MessageArea.close()
 
             self.unset_op(device)
 

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -5,12 +5,12 @@ from typing import Dict, List, Tuple, Optional
 
 from blueman.Constants import UI_PATH
 from blueman.Functions import create_menuitem, e_
+from blueman.Service import Service
 from blueman.bluez.Network import AnyNetwork
 from blueman.bluez.Device import AnyDevice, Device
 from blueman.gui.manager.ManagerProgressbar import ManagerProgressbar
 from blueman.main.DBusProxies import AppletService, DBusProxyFailed
 from blueman.gui.MessageArea import MessageArea
-from blueman.services import SerialPort
 from blueman.Sdp import (
     ServiceUUID,
     AUDIO_SOURCE_SVCLASS_ID,
@@ -18,8 +18,7 @@ from blueman.Sdp import (
     HANDSFREE_AGW_SVCLASS_ID,
     HANDSFREE_SVCLASS_ID,
     HEADSET_SVCLASS_ID,
-    HID_SVCLASS_ID,
-    SERIAL_PORT_SVCLASS_ID)
+    HID_SVCLASS_ID)
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -98,10 +97,10 @@ class ManagerDeviceMenu(Gtk.Menu):
         if key == "Connected":
             self.generate()
 
-    def on_connect(self, _item, service):
+    def on_connect(self, _item: Gtk.MenuItem, service: Service) -> None:
         device = service.device
 
-        def success(_obj, _result, _user_data):
+        def success(_obj: AppletService, _result: None, _user_data: None) -> None:
             logging.info("success")
             prog.message(_("Success!"))
 
@@ -109,7 +108,7 @@ class ManagerDeviceMenu(Gtk.Menu):
 
             self.unset_op(device)
 
-        def fail(obj, result, _user_data):
+        def fail(_obj: Optional[AppletService], result: GLib.Error, _user_data: None) -> None:
             prog.message(_("Failed"))
 
             self.unset_op(device)
@@ -130,12 +129,12 @@ class ManagerDeviceMenu(Gtk.Menu):
 
         prog.start()
 
-    def on_disconnect(self, item, service, port=0):
-        def ok(obj, result, user_date):
+    def on_disconnect(self, _item: Gtk.MenuItem, service: Service, port: int = 0) -> None:
+        def ok(_obj: AppletService, _result: None, _user_date: None) -> None:
             logging.info("disconnect success")
             self.generate()
 
-        def err(obj, result, user_date):
+        def err(_obj: Optional[AppletService], result: GLib.Error, _user_date: None) -> None:
             logging.warning(f"disconnect failed {result}")
             msg, tb = e_(result.message)
             MessageArea.show_message(_("Disconnection Failed: ") + msg, tb)
@@ -155,15 +154,15 @@ class ManagerDeviceMenu(Gtk.Menu):
             if key in ("Connected", "UUIDs", "Trusted", "Paired"):
                 self.generate()
 
-    def generic_connect(self, item, device, connect):
-        def fail(obj, result, user_date):
+    def generic_connect(self, _item: Gtk.MenuItem, device: Device, connect: bool) -> None:
+        def fail(_obj: AppletService, result: GLib.Error, _user_data: None) -> None:
             logging.info(f"fail: {result}")
             prog.message(_("Failed"))
             self.unset_op(device)
             msg, tb = e_(result.message)
             MessageArea.show_message(_("Connection Failed: ") + msg)
 
-        def success(obj, result, user_data):
+        def success(_obj: AppletService, _result: None, _user_data: None) -> None:
             logging.info("success")
             prog.message(_("Success!"))
             MessageArea.close()

--- a/blueman/main/NetworkManager.py
+++ b/blueman/main/NetworkManager.py
@@ -1,7 +1,9 @@
 import gi
 import logging
 import uuid
-from typing import Optional
+from typing import Optional, Callable, Union
+
+from blueman.Service import Service
 
 try:
     gi.require_version('NM', '1.0')
@@ -19,7 +21,8 @@ class NMConnectionError(Exception):
 class NMConnectionBase:
     conntype: str
 
-    def __init__(self, service, reply_handler, error_handler):
+    def __init__(self, service: Service, reply_handler: Callable[[], None],
+                 error_handler: Callable[[Union[NMConnectionError, GLib.Error]], None]):
         if self.conntype not in ('dun', 'panu'):
             error_handler(
                 NMConnectionError(f"Invalid connection type {self.conntype}, should be panu or dun")

--- a/blueman/plugins/applet/AutoConnect.py
+++ b/blueman/plugins/applet/AutoConnect.py
@@ -1,4 +1,5 @@
 from gettext import gettext as _
+from typing import Union
 
 from gi.repository import GLib
 
@@ -32,12 +33,12 @@ class AutoConnect(AppletPlugin):
             if device is None or device.get("Connected"):
                 continue
 
-            def reply(*_args):
+            def reply() -> None:
                 Notification(_("Connected"), _("Automatically connected to %(service)s on %(device)s") %
                              {"service": ServiceUUID(uuid).name, "device": device["Alias"]},
                              icon_name=device["Icon"]).show()
 
-            def err(_reason):
+            def err(_reason: Union[Exception, str]) -> None:
                 pass
 
             self.parent.Plugins.DBusService.connect_service(device.get_object_path(), uuid, reply, err)

--- a/blueman/plugins/applet/NMDUNSupport.py
+++ b/blueman/plugins/applet/NMDUNSupport.py
@@ -1,7 +1,11 @@
 from gettext import gettext as _
+from typing import Callable, Union
 
+from gi.repository import GLib
+
+from blueman.Service import Service
 from blueman.plugins.AppletPlugin import AppletPlugin
-from blueman.main.NetworkManager import NMDUNConnection
+from blueman.main.NetworkManager import NMDUNConnection, NMConnectionError
 from blueman.Sdp import DIALUP_NET_SVCLASS_ID
 
 
@@ -17,7 +21,8 @@ class NMDUNSupport(AppletPlugin):
         pass
 
     @staticmethod
-    def service_connect_handler(service, ok, err):
+    def service_connect_handler(service: Service, ok: Callable[[], None],
+                                err: Callable[[Union[NMConnectionError, GLib.Error]], None]) -> bool:
         if DIALUP_NET_SVCLASS_ID != service.short_uuid:
             return False
 
@@ -27,7 +32,8 @@ class NMDUNSupport(AppletPlugin):
         return True
 
     @staticmethod
-    def service_disconnect_handler(service, ok, err):
+    def service_disconnect_handler(service: Service, ok: Callable[[], None],
+                                   err: Callable[[Union[NMConnectionError, GLib.Error]], None]) -> bool:
         if DIALUP_NET_SVCLASS_ID != service.short_uuid:
             return False
 

--- a/blueman/plugins/applet/NMPANSupport.py
+++ b/blueman/plugins/applet/NMPANSupport.py
@@ -1,7 +1,11 @@
 from gettext import gettext as _
+from typing import Callable, Union
 
+from gi.repository import GLib
+
+from blueman.Service import Service
 from blueman.plugins.AppletPlugin import AppletPlugin
-from blueman.main.NetworkManager import NMPANConnection
+from blueman.main.NetworkManager import NMPANConnection, NMConnectionError
 from blueman.services.meta import NetworkService
 
 
@@ -17,7 +21,8 @@ class NMPANSupport(AppletPlugin):
         pass
 
     @staticmethod
-    def service_connect_handler(service, ok, err):
+    def service_connect_handler(service: Service, ok: Callable[[], None],
+                                err: Callable[[Union[NMConnectionError, GLib.Error]], None]) -> bool:
         if not isinstance(service, NetworkService):
             return False
 
@@ -27,7 +32,8 @@ class NMPANSupport(AppletPlugin):
         return True
 
     @staticmethod
-    def service_disconnect_handler(service, ok, err):
+    def service_disconnect_handler(service: Service, ok: Callable[[], None],
+                                   err: Callable[[Union[NMConnectionError, GLib.Error]], None]) -> bool:
         if not isinstance(service, NetworkService):
             return False
 

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -2,10 +2,10 @@ from gettext import gettext as _
 from operator import itemgetter
 import time
 import logging
-from typing import Dict, List, TYPE_CHECKING, Optional, Callable, cast
+from typing import Dict, List, TYPE_CHECKING, Optional, Callable, cast, Union
 
 from blueman.bluez.Device import Device
-from blueman.bluez.errors import DBusNoSuchAdapterError, BluezDBusException
+from blueman.bluez.errors import DBusNoSuchAdapterError
 from blueman.gui.Notification import Notification
 from blueman.Sdp import ServiceUUID
 from blueman.plugins.AppletPlugin import AppletPlugin
@@ -224,16 +224,16 @@ class RecentConns(AppletPlugin):
         self.parent.Plugins.Menu.on_menu_changed()
 
         def reply() -> None:
-            assert item["mitem"] is not None
+            assert item["mitem"] is not None  # https://github.com/python/mypy/issues/2608
             Notification(_("Connected"), _("Connected to %s") % item["mitem"]["text"],
                          icon_name=item["icon"]).show()
             item["mitem"]["sensitive"] = True
             self.parent.Plugins.Menu.on_menu_changed()
 
-        def err(reason: BluezDBusException) -> None:
+        def err(reason: Union[Exception, str]) -> None:
             Notification(_("Failed to connect"), str(reason).split(": ")[-1],
                          icon_name="dialog-error").show()
-            assert item["mitem"] is not None
+            assert item["mitem"] is not None  # https://github.com/python/mypy/issues/2608
             item["mitem"]["sensitive"] = True
             self.parent.Plugins.Menu.on_menu_changed()
 

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -1,11 +1,12 @@
 from gettext import gettext as _
-from typing import Dict, Any  # noqa: F401
+from typing import Dict, Any, Callable  # noqa: F401
 
+from blueman.Service import Service
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.gui.Notification import Notification
 from blueman.Sdp import SERIAL_PORT_SVCLASS_ID
 from blueman.services.Functions import get_services
-from _blueman import rfcomm_list
+from _blueman import rfcomm_list, RFCOMMError
 from subprocess import Popen
 import logging
 import os
@@ -123,8 +124,9 @@ class SerialManager(AppletPlugin):
                 logging.info(f"Sending HUP to {process.pid}")
                 os.killpg(process.pid, signal.SIGHUP)
 
-    def rfcomm_connect_handler(self, service, reply, err):
-        if SERIAL_PORT_SVCLASS_ID == service.short_uuid:
+    def rfcomm_connect_handler(self, service: Service, reply: Callable[[str], None],
+                               err: Callable[[RFCOMMError], None]) -> bool:
+        if isinstance(service, SerialService):
             service.connect(reply_handler=reply, error_handler=err)
             return True
         else:


### PR DESCRIPTION
...and fix some issues.

The ok callback in connect_service and disconnect_service is used in places where it is expected to take no argument (Device.connect, Device.disconnect, SerialService.disconnect, NetworkService.disconnect) or a str argument (service_connect_handler, service_disconnect_handler, explicit call after rfcomm_connect_handler, SerialService.connect, NetworkService.connect). None of the usages of those methods - including the the DBus call due to its empty output signature - actually cares about the argument, so we can unify the signature to a noargs reply handler. ab84869 already dropped the unused reply argument in RecentConns and thus broke it for the serial and network service cases.

The reply value passed on by service_connect_handler, service_disconnect_handler, and NMBaseConnection is never actually used, so we can drop it and use a noargs callback. So is the NMBaseConnection's ability to not pass a reply_handler.

The reply handler for serial port services in ManagerDeviceMenu.on_connect seems broken as the result of the ConnectService DBus method will always be None due to its signature. (I think the code works, the message is just useless as it contains "None")

The err callback in connect_service typically receives an Exception but one explicit call in connect_service passes a str instead. The same holds for disconnect_service where a str gets passed in SerialService.disconnect. We can leave this
as it is for now, but require the callback to handle both.