### PR TITLE
Refactor inter-plugin callback handling

### DIFF
--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -254,13 +254,9 @@ class ManagerDeviceMenu(Gtk.Menu):
             connect_item.show()
             self.append(connect_item)
 
-        rets = [plugin.on_request_menu_items(self, self.SelectedDevice)
-                for plugin in self.Blueman.Plugins.get_loaded_plugins(MenuItemsProvider)]
-
-        for ret in rets:
-            if ret:
-                for (item, pos) in ret:
-                    items.append((pos, item))
+        for plugin in self.Blueman.Plugins.get_loaded_plugins(MenuItemsProvider):
+            for item, pos in plugin.on_request_menu_items(self, self.SelectedDevice):
+                items.append((pos, item))
 
         logging.debug(row["alias"])
 

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -26,6 +26,12 @@ from gi.repository import Gtk
 from gi.repository import GLib
 
 
+class MenuItemsProvider:
+    def on_request_menu_items(self, manager_menu: "ManagerDeviceMenu",
+                              device: Device) -> List[Tuple[Gtk.MenuItem, int]]:
+        ...
+
+
 class ManagerDeviceMenu(Gtk.Menu):
     __ops__: Dict[str, str] = {}
     __instances__: List["ManagerDeviceMenu"] = []
@@ -248,7 +254,8 @@ class ManagerDeviceMenu(Gtk.Menu):
             connect_item.show()
             self.append(connect_item)
 
-        rets = self.Blueman.Plugins.run("on_request_menu_items", self, self.SelectedDevice)
+        rets = [plugin.on_request_menu_items(self, self.SelectedDevice)
+                for plugin in self.Blueman.Plugins.get_loaded_plugins(MenuItemsProvider)]
 
         for ret in rets:
             if ret:

--- a/blueman/main/Applet.py
+++ b/blueman/main/Applet.py
@@ -32,7 +32,8 @@ class BluemanApplet(Gio.Application):
         self.Plugins = PersistentPluginManager(AppletPlugin, blueman.plugins.applet, self)
         self.Plugins.load_plugin()
 
-        self.Plugins.run("on_plugins_loaded")
+        for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
+            plugin.on_plugins_loaded()
 
         self.Manager.watch_name_owner(self._on_dbus_name_appeared, self._on_dbus_name_vanished)
 
@@ -51,32 +52,40 @@ class BluemanApplet(Gio.Application):
         logging.info(f"{name} {owner}")
         self.manager_state = True
         self.plugin_run_state_changed = True
-        self.Plugins.run("on_manager_state_changed", self.manager_state)
+        for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
+            plugin.on_manager_state_changed(self.manager_state)
 
     def _on_dbus_name_vanished(self, _connection, name):
         logging.info(name)
         self.manager_state = False
         self.plugin_run_state_changed = True
-        self.Plugins.run("on_manager_state_changed", self.manager_state)
+        for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
+            plugin.on_manager_state_changed(self.manager_state)
 
     def _on_adapter_property_changed(self, _adapter, key, value, path):
-        self.Plugins.run("on_adapter_property_changed", path, key, value)
+        for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
+            plugin.on_adapter_property_changed(path, key, value)
 
     def _on_device_property_changed(self, _device, key, value, path):
-        self.Plugins.run("on_device_property_changed", path, key, value)
+        for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
+            plugin.on_device_property_changed(path, key, value)
 
     def on_adapter_added(self, _manager, path):
         logging.info(f"Adapter added {path}")
-        self.Plugins.run("on_adapter_added", path)
+        for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
+            plugin.on_adapter_added(path)
 
     def on_adapter_removed(self, _manager, path):
         logging.info(f"Adapter removed {path}")
-        self.Plugins.run("on_adapter_removed", path)
+        for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
+            plugin.on_adapter_removed(path)
 
     def on_device_created(self, _manager, path):
         logging.info(f"Device created {path}")
-        self.Plugins.run("on_device_created", path)
+        for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
+            plugin.on_device_created(path)
 
     def on_device_removed(self, _manager, path):
         logging.info(f"Device removed {path}")
-        self.Plugins.run("on_device_removed", path)
+        for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
+            plugin.on_device_removed(path)

--- a/blueman/main/PluginManager.py
+++ b/blueman/main/PluginManager.py
@@ -15,10 +15,6 @@ from blueman.plugins.ManagerPlugin import ManagerPlugin
 from blueman.typing import GSignals
 
 
-class StopException(Exception):
-    pass
-
-
 class LoadException(Exception):
     pass
 

--- a/blueman/plugins/BasePlugin.py
+++ b/blueman/plugins/BasePlugin.py
@@ -1,13 +1,9 @@
 import logging
 import weakref
 from gettext import gettext as _
-from typing import List, TYPE_CHECKING, Dict, Tuple, Any, Type
+from typing import List, TYPE_CHECKING, Dict, Tuple, Any
 
 from blueman.main.Config import Config
-
-
-class MethodAlreadyExists(Exception):
-    pass
 
 
 if TYPE_CHECKING:
@@ -48,8 +44,6 @@ class BasePlugin:
     def __init__(self, parent):
         self.parent = parent
 
-        self.__methods: List[Tuple[Type[BasePlugin], str]] = []
-
         if self.__options__:
             self.__config = Config(
                 self.__class__.__gsettings__.get("schema"),
@@ -67,21 +61,8 @@ class BasePlugin:
         res = map(lambda x: (len(x) > 2), cls.__options__.values())
         return True in res
 
-    @classmethod
-    def add_method(cls, func):
-        """Add a new method that can be used by other plugins to listen for changes, query state, etc"""
-        func.__self__.__methods.append((cls, func.__name__))
-
-        if func.__name__ in cls.__dict__:
-            raise MethodAlreadyExists
-        else:
-            setattr(cls, func.__name__, func)
-
     def _unload(self):
         self.on_unload()
-
-        for cls, met in self.__methods:
-            delattr(cls, met)
 
         self.__class__.__instance__ = None
 

--- a/blueman/plugins/ManagerPlugin.py
+++ b/blueman/plugins/ManagerPlugin.py
@@ -7,7 +7,3 @@ class ManagerPlugin(BasePlugin):
 
     def on_unload(self):
         pass
-
-    # return list of (GtkMenuItem, position) tuples
-    def on_request_menu_items(self, manager_menu, device):
-        pass

--- a/blueman/plugins/applet/AppIndicator.py
+++ b/blueman/plugins/applet/AppIndicator.py
@@ -4,13 +4,16 @@ from blueman.plugins.AppletPlugin import AppletPlugin
 
 # Check if Appindicator is available and raise ImportError
 from gi import require_version
+
+from blueman.plugins.applet.StatusIcon import StatusIconImplementationProvider
+
 try:
     require_version('AppIndicator3', '0.1')
 except ValueError:
     raise ImportError("AppIndicator3 not found")
 
 
-class AppIndicator(AppletPlugin):
+class AppIndicator(AppletPlugin, StatusIconImplementationProvider):
     __description__ = _("Uses libappindicator to show a statusicon")
     __icon__ = "blueman-tray"
     __author__ = "Walmis"

--- a/blueman/plugins/applet/KillSwitch.py
+++ b/blueman/plugins/applet/KillSwitch.py
@@ -8,8 +8,8 @@ import logging
 
 from blueman.main.DBusProxies import Mechanism
 from blueman.plugins.AppletPlugin import AppletPlugin
-from blueman.plugins.applet.StatusIcon import StatusIcon
-
+from blueman.plugins.applet.PowerManager import PowerStateHandler
+from blueman.plugins.applet.StatusIcon import StatusIcon, StatusIconVisibilityHandler
 
 RFKILL_TYPE_BLUETOOTH = 2
 
@@ -32,7 +32,7 @@ class Switch:
         self.hard = hard
 
 
-class KillSwitch(AppletPlugin):
+class KillSwitch(AppletPlugin, PowerStateHandler, StatusIconVisibilityHandler):
     __author__ = "Walmis"
     __description__ = _("Switches Bluetooth killswitch status to match Bluetooth power state."
                         "Allows turning Bluetooth back on from an icon that shows its status; "

--- a/blueman/plugins/applet/NMDUNSupport.py
+++ b/blueman/plugins/applet/NMDUNSupport.py
@@ -7,9 +7,10 @@ from blueman.Service import Service
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.main.NetworkManager import NMDUNConnection, NMConnectionError
 from blueman.Sdp import DIALUP_NET_SVCLASS_ID
+from blueman.plugins.applet.DBusService import ServiceConnectHandler
 
 
-class NMDUNSupport(AppletPlugin):
+class NMDUNSupport(AppletPlugin, ServiceConnectHandler):
     __depends__ = ["StatusIcon", "DBusService"]
     __conflicts__ = ["PPPSupport"]
     __icon__ = "modem"
@@ -20,8 +21,7 @@ class NMDUNSupport(AppletPlugin):
     def on_load(self):
         pass
 
-    @staticmethod
-    def service_connect_handler(service: Service, ok: Callable[[], None],
+    def service_connect_handler(self, service: Service, ok: Callable[[], None],
                                 err: Callable[[Union[NMConnectionError, GLib.Error]], None]) -> bool:
         if DIALUP_NET_SVCLASS_ID != service.short_uuid:
             return False
@@ -31,8 +31,7 @@ class NMDUNSupport(AppletPlugin):
 
         return True
 
-    @staticmethod
-    def service_disconnect_handler(service: Service, ok: Callable[[], None],
+    def service_disconnect_handler(self, service: Service, ok: Callable[[], None],
                                    err: Callable[[Union[NMConnectionError, GLib.Error]], None]) -> bool:
         if DIALUP_NET_SVCLASS_ID != service.short_uuid:
             return False

--- a/blueman/plugins/applet/NMPANSupport.py
+++ b/blueman/plugins/applet/NMPANSupport.py
@@ -6,10 +6,11 @@ from gi.repository import GLib
 from blueman.Service import Service
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.main.NetworkManager import NMPANConnection, NMConnectionError
+from blueman.plugins.applet.DBusService import ServiceConnectHandler
 from blueman.services.meta import NetworkService
 
 
-class NMPANSupport(AppletPlugin):
+class NMPANSupport(AppletPlugin, ServiceConnectHandler):
     __depends__ = ["DBusService"]
     __conflicts__ = ["DhcpClient"]
     __icon__ = "network-workgroup"
@@ -20,8 +21,7 @@ class NMPANSupport(AppletPlugin):
     def on_load(self):
         pass
 
-    @staticmethod
-    def service_connect_handler(service: Service, ok: Callable[[], None],
+    def service_connect_handler(self, service: Service, ok: Callable[[], None],
                                 err: Callable[[Union[NMConnectionError, GLib.Error]], None]) -> bool:
         if not isinstance(service, NetworkService):
             return False
@@ -31,8 +31,7 @@ class NMPANSupport(AppletPlugin):
 
         return True
 
-    @staticmethod
-    def service_disconnect_handler(service: Service, ok: Callable[[], None],
+    def service_disconnect_handler(self, service: Service, ok: Callable[[], None],
                                    err: Callable[[Union[NMConnectionError, GLib.Error]], None]) -> bool:
         if not isinstance(service, NetworkService):
             return False

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -16,6 +16,7 @@ from gi.repository import GLib
 
 import gi
 
+from blueman.plugins.applet.PPPSupport import PPPConnectedListener
 from blueman.typing import GSignals
 
 gi.require_version("Gtk", "3.0")
@@ -281,7 +282,7 @@ class Dialog:
                 return
 
 
-class NetUsage(AppletPlugin, GObject.GObject):
+class NetUsage(AppletPlugin, GObject.GObject, PPPConnectedListener):
     __depends__ = ["Menu"]
     __icon__ = "network-wireless"
     __description__ = _("Allows you to monitor your (mobile broadband) network traffic usage. Useful for limited "

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -9,8 +9,7 @@ from blueman.bluez.errors import DBusNoSuchAdapterError
 from blueman.gui.Notification import Notification
 from blueman.Sdp import ServiceUUID
 from blueman.plugins.AppletPlugin import AppletPlugin
-from blueman.plugins.applet.PowerManager import PowerManager
-
+from blueman.plugins.applet.PowerManager import PowerManager, PowerStateListener
 
 if TYPE_CHECKING:
     from typing_extensions import TypedDict
@@ -44,7 +43,7 @@ if TYPE_CHECKING:
 REGISTRY_VERSION = 0
 
 
-class RecentConns(AppletPlugin):
+class RecentConns(AppletPlugin, PowerStateListener):
     __depends__ = ["DBusService", "Menu"]
     __icon__ = "document-open-recent"
     __description__ = _("Provides a menu item that contains last used connections for quick access")

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -1,13 +1,12 @@
 from gettext import gettext as _
 from typing import Dict, Any, Callable  # noqa: F401
 
-from blueman.Service import Service
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.gui.Notification import Notification
 from blueman.Sdp import SERIAL_PORT_SVCLASS_ID
-from blueman.plugins.applet.DBusService import RFCOMMConnectedListener, RFCOMMConnectHandler
+from blueman.plugins.applet.DBusService import RFCOMMConnectedListener
 from blueman.services.Functions import get_services
-from _blueman import rfcomm_list, RFCOMMError
+from _blueman import rfcomm_list
 from subprocess import Popen
 import logging
 import os
@@ -18,7 +17,7 @@ from gi.repository import GLib
 from blueman.services.meta import SerialService
 
 
-class SerialManager(AppletPlugin, RFCOMMConnectedListener, RFCOMMConnectHandler):
+class SerialManager(AppletPlugin, RFCOMMConnectedListener):
     __icon__ = "blueman-serial"
     __description__ = _("Standard SPP profile connection handler, allows executing custom actions")
     __author__ = "walmis"
@@ -124,14 +123,6 @@ class SerialManager(AppletPlugin, RFCOMMConnectedListener, RFCOMMConnectHandler)
             if process:
                 logging.info(f"Sending HUP to {process.pid}")
                 os.killpg(process.pid, signal.SIGHUP)
-
-    def rfcomm_connect_handler(self, service: Service, reply: Callable[[str], None],
-                               err: Callable[[RFCOMMError], None]) -> bool:
-        if isinstance(service, SerialService):
-            service.connect(reply_handler=reply, error_handler=err)
-            return True
-        else:
-            return False
 
     def on_device_disconnect(self, device):
         serial_services = [service for service in get_services(device) if isinstance(service, SerialService)]

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -5,6 +5,7 @@ from blueman.Service import Service
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.gui.Notification import Notification
 from blueman.Sdp import SERIAL_PORT_SVCLASS_ID
+from blueman.plugins.applet.DBusService import RFCOMMConnectedListener, RFCOMMConnectHandler
 from blueman.services.Functions import get_services
 from _blueman import rfcomm_list, RFCOMMError
 from subprocess import Popen
@@ -17,7 +18,7 @@ from gi.repository import GLib
 from blueman.services.meta import SerialService
 
 
-class SerialManager(AppletPlugin):
+class SerialManager(AppletPlugin, RFCOMMConnectedListener, RFCOMMConnectHandler):
     __icon__ = "blueman-serial"
     __description__ = _("Standard SPP profile connection handler, allows executing custom actions")
     __author__ = "walmis"

--- a/blueman/plugins/applet/ShowConnected.py
+++ b/blueman/plugins/applet/ShowConnected.py
@@ -4,8 +4,10 @@ from gi.repository import GLib
 from blueman.plugins.AppletPlugin import AppletPlugin
 from gettext import ngettext
 
+from blueman.plugins.applet.StatusIcon import StatusIconProvider
 
-class ShowConnected(AppletPlugin):
+
+class ShowConnected(AppletPlugin, StatusIconProvider):
     __author__ = "Walmis"
     __depends__ = ["StatusIcon"]
     __icon__ = "blueman-active"
@@ -25,7 +27,7 @@ class ShowConnected(AppletPlugin):
     def on_status_icon_query_icon(self):
         if self.num_connections > 0:
             self.active = True
-            return "blueman-active",
+            return "blueman-active"
         else:
             self.active = False
 

--- a/blueman/plugins/applet/StandardItems.py
+++ b/blueman/plugins/applet/StandardItems.py
@@ -7,11 +7,14 @@ from blueman.gui.CommonUi import show_about_dialog
 from blueman.gui.applet.PluginDialog import PluginDialog
 
 import gi
+
+from blueman.plugins.applet.PowerManager import PowerStateListener
+
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 
-class StandardItems(AppletPlugin):
+class StandardItems(AppletPlugin, PowerStateListener):
     __depends__ = ["StatusIcon", "Menu"]
     __unloadable__ = False
     __description__ = _("Adds standard menu items to the status icon menu")

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -5,7 +5,6 @@ from gi.repository import GObject, GLib
 
 from blueman.Functions import launch
 from blueman.plugins.AppletPlugin import AppletPlugin
-from blueman.plugins.applet.PowerManager import PowerStateListener
 from blueman.typing import GSignals
 
 
@@ -24,7 +23,7 @@ class StatusIconProvider:
         ...
 
 
-class StatusIcon(AppletPlugin, GObject.GObject, PowerStateListener):
+class StatusIcon(AppletPlugin, GObject.GObject):
     __gsignals__: GSignals = {'activate': (GObject.SignalFlags.NO_HOOKS, None, ())}
 
     __unloadable__ = False
@@ -58,14 +57,6 @@ class StatusIcon(AppletPlugin, GObject.GObject, PowerStateListener):
         self._add_dbus_method("GetStatusIconImplementation", (), "s", self._get_status_icon_implementation)
         self._add_dbus_method("GetIconName", (), "s", self._get_icon_name)
         self._add_dbus_method("Activate", (), "", lambda: self.emit("activate"))
-
-    def on_power_state_changed(self, _manager, state):
-        if state:
-            self.set_text_line(0, _("Bluetooth Enabled"))
-            self.query_visibility(delay_hiding=True)
-        else:
-            self.set_text_line(0, _("Bluetooth Disabled"))
-            self.query_visibility()
 
     def query_visibility(self, delay_hiding=False, emit=True):
         rets = [plugin.on_query_status_icon_visibility()

--- a/blueman/plugins/manager/Info.py
+++ b/blueman/plugins/manager/Info.py
@@ -6,6 +6,7 @@ import logging
 from blueman.Functions import create_menuitem
 from blueman.Sdp import ServiceUUID
 from blueman.bluez.errors import BluezDBusException
+from blueman.gui.manager.ManagerDeviceMenu import MenuItemsProvider
 
 from blueman.plugins.ManagerPlugin import ManagerPlugin
 
@@ -107,7 +108,7 @@ def show_info(device, parent):
     dialog.destroy()
 
 
-class Info(ManagerPlugin):
+class Info(ManagerPlugin, MenuItemsProvider):
     def on_unload(self):
         pass
 

--- a/blueman/plugins/manager/Notes.py
+++ b/blueman/plugins/manager/Notes.py
@@ -4,6 +4,7 @@ from tempfile import NamedTemporaryFile
 
 from blueman.Constants import UI_PATH
 from blueman.Functions import create_menuitem, launch
+from blueman.gui.manager.ManagerDeviceMenu import MenuItemsProvider
 from blueman.plugins.ManagerPlugin import ManagerPlugin
 
 import gi
@@ -44,7 +45,7 @@ def send_note(device, parent):
     dialog.present()
 
 
-class Notes(ManagerPlugin):
+class Notes(ManagerPlugin, MenuItemsProvider):
     def on_unload(self):
         pass
 

--- a/blueman/plugins/manager/PulseAudioProfile.py
+++ b/blueman/plugins/manager/PulseAudioProfile.py
@@ -5,7 +5,7 @@ from typing import Dict, List, TYPE_CHECKING
 from blueman.bluez.Device import Device
 from blueman.plugins.ManagerPlugin import ManagerPlugin
 from blueman.main.PulseAudioUtils import PulseAudioUtils, EventType
-from blueman.gui.manager.ManagerDeviceMenu import ManagerDeviceMenu
+from blueman.gui.manager.ManagerDeviceMenu import ManagerDeviceMenu, MenuItemsProvider
 from blueman.gui.MessageArea import MessageArea
 from blueman.Functions import create_menuitem
 from blueman.Sdp import AUDIO_SOURCE_SVCLASS_ID, AUDIO_SINK_SVCLASS_ID, ServiceUUID
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from blueman.main.PulseAudioUtils import CardInfo  # noqa: F401
 
 
-class PulseAudioProfile(ManagerPlugin):
+class PulseAudioProfile(ManagerPlugin, MenuItemsProvider):
     def on_load(self):
         self.devices: Dict[str, "CardInfo"] = {}
 

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -2,6 +2,7 @@ from gettext import gettext as _
 
 import cairo
 from blueman.bluez.Network import Network
+from blueman.gui.manager.ManagerDeviceMenu import MenuItemsProvider
 from blueman.plugins.ManagerPlugin import ManagerPlugin
 from blueman.Functions import create_menuitem
 from blueman.main.DBusProxies import AppletService
@@ -16,7 +17,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 
-class Services(ManagerPlugin):
+class Services(ManagerPlugin, MenuItemsProvider):
     def on_load(self):
         self.icon_theme = Gtk.IconTheme.get_default()
 


### PR DESCRIPTION
Use mixins for dynamically defining functionality instead of dynamically adding it to / removing it from the AppletPlugin and dynamically calling it. PluginManager now only provides a convenience way of getting loaded plugins that are instances of a specific mixin and calls are done directly without any necessity for fancy call handling as the caller can do whatever it wants to do directly.

Depends on #1329 (due to many conflicting code locations) and currently does not work due to circular dependencies at least between StatusIcon and PowerManager.