### PR TITLE
Enable mypy --disallow-untyped-calls --disallow-untyped-defs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,7 +54,7 @@ jobs:
       - run: apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext libglib2.0-dev python-gi-dev libbluetooth-dev
       - run: python3 -m pip install cython mypy==0.782
       - run: ./autogen.sh
-      - run: python3 -m mypy -p blueman --ignore-missing-imports --warn-unused-configs --disallow-any-generics --disallow-incomplete-defs --check-untyped-defs --disallow-untyped-decorators --no-implicit-optional --warn-redundant-casts --warn-unused-ignores --warn-return-any --no-implicit-reexport --strict-equality
+      - run: python3 -m mypy -p blueman --ignore-missing-imports --warn-unused-configs --disallow-any-generics --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs --check-untyped-defs --disallow-untyped-decorators --no-implicit-optional --warn-redundant-casts --warn-unused-ignores --warn-return-any --no-implicit-reexport --strict-equality
         env:
           MYPYPATH: ${{ github.workspace }}/stubs
 

--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -8,12 +8,13 @@ from gi.repository import Gio, GLib
 from blueman.bluez.Adapter import Adapter
 from _blueman import create_rfcomm_device, get_rfcomm_channel, RFCOMMError
 from blueman.Service import Service
+from blueman.bluez.Device import Device
 from blueman.main.DBusProxies import Mechanism
 from blueman.Constants import RFCOMM_WATCHER_PATH
 
 
 class SerialService(Service):
-    def __init__(self, device, uuid):
+    def __init__(self, device: Device, uuid: str) -> None:
         super().__init__(device, uuid)
         self._handlerids: Dict[int, int] = {}
 


### PR DESCRIPTION
We're basically mypy --strict now, just --disallow-subclassing-any is missing as all the untyped GLib / Gtk classes we inherit from are considered Any. This can be fixed by adding stubs for them which will reveal all kinds of edge cases I guess.

Depends on #1338 #1340 #1341.