### PR TITLE
Handle unexpected DBus errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Untranslated strings (@cwenling / Colomban Wendling)
 * Searching (with Ctrl+F in manager device list) did not work
 * Default PIN lookup
+* Exceptions from asynchronous DBus calls (getting picked up by tools like Apport or ABRT)
 
 ## 2.1.1
 

--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -1,8 +1,11 @@
+from typing import Optional, Callable
+
 from gi.repository import GLib
 
 from blueman.bluez.AnyBase import AnyBase
 from blueman.bluez.Base import Base
 from blueman.bluez.Device import Device
+from blueman.bluez.errors import BluezDBusException
 
 
 class Adapter(Base):
@@ -11,8 +14,8 @@ class Adapter(Base):
     def __init__(self, obj_path: str):
         super().__init__(obj_path=obj_path)
 
-    def start_discovery(self) -> None:
-        self._call('StartDiscovery')
+    def start_discovery(self, error_handler: Optional[Callable[[BluezDBusException], None]] = None) -> None:
+        self._call('StartDiscovery', error_handler=error_handler)
 
     def stop_discovery(self) -> None:
         self._call('StopDiscovery')

--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -80,7 +80,7 @@ class Base(Gio.DBusProxy, metaclass=BaseMeta):
                 if error:
                     error(parse_dbus_error(e))
                 else:
-                    raise parse_dbus_error(e)
+                    logging.error(f"Unhandled error for {self.get_interface_name()}.{method}", exc_info=True)
 
         self.call(method, param, Gio.DBusCallFlags.NONE, GLib.MAXINT, None,
                   callback, reply_handler, error_handler)

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import os
 import logging
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Callable
 
 from blueman.Functions import adapter_path_to_name
 from blueman.gui.GenericList import GenericList, ListDataDict
@@ -10,7 +10,7 @@ from _blueman import conn_info, ConnInfoReadError
 from blueman.bluez.Manager import Manager
 from blueman.bluez.Device import Device, AnyDevice
 from blueman.bluez.Adapter import Adapter, AnyAdapter
-from blueman.bluez.errors import DBusNoSuchAdapterError
+from blueman.bluez.errors import DBusNoSuchAdapterError, BluezDBusException
 
 from gi.repository import GObject
 from gi.repository import GLib
@@ -312,11 +312,12 @@ class DeviceList(GenericList):
         if autoselect:
             self.selection.select_path(0)
 
-    def discover_devices(self, time: float = 10.24) -> None:
+    def discover_devices(self, time: float = 10.24,
+                         error_handler: Optional[Callable[[BluezDBusException], None]] = None) -> None:
         if not self.discovering:
             self.__discovery_time = 0
             if self.Adapter is not None:
-                self.Adapter.start_discovery()
+                self.Adapter.start_discovery(error_handler=error_handler)
                 self.discovering = True
                 t = 1.0 / 15 * 1000
                 GLib.timeout_add(int(t), self.update_progress, t / 1000, time)

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -194,11 +194,12 @@ class Blueman(Gtk.Application):
 
         prog = ManagerProgressbar(self, text=_("Searching"))
         prog.connect("cancelled", lambda x: self.List.stop_discovery())
-        try:
-            self.List.discover_devices()
-        except Exception as e:
+
+        def on_error(e: Exception) -> None:
             prog.finalize()
             MessageArea.show_message(*e_(e))
+
+        self.List.discover_devices(error_handler=on_error)
 
         s1 = self.List.connect("discovery-progress", on_progress)
         s2 = self.List.connect("adapter-property-changed", prop_changed)


### PR DESCRIPTION
The _call method is basically used in two ways:

* Make an asynchronous call, providing a reply and an error handler for when it's done
* Make a call whose result we do not care about, providing no handlers.

In the latter case, we also do an asynchronous call which makes sense as the caller does not have to wait for it (might be an issue, though, as he might expect the call to already have an effect when the method returns). However, raising an exception when we get an error for that call does not make any sense at it will just get raised into the main loop (and get picked up by tools like Apport or ABRT), so best we can do here is just log the error and the call we got it for.
More involved solutions would be to either make the error_handler argument mandatory so that the caller has to think about errors showing up asynchronously or make a synchronous call if no error_handler is provided so that we're actually able to raise exceptions.