### PR TITLE
Restore blueman.pot

### DIFF
--- a/.github/workflows/weblate.yml
+++ b/.github/workflows/weblate.yml
@@ -11,17 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get install autopoint python-gi-dev cython libglib2.0-dev libbluetooth-dev gettext
-      - run: ./autogen.sh
-      - env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: "curl -L -H \"Authorization: Bearer $TOKEN\" -o blueman.pot.zip \"$(curl \"$(curl 'https://api.github.com/repos/blueman-project/blueman/actions/workflows/weblate.yml/runs?status=success&event=push&branch=master' | jq -r .workflow_runs[0].artifacts_url)\" | jq -r .artifacts[0].archive_download_url)\""
-      - run: unzip -d po blueman.pot.zip
-      - run: make -C po blueman.pot-update
-      - uses: actions/upload-artifact@v2
-        with:
-          name: blueman.pot
-          path: po/blueman.pot
       - env:
           TOKEN: ${{ secrets.WEBLATE_KEY }}
         run: "curl -F file=@po/blueman.pot -F method=source -H \"Authorization: Token $TOKEN\" https://hosted.weblate.org/api/translations/blueman/blueman/en/file/"

--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Afrikaans (http://www.transifex.com/mate/MATE/language/af/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr ""
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr ""
 
@@ -65,8 +65,8 @@ msgstr ""
 msgid "_View"
 msgstr "_Bekyk"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Hulp"
 
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Search"
 msgstr "Soek"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -88,17 +88,17 @@ msgstr ""
 msgid "Pair"
 msgstr ""
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr ""
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "Setup..."
 msgstr ""
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr ""
 
@@ -282,7 +282,12 @@ msgstr ""
 msgid "<b>Author:</b>"
 msgstr ""
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -344,7 +349,7 @@ msgstr ""
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -352,30 +357,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr ""
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr ""
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -386,142 +391,134 @@ msgstr ""
 msgid "Searching"
 msgstr ""
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr ""
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr ""
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr ""
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr ""
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr ""
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -552,242 +549,242 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nee"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Soek"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting..."
 msgid "Connecting…"
 msgstr "Besig om te koppel..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Ontkoppel tans..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 msgid "Send a _File…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Verwyder"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr ""
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  maiatoday https://launchpad.net/~maiatoday"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -795,17 +792,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Inproppe"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -813,7 +810,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -821,844 +818,1218 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Ontkoppel tans..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:10
+msgid "Phone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:12
+msgid "Access point"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+msgid "Desktop"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:33
+msgid "Server"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:35
+msgid "Laptop"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+msgid "Smart phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
+msgid "17-33 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
+msgid "50-67 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
+msgid "67-83 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "onbekend"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:88
+msgid "Microphone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+msgid "Video camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+msgid "Video monitor"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+msgid "Video conferencing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+msgid "Keyboard"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
+msgid "Pointing"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Koppel"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 msgid "OBEX File Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr ""
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr ""
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr ""
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr ""
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr ""
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr ""
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr ""
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr ""
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr ""
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr ""
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr ""
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Device"
 msgid "Device Name"
 msgstr "Toestel"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr ""
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ja"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nee"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1683,34 +2054,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Gekoppel"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1773,141 +2145,136 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1921,27 +2288,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
@@ -1953,107 +2320,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2064,78 +2437,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Netwerk"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2143,8 +2515,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2160,21 +2532,12 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
-msgstr ""
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
 msgstr ""
 
 #: data/blueman-manager.desktop.in:3
@@ -2217,10 +2580,8 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "unknown"
+#~ msgstr "onbekend"
+
 #~ msgid "_Remove..."
 #~ msgstr "_Verwyder..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Koppel"

--- a/po/am.po
+++ b/po/am.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Amharic (http://www.transifex.com/mate/MATE/language/am/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>መመልከቻ ማሰናጃ</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "የ ተደበቀ"
 
@@ -65,8 +65,8 @@ msgstr "_አካል"
 msgid "_View"
 msgstr "_መመልከቻ"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_እርዳታ"
 
@@ -79,7 +79,7 @@ msgstr "በቅርብ ያሉ አካሎች መፈለጊያ"
 msgid "Search"
 msgstr "መፈለጊያ"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "ከ አካሉ ጋር ማጣመሪያ መፍጠሪያ"
 
@@ -88,17 +88,17 @@ msgstr "ከ አካሉ ጋር ማጣመሪያ መፍጠሪያ"
 msgid "Pair"
 msgstr "ማጣመሪያ"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "ይህ አካል ይታመን እንደሆን ምልክት ማድረጊያ/ምልክቱን ማጥፊያ"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "የሚታመን"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "ለዚህ አካል የ ማሰጃ ረዳት ያስኪዱ"
 
@@ -107,7 +107,7 @@ msgstr "ለዚህ አካል የ ማሰጃ ረዳት ያስኪዱ"
 msgid "Setup..."
 msgstr "ማሰናጃ..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "ይህን አካል ከሚታወቁ አካሎች ዝርዝር ውስጥ ማስወገጃ"
 
@@ -286,7 +286,12 @@ msgstr "ያልተወሰነ"
 msgid "<b>Author:</b>"
 msgstr "<b>ደራሲው:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -348,7 +353,7 @@ msgstr "_እንደ ነበር መመለሻ"
 msgid "Send note"
 msgstr "ማስታወሻ መላኪያ"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "ብሉቱዝ ማብራት ያስፈልጋል የ ተሰኪ አስተዳዳሪ እንዲሰራ"
 
@@ -356,32 +361,30 @@ msgstr "ብሉቱዝ ማብራት ያስፈልጋል የ ተሰኪ አስተዳ�
 msgid "Bluetooth Adapters"
 msgstr "የ ብሉቱዝ አዳፕተሮች"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "ሁልጊዜ "
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d ደቂቃ"
 msgstr[1] "%d ደቂቆች "
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "አዳፕተር"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "ብሉቱዝ ማብራት ያስፈልጋል የ አካል አስተዳዳሪ እንዲሰራ"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "ግንኙነት ወደ BlueZ አልተሳካም"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -394,142 +397,134 @@ msgstr ""
 msgid "Searching"
 msgstr "በመፈለግ ላይ"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "የ ብሉቱዝ እረዳት"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "የ ተሰኪ ምርጫዎች"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "ፋይል መላኪያ"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "የ ብሉቱዝ ፋይል ማስተላለፊያ"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "በመገናኘት ላይ"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd ዝግጁ አይደለም"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "በመሰረዝ ላይ"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "ፋይል በመላክ ላይ "
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "ፋይል በሚላክ ጊዜ ስህተት ተፈጥሯል %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "መዝለያ"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "እንደገና መሞከሪያ"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "ስህተት ተፈጥሯል"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "የአካባቢ ግልጋሎቶች "
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "የማጣመር ጥያቄ ለ %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "የ ብሉቱዝ ማረጋገጫ"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "የ ፒን ኮድ ያስገቡ ለ ማረጋገጫ:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "የ ፒን ኮድ ያስገቡ"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "የማለፊያ ቁልፍ ያስገቡ ለ ማረጋገጫ:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "የማለፊያ ቁልፍ ያስገቡ"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "የማጣመሪያ ማለፊያ ቁልፍ ለ"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "በማጣመር ላይ የ ፒን ኮድ ለ"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "በማጣመር ላይ የተጠየቀውን ለ:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "ለ ማረጋገጫ ዋጋዎችን ያረጋግጡ"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "ማረጋገጫ"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "መከልከያ"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "ማረጋገጫ ተጠይቋል ለ:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "ግልጋሎት:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "ሁል ጊዜ ተቀበል"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "ተቀብያለሁ"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -563,247 +558,245 @@ msgstr "አዎ "
 msgid "No"
 msgstr "አይ "
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "ችግሩን _ያሳውቁን"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "የ አካሎች አስተዳዳሪ"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "_እቃ መደርደሪያ ማሳያ"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "የ _ሁኔታ መደርደሪያ ማሳያ"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "መ_ለያ በ"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_ስም"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_ተጨምሯል"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_እየቀነሰ በሚሄድ"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_ተሰኪዎች"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "የ _አካባቢ ግልጋሎቶች "
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "የ ግልጋሎት ምርጫዎች "
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_መፈለጊያ"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "የ ተሰኪ ምርጫዎች"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "ያልተመደበ"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>የሚታመን እና ማጣመሪያ</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>ማጣመሪያ</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>የሚታመን</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "ደካማ"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "ንዑስ-አጥጋቢ"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "አጥጋቢ"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "ብዙ"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "በጣም ብዙ"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "ዝቅተኛ"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "ከፍተኛ"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "በጣም ከፍተኛ"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "ተሳክቷል!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Serial port ተገናኝቷል ከ %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "አልተሳካም"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "ግንኙነቱ ወድቋል: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "በመገናኘት ላይ"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "መለያየት አልተቻለም"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "በ መለያየት ላይ..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "በራሱ መገናኛ ገጽታዎች ይገናኛል A2DP ምንጭ: A2DP sink, እና HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "አካሉን በ ሀይል ይለያዩ"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>መገናኛ ወደ:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>መለያያ:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "_ፋይል መላኪያ..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_ማጣመሪያ"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_የሚታመን"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_የማይታመን"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "አካሉን እንደገና መሰየሚያ"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "ማስወገጃ \"%s\""
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "ተግባሩን መሰረዣ"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "የ ዳታ እንቅስቃሴ ማሳያ"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "ጠቅላላ የ ተቀበሉት ዳታ እና የ ማስተላለፊያ መጠን"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "ጠቅላላ የ ተላከው ዳታ እና የ ማስተላለፊያ መጠን"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "የማይታመን"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "አካል ይምረጡ"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "ተጨማሪ"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "ምስጋና ለተርጓሚዎች:\n"
 "  samson https://launchpad.net/~sambelet"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman is a GTK+ የ ብሉቱዝ አስተዳዳሪ"
 
@@ -811,17 +804,17 @@ msgstr "Blueman is a GTK+ የ ብሉቱዝ አስተዳዳሪ"
 msgid "GSM Settings"
 msgstr "GSM ማሰናጃ"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "ተሰኪዎች"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "የ ጥገኝነት ችግር"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -832,7 +825,7 @@ msgstr ""
 "ያወርዳል <b>\"%(0)s\"</b>.\n"
 "ልቀጥል?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -843,886 +836,1259 @@ msgstr ""
 "b>.\n"
 "ልቀጥል?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "የ አዳፕተር ምርጫ"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "ሊገኝ የሚችል… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "ያልተመደበ"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "ኔትዎርክ መድረሻ ነጥብ"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "ዴስክቶፕ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "ሰርቨር"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "ላፕቶፕ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "በ እጅ የሚያዝ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "ፓልም"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "ሴሉላር"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "ሽቦ አልባ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "ስማርት ስልክ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "ሞደም "
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd ዝግጁ አይደለም"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "በ ጆሮ ማድመጫ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "ከ እጅ ነፃ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "ያልታወቀ"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "ማይክሮፎን"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "የድምፅ ምንጭ "
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "የድምፅ ምንጭ "
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "የድምፅ ምንጭ "
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "የ ፊደል ገበታ"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "መጠቆሚያ"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "የ ፊደል ገበታ"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "መጠቆሚያ"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "መገናኛ"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "መገናኛ"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "መገናኛ"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "መገናኛ"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "የ ብሉቱዝ ፋይል ማስተላለፊያ"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "መገናኛ"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "የ ብሉቱዝ ፋይል ማስተላለፊያ"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "የ ብሉቱዝ ፋይል ማስተላለፊያ"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "የቡድን ኔትዎርክ"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "የ ብሉቱዝ ፋይል ማስተላለፊያ"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "መገናኛ"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "መገናኛ"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "የ ብሉቱዝ ፋይል ማስተላለፊያ"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "መገናኛ"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "የቡድን ኔትዎርክ"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Serial Ports"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Dialup Networking (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "የ ብሉቱዝ ፋይል ማስተላለፊያ"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "በ ጆሮ ማድመጫ"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "የድምፅ ምንጭ "
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "የ ድምፅ መጨረሻ"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "ኔትዎርክ መድረሻ ነጥብ"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "የቡድን ኔትዎርክ"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "ከ እጅ ነፃ"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "ኔትዎርክ መድረሻ ነጥብ (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "ኔትዎርክ መድረሻ ነጥብ (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "የቡድን ኔትዎርክ"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "የ ብሉቱዝ ፋይል ማስተላለፊያ"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "የድምፅ ምንጭ "
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "የ ድምፅ መጨረሻ"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "የድምፅ ምንጭ "
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "አካሉን እንደገና መሰየሚያ"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "የ አካል መረጃ ማሳያ"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "የአካባቢ ግልጋሎቶች "
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "ማስተላለፊያ"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "አፕሌት"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "አካል ማጣመሪያ"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "በቅርብ ያሉ አካሎች መፈለጊያ"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "ማስተላለፊያ"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "አፕሌት"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "አካል ማጣመሪያ"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "በቅርብ ያሉ አካሎች መፈለጊያ"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "የ አካሎች አስተዳዳሪ"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "የቅርብ ጊዜ _ግንኙነቶች"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "የ አካሎች አስተዳዳሪ"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "የ ተሰኪ ምርጫዎች"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "በራሱ መገናኛ ገጽታ"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "ባለቤቱ"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "አዎ"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "አይ"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_መረጃ"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "የ አካል መረጃ ማሳያ"
 
@@ -1747,34 +2113,35 @@ msgstr "የ ድምፅ ገጽታ"
 msgid "Select audio profile for PulseAudio"
 msgstr "የ ድምፅ ገጽታ ይምረጡ ለ PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Serial Port %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "የ IP አድራሻ እንደገና ማደሻ"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "መደወያ ማሰናጃ"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Serial Ports"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "ያልተወሰነ"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "ተገናኝቷል"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1839,148 +2206,139 @@ msgstr "የ ኔትዎርክ _አጠቃቀም"
 msgid "Shows network traffic usage"
 msgstr "የ ኔትዎርክ ትራፊክ አጠቃቀም ማሳያ "
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "ብሉቱዝ ተችሏል"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "ብሉቱዝ ተሰናክሏል"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "የ አካባቢ ኔትዎርክ ግልጋሎት አስተዳዳሪ እንደ NAP bridges"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 "ድጋፍ ይሰጣል ለ Dial Up Networking (DUN) with ModemManager እና NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "ዝርዝር እቃዎችን ያቀርባል መጨረሻ የ ተጠቀሙበትን ግኑኘነቶች ጋር  በፍጥነት ለ መድረስ"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "ከፍተኛው እቃዎች"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "ከፍተኛው ቁጥር ለ እቃዎች የ ቅርብ ጊዜ ግንኙነት ዝርዝር የሚታየው"
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "የቅርብ ጊዜ _ግንኙነቶች"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "ተገናኝቷል ወደ %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "መገናኘት አልተቻለም"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s on %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "ተሰኪ ለዚህ ግንኙነት አልተገኘም"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 "እርዳታ ያቀርባል ለ Personal Area Networking (PAN) introduced in NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "የ DBus API ያቀርባል ለ ሌላ Blueman አካላቶች"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "በ ብሉቱዝ የሚመጣ ፋይል "
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "የሚመጣ ፋይል  %(0)s ከ %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "አልቀበለም"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "ፋይል በመቀበል ላይ "
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "ፋይል በመቀበል ላይ %(0)s ከ %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "ለ OBEX የ ፋይል ማስተላለፊያ ችሎታ ያቀርባል"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "ዳይሬክቶሪ ማሰናጃ ለሚመጡ ፋይሎች ላልነበሩ"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "ፋይል ተቀብለዋል"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "ፋይል %(0)s ከ %(1)s ተሳክቶ ተቀብለዋል"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "ማስተላለፍ አልተቻለም"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "ፋይል ማስተላለፍ %(0)s አልተቻለም"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "የተቀበሉዋቸው ፋይሎች"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "ተቀብለዋል %d ፋይሎች ከ በስተ ጀርባ"
 msgstr[1] "ተቀብለዋል %d ፋይሎች ከ በስተ ጀርባ "
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "ተቀብለዋል %d ተጨማሪ ፋይሎች ከ በስተ ጀርባ"
@@ -1993,27 +2351,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr " መደበኛ ዝርዝር እቃዎች መጨመሪያ ለ ሁኔታዎች ምልክት ዝርዝር"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "አዲስ አካል _ማሰናጃ"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "_ፋይሎች ወደ አካሉ መላኪያ"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_አካሎች"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "አዳፕ_ተሮች"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "አፕሌት"
 
@@ -2025,27 +2383,27 @@ msgstr "የ ማለፊያ ቃል ያቀርባል: የ ማረጋገጫ ግልጋ�
 msgid "Adds an exit menu item to quit the applet"
 msgstr "የ መውጫ ዝርዝር ለ እቃ መጨመሪያ ከ አፕሌቱ ለ መውጣት"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "መደበኛ የ dhcp ደንበኛ ያቀርባል ለ ብሉቱዝ PAN ግንኙነት."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "የ ብሉቱዝ ኔትዎርክ"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "ገጽታ %(0)s መዝለያ ወደ IP address %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "የ IP አድራሻ ማግኘት አልተቻለም %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2054,62 +2412,66 @@ msgstr ""
 "ለ ማግኘት በ መሞከር ላይ የ %s\n"
 "እባክዎን ይጠብቁ…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr "መጠቆሚያ መጨመሪያ በ ሁኔታዎች ምልክት ላይ: ብሉቱዝ ንቁ ሲሆን እና የ ተገናኘውን የ እቃ ጫፍ ቁጥር ማሳያ"
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "ብሉቱዝ ንቁ ነው"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d ንቁ ግንኙነቶች</b> "
 msgstr[1] "<b>%d ንቁ ግንኙነቶች</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "ብሉቱዝ ተሰናክሏል"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "ይጠቀማል የ libappindicator ለማሳየት የ statusicon"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr "ዝርዝር እቃ ያቀርባል ለ ነባር ተሰኪ ለጊዜው የሚታይ በ ነባር ወደ መደበቂያ ሲሰናዳ"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "ጊዜው አልፏል ሊገኝ የሚችል"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "የ ጊዜ መጠን በ ሰከንዶች ሊገኝ የሚችል የሚቆይበት ጊዜ"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "ሊገኝ የሚችል _መፍጠሪያ"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "ነባር አዳፕተር ለ ጊዜው እንዲታይ ማድረጊያ"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "ሊገኝ የሚችል… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "ዝርዝር ያቀርባል ለአፕሌት እና API ለ ሌላ ተሰኪዎች manipulate it"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2118,20 +2480,20 @@ msgstr ""
 "ተሳክቶ ተገናኝቷል ወደ <b>DUN</b> ግልጋሎት በ <b>%(0)s.</b>\n"
 "ኔትዎርክ አሁን በ ሙሉ ዝግጁ ነው <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "መሰረታዊ የ ግንኙነት ድጋፍ ይሰጣል ለ ኢንተርኔት ለ DUN profile."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr "መደበኛ የ SPP ገጽታ ግንኙነት ያዢ: የ ተግባር ማስተካከያ መፈጸም ያስችላል"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "በ ግንኙነት ጊዜ የሚፈጸመው ጽሁፍ"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2149,21 +2511,21 @@ msgstr ""
 "\n"
 "አካሉ በሚለያይ ጊዜ ጽሁፍ ይላካል የ HUP ምልክት</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Serial port ተገናኝቷል"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr "Serial port ግልጋሎት በ አካሉ ላይ <b>%s</b> አሁን ዝግጁ ይሆናል በ  <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "የ Serial port ግንኙነት ጽሁፍ ወደቋል"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2172,57 +2534,56 @@ msgstr ""
 "ችግር ተፈጥሯል ጽሁፍ በማስጀመር ላይ እንዳለ %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "የ ብሉቱዝ ተሰኪ ሀይል ሁኔታ መቆጣጠሪያ"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "በራሱ ሀይል ማብሪያ"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "ራሱ በራሱ ሀይል ማብሪያ አዳፕተርስ"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>ብሉቱዝ _ማጥፊያ</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "ሁሉንም አዳፕተሮች ማጥፊያ"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>ብሉቱዝ _ማብሪያ</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "ሁሉንም አዳፕተሮች ማብሪያ"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr "ለጊዜው የ መመልከቻውን ማዳኛ ያግዳል የ ብሉቱዝ መጫወቻ በሚገናኝ ጊዜ"
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "ኔትዎርክ:"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "ዋጋ የሌለው አድራሻ:"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP address ከ ገጽታው ጋር ይጋጫል %s ተመሳሳይ አድራሻ ነው ያላቸው"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2230,8 +2591,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "አሁን በዚህ ማሰናጃ የ ተደገፈ አይደለም"
 
@@ -2245,40 +2606,26 @@ msgstr "የ ማስተላለፊያ ግልጋሎት ተሰኪ አፕሌት ተሰ�
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "የ ብሉቱዝ አዳፕተሮች"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "አፕሌት"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman is a GTK+ የ ብሉቱዝ አስተዳዳሪ"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "ብሉቱዝ ተችሏል"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "የ ብሉቱዝ አካሎች"
 
@@ -2314,6 +2661,31 @@ msgstr "የ RfKill ሁኔታ ማሰናጃ ቅድሚያ ማስነሻ ይፈልጋ
 msgid "Setting RfKill State requires privileges"
 msgstr "የ RfKill ሁኔታ ማሰናጃ ቅድሚያ ማስነሻ ይፈልጋል "
 
+#~ msgid "Enter PIN code"
+#~ msgstr "የ ፒን ኮድ ያስገቡ"
+
+#~ msgid "Enter passkey"
+#~ msgstr "የማለፊያ ቁልፍ ያስገቡ"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Serial port ተገናኝቷል ከ %s"
+
+#~ msgid "palm"
+#~ msgstr "ፓልም"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "በ ጆሮ ማድመጫ"
+
+#~ msgid "handsfree"
+#~ msgstr "ከ እጅ ነፃ"
+
+#~ msgid "unknown"
+#~ msgstr "ያልታወቀ"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "የ ብሉቱዝ አካሎች"
 
@@ -2334,11 +2706,6 @@ msgstr "የ RfKill ሁኔታ ማሰናጃ ቅድሚያ ማስነሻ ይፈልጋ
 
 #~ msgid "_Remove..."
 #~ msgstr "_ማስወገጃ... "
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "መገናኛ"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/ar.po
+++ b/po/ar.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-29 15:23+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -32,7 +32,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>إعدادات الرؤية</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "مَخفي"
 
@@ -76,8 +76,8 @@ msgstr "_الجهاز"
 msgid "_View"
 msgstr "_عرض"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_مساعدة"
 
@@ -90,7 +90,7 @@ msgstr "ابحث عن أجهزة قريبة"
 msgid "Search"
 msgstr "ابحث"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "إنشاء إقتران مع الجهاز"
 
@@ -99,17 +99,17 @@ msgstr "إنشاء إقتران مع الجهاز"
 msgid "Pair"
 msgstr "إقتران"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "علّم\\ألغ تعليم الجهاز بأنه موثوق"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "استوثق"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "شغّل مساعد الضبط لهذا الجهاز"
 
@@ -118,7 +118,7 @@ msgstr "شغّل مساعد الضبط لهذا الجهاز"
 msgid "Setup..."
 msgstr "ضبط..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "أزل هذا الجهاز من قائمة الأجهزة المعروفة"
 
@@ -297,7 +297,12 @@ msgstr "غير محدّد"
 msgid "<b>Author:</b>"
 msgstr "<b>الكاتب:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -359,7 +364,7 @@ msgstr "_تصفير"
 msgid "Send note"
 msgstr "ارسل الملاحظة"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "يجب تشغيل البلوتوث ليعمل مدير المحوّلات"
 
@@ -367,14 +372,12 @@ msgstr "يجب تشغيل البلوتوث ليعمل مدير المحوّلا�
 msgid "Bluetooth Adapters"
 msgstr "محولات بلوتوث"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "دائما"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d دقيقة"
@@ -384,19 +387,19 @@ msgstr[3] "%d دقائق"
 msgstr[4] "%d دقيقة"
 msgstr[5] "%d دقيقة"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "يجب تشغيل البلوتوث ليشتغل مدير الأجهزة"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -407,48 +410,48 @@ msgstr ""
 msgid "Searching"
 msgstr "بحث"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "مساعد البلوتوث"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "مرسل الملفات"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "نقل الملفات بواسطة Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "إتصال"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd غير متوفر"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "إلغاء"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "إرسال ملف"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "الوقت المتوقع للإتمام:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -459,94 +462,86 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "حدث خطأ أثناء إرسال الملف %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "تخطي"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "أعد المحاولة"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "حدث خطأ"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "خدمات محلية"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "طلب الإقتران بـ %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "مصادقة البلوتوث"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "أدخل رمز PIN للمصادقة"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "أدخل رمز PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "أدخل مفتاح المرور للمصادقة"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "أدخل مفتاح المرور"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "مفتاح مرور الإقتران بـ"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "رمز PIN الإقتران بـ"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "طلب الإقتران بـ:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "أكّد القيمة للمصادقة:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "تأكيد"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "رفض"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "طلب المصادقة  لـ:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "الخدمة:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "القبول دائما"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "قبول"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -577,247 +572,245 @@ msgstr "نعم"
 msgid "No"
 msgstr "لا"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_بلّغ عن مشكلة"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "مدير الأجهزة"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "عرض شريط _الأدوات"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "عرض شريط _الحالة"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_إضافات"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_خدمات محلية"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "تفضيلات الخدمة"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_بحث"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Service Preferences"
 msgid "_Preferences"
 msgstr "تفضيلات الخدمة"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "غير مصنّف"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>موثوق</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "فقير"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "الأمثل"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "كثير"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "كثير جدا"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "منخفض"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "عال"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "عال جدا"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "نجاح"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "المنفذ التسلسلي متصل بـ %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "فشل"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "فشل الإتصال"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "إتصال"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "_قطع الإتصال..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "قطع اتصال الجهاز بالقوة"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>إتصال بـ:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>قطع الإتصال:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "إرسال _ملف..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_إقتران"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_وثوق"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_غير-موثوق"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "غيّر اسم الجهاز"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "أزل"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "إلغاء العملية"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "اجمالي البيانات المُستقبلة ومعدل التراسل"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "غير موثوق"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "حدّد جهازا"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "أكثر"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "فريق عيون العرب للترجمة http://www.arabeyes.org :\n"
 "مصعب الزعبي\t<moceap@hotmail.com>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -825,17 +818,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr "إعدادات GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "إضافات"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "نقص إعتمادية"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -846,7 +839,7 @@ msgstr ""
 "أيضا إلى إيقاف <b>\"%(0)s\"</b>.\n"
 "هل تكمل؟"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -857,878 +850,1253 @@ msgstr ""
 "إيقاف <b>\"%(0)s\"</b>.\n"
 "هل تكمل؟"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "تحديد المحوّل"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "_قطع الإتصال..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "غير مصنّف"
-
-#. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
-msgstr "حاسوب مكتبي"
-
-#. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
-msgstr "خادم"
-
-#. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
-msgstr "حاسوب محمول"
-
-#. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "نقطة إتصال شبكية"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
+msgstr "حاسوب مكتبي"
+
+#. translators: device class
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
+msgstr "خادم"
+
+#. translators: device class
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
+msgstr "حاسوب محمول"
+
+#. translators: device class
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
+msgstr "هاتف خليوي"
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
+msgstr "هاتف ذكي"
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
+msgstr "مودم"
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
-msgstr "هاتف خليوي"
+msgid "17-33 percent"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
-msgstr "هاتف ذكي"
+msgid "50-67 percent"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
-msgstr "مودم"
+msgid "67-83 percent"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd غير متوفر"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "سماعة الرأس"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "مجهول"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "ميكروفون"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "مصدر الصوت"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "مصدر الصوت"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "مصدر الصوت"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "لوحة مفاتيح"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "إتصال"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "لوحة مفاتيح"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "اتصل"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "اتصل"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "اتصل"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "اتصل"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "نقل الملفات بواسطة Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "اتصل"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "نقل الملفات بواسطة Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "نقل الملفات بواسطة Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "شبكة المجموعة"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "نقل الملفات بواسطة Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "اتصل"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "اتصل"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "نقل الملفات بواسطة Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "اتصل"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "شبكة المجموعة"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "نقل الملفات بواسطة Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "سماعة الرأس"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "مصدر الصوت"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "نقطة إتصال شبكية"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "شبكة المجموعة"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "نقطة إتصال شبكية (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "نقطة إتصال شبكية (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "شبكة المجموعة"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "نقل الملفات بواسطة Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "مصدر الصوت"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "مصدر الصوت"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "غيّر اسم الجهاز"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "خدمات محلية"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "النقل"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "بريمج"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "إقتران مع  الجهاز"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "ابحث عن أجهزة قريبة"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "النقل"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "بريمج"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "إقتران مع  الجهاز"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "ابحث عن أجهزة قريبة"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "مدير الأجهزة"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "الإتصالات الحديثة"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "مدير الأجهزة"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Service Preferences"
 msgid "Report Reference"
 msgstr "تفضيلات الخدمة"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "نعم"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "لا"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1753,34 +2121,35 @@ msgstr "نمط الصوت"
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "تجديد عنوان IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "غير محدّد"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "متصّل"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1858,137 +2227,130 @@ msgstr "_استخدام الشبكة"
 msgid "Shows network traffic usage"
 msgstr "يعرض استعمال الشبكة"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "فُعّل البلوتوث"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "عُطّل البلوتوث"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "تدير خدمات الشبكة المحلية، مثل جسور NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "توّفر عنصر قائمة يحتوي على آخر الاتصالات المستخدمة للوصول السريع"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "أقصى عدد للعناصر"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "العدد الأقصى للعناصر المعروضة في الإتصالات الحديثة"
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "الإتصالات الحديثة"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "متصّل بـ %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "فشل الإتصال"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s في %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "المحوّل لهذا الاتصال غير متوفّر"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "استقبال ملفات عبر بلوتوث"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "الملف %(0)s قادم من %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "رفض"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "استقبال ملف"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "استقبال الملف %(0)s من %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "أُستقبِل الملف"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "الملف %(0)s من %(1)s أُستقبِل بنجاح"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "فشل النقل"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "فشل نقل الملف %(0)s"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "أُستقبِلت الملفات"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "استقبال %d ملف في الخلفية"
@@ -1998,10 +2360,8 @@ msgstr[3] "استقبال %d ملفات في الخلفية"
 msgstr[4] "استقبال %d ملفا في الخلفية"
 msgstr[5] "استقبال %d ملف في الخلفية"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "استقبال %d ملف في الخلفية"
@@ -2018,27 +2378,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "تضيف قائمة عناصر قياسية لقائمة أيقونات الحالة"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "إرسال _ملفات إلى جهاز"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_الأجهزة"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "_المحوّلات"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "بريمج"
 
@@ -2050,44 +2410,44 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr "تضيف عنصر الخروج للقائمة لإنهاء البريمج"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "شبكة بلوتوث"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "البلوتوث نَشِط"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
@@ -2098,64 +2458,70 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "عُطّل البلوتوث"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 "توفّر عنصر قائمة يجعل المحوّل الافتراضي يظهر مؤقتا عندما يكون مٌخفىً افتراضيا"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "الاوامر النصية المراد تنفيذها عند الاتصال"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2166,78 +2532,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_إيقاف بلوتوث</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "إيقاف كل المحوّلات"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_تشغيل بلوتوث</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "تشغيل كل المحوّلات"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "الشبكة"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "عنوان IP غير صالح"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2245,8 +2610,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2260,40 +2625,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "محولات بلوتوث"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "بريمج"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "فُعّل البلوتوث"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "فُعّل البلوتوث"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "أجهزة البلوتوث"
 
@@ -2329,6 +2680,22 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "أدخل رمز PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "أدخل مفتاح المرور"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "المنفذ التسلسلي متصل بـ %s"
+
+#~ msgid "headset"
+#~ msgstr "سماعة الرأس"
+
+#~ msgid "unknown"
+#~ msgstr "مجهول"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "أجهزة البلوتوث"
 
@@ -2357,11 +2724,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_إزالة..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "اتصل"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "يجب تشغيل البلوتوث لإرسال الملفات"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Asturian (http://www.transifex.com/mate/MATE/language/ast/)\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Axustes de visibilidá</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Anubríu"
 
@@ -67,8 +67,8 @@ msgstr "_Preséu"
 msgid "_View"
 msgstr "_Ver"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Ayuda"
 
@@ -81,7 +81,7 @@ msgstr "Guetar preseos cercanos"
 msgid "Search"
 msgstr "Guetar"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Crear empareyamientu col preséu"
 
@@ -90,17 +90,17 @@ msgstr "Crear empareyamientu col preséu"
 msgid "Pair"
 msgstr "Empareyar"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Conseñar/ non conseñar esti preséu como de confianza "
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Enfotu"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Executar l'encontu pa la configuración d'esti preséu"
 
@@ -109,7 +109,7 @@ msgstr "Executar l'encontu pa la configuración d'esti preséu"
 msgid "Setup..."
 msgstr "Configurar..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Desaniciar esti preséu de la llista de preseos conocíos"
 
@@ -290,7 +290,12 @@ msgstr "Non especificáu"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -352,7 +357,7 @@ msgstr "_Reaniciar"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "El bluetooth necesita prendese pa que l'alministrador de preseos furrule"
@@ -361,32 +366,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Adautadores Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Siempres"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minutu"
 msgstr[1] "%d Minutos"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Falló la conexón a BlueZ"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -400,142 +403,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Guetando"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Encontu pal bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Tresferencia de ficheros Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Coneutando"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Encaboxando"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Unviando ficheru"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Asocedió un fallu entrín s'unviaba'l ficheru %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Saltar"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Reintentar"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Asocedió un fallu"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Servicios llocales"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Solicitú d'empareyamientu pa %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autenticación Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Introduz el códigu PIN pa l'autenticación:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Introducir códigu PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Introduz la contraseña pa l'autenticación:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Introducir contraseña"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Petición d'empareyamientu pa:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirma'l valor pa l'autenticación:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Refugar"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Solicitú d'autenticación pa:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Serviciu:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Aceutar siempres"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Aceutar"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -566,241 +561,241 @@ msgstr "Sí"
 msgid "No"
 msgstr "Non"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Informar un problema"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Alministrador de preseos"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Complementos"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Servicios _llocales"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Guetar"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "Ensin estaya"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Probe"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Mala"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optima"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Abonda"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Enforma"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Baxa"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Alta"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Mui alta"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "¡Ésitu!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Puertu serial coneutáu a %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Fallíu"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Conexón fallida:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Coneutando"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Desconeutando..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Forciar desconexón del preséu"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Coneutar a:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Desconeutar:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Unviar un _ficheru..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Empareyar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Confiar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Nun confiar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Desaniciar"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Encaboxar operación"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Datos totales recibíos y tasa de tresmisión"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Datos totales dunviaos y tasa de tresmisión"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Esbillar preséu"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Más"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr "Softastur <www.softastur.org>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -808,17 +803,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr "Axustes GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Complementos"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problema de dependencia"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -829,7 +824,7 @@ msgstr ""
 "%(1)s</b> tamién descargará <b>\"%(0)s\"</b>.\n"
 "¿Siguir?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -840,878 +835,1254 @@ msgstr ""
 "%(1)s</b> tamién descargará <b>\"%(0)s\"</b>.\n"
 "¿Siguir?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Esbilla d'adautador"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Desconeutando..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "Ensin estaya"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Puntu d'accesu de rede"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "escritoriu"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "sirvidor"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "portátil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "de mano"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "móvil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "ensin cable"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "teléfonu intelixente"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "módem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "ISDN"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+msgid "Not available"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "Cascos"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "manos llibres"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "desconocíu"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "micrófonu"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Fonte d'audiu"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Fonte d'audiu"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Fonte d'audiu"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tecláu"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "Apuntador"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tecláu"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "Apuntador"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Coneutar"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Coneutar"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Coneutar"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Coneutar"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Tresferencia de ficheros Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Coneutar"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Tresferencia de ficheros Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Tresferencia de ficheros Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Rede de grupu"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Tresferencia de ficheros Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Coneutar"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Coneutar"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Tresferencia de ficheros Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Coneutar"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Rede de grupu"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Puertos serial"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Rede de marcáu (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Tresferencia de ficheros Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "Cascos"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Fonte d'audiu"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Puntu d'accesu de rede"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Rede de grupu"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "manos llibres"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Puntu d'accesu de rede (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Puntu d'accesu de rede (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Rede de grupu"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Tresferencia de ficheros Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Fonte d'audiu"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Fonte d'audiu"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr ""
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Servicios llocales"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Treferencia"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "applet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Servicios llocales"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Guetar preseos cercanos"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Treferencia"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "applet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Local Services"
-msgid "Primary Service"
-msgstr "Servicios llocales"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Guetar preseos cercanos"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Alministrador de preseos"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "_Conexones recientes"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Alministrador de preseos"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "sí"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "non"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1736,34 +2107,35 @@ msgstr "Perfil d'audiu"
 msgid "Select audio profile for PulseAudio"
 msgstr "Esbillar perfil d'audiu pa PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Puertu serial %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Anovar direición IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Axustes de marcáu"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Puertos serial"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Ensin especificar"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Coneutáu"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1830,28 +2202,23 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr "Amuesa l'usu de tráficu de rede"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth habilitáu"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth deshabilitáu"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Alministra servicios de rede llocal, como pontes NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1859,121 +2226,117 @@ msgstr ""
 "accesu rápidu"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Elementos máximos"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Amosaráse'l númberu máximu d'elementos del menú de conexones recientes."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Conexones recientes"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Coneutáu a %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Fallu al coneutar"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s en %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "L'adautador nun ta disponible pa esta conexón"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 "Apurre sofitu pa rede d'area personal (PAN) introducida en NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Apurre una API DBus pa otros componentes de Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Ficheru entrante sobro Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Ficheru entrante %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Refugar"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Recibiendo ficheru"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Recibiendo ficheru %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Apurre capacidaes de tresferencia de ficheros OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Ficheru recibíu"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Recibióse con ésitu'l ficheru %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Tresferencia fallida"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Tresferencia del ficheru %(0)s fallida"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Ficheros recibíos"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Recibíu %d ficheru de fondu"
 msgstr[1] "Recibíos %d ficheros de fondu"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Recibíu %d ficheru más de fondu"
@@ -1986,27 +2349,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Amiesta un menú d'elementos estándar al menú d'estáu d'iconu"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Unviar _ficheros al preséu"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Preseos"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adau_tadores"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2018,34 +2381,34 @@ msgstr "Apurre contraseñes, servicios d'autenticación pal degorriu BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Amiesta un menú de salida pa colar del applet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Apurre un veceru dhcp básicu pa conexones Bluetooth PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Rede Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Fallu al consiguir una direición IP en %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2053,24 +2416,27 @@ msgstr ""
 "Amiesta una indicación nel iconu d'estáu cuando'l Bluetooth ta activu y "
 "amuesa'l númberu de conexones na caxa funciones."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth activu"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d conexón activa</b>"
 msgstr[1] "<b>%d conexones actives</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth deshabilitáu"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Usa libappindicator p'amosar un iconu d'estáu"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2078,53 +2444,54 @@ msgstr ""
 "Apurre un menú d'elementos pa facer visible temporalmente l'adautador por "
 "defeutu al tar afitáu como anubríu por defeutu"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Facer temporalmente visible l'adautador por defeutu"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "Apurre sofitu básicu pa conexones a internet pel perfil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script pa executar na conexón"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2135,11 +2502,11 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Coneutáu'l puertu serial"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2147,11 +2514,11 @@ msgstr ""
 "Agora tará disponible per <b>%s</b> el serviciu de puertu serial nel preséu "
 "<b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2160,57 +2527,56 @@ msgstr ""
 "Hebo un problema executando'l script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Apagar tolos adautadores"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Encender tolos adautadores"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Rede"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Direición IP inválida"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2218,8 +2584,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Nun ta anguaño sofitáu con esta configuración"
 
@@ -2233,40 +2599,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adautadores Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth habilitáu"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth habilitáu"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Preseos Bluetooth"
 
@@ -2302,6 +2654,31 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Introducir códigu PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Introducir contraseña"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Puertu serial coneutáu a %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "ISDN"
+
+#~ msgid "headset"
+#~ msgstr "Cascos"
+
+#~ msgid "handsfree"
+#~ msgstr "manos llibres"
+
+#~ msgid "unknown"
+#~ msgstr "desconocíu"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Preseos Bluetooth"
 
@@ -2317,11 +2694,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "Desanicia_r..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Coneutar"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "El bluetooth necesita prendese pa que l'unviu de ficheros furrule"

--- a/po/be.po
+++ b/po/be.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Belarusian (http://www.transifex.com/mate/MATE/language/be/)\n"
@@ -25,7 +25,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Налады бачнасці</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Нябачны"
 
@@ -69,8 +69,8 @@ msgstr "_Прылада"
 msgid "_View"
 msgstr "Пра_гляд"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Даведка"
 
@@ -83,7 +83,7 @@ msgstr "Пошук прылад вакол"
 msgid "Search"
 msgstr "Пошук"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Стварыць звязванне з прыладай"
 
@@ -92,17 +92,17 @@ msgstr "Стварыць звязванне з прыладай"
 msgid "Pair"
 msgstr "Звязаць"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Пазначыць/зняць пазнаку прылады як даверанай"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Давер"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Запусціць дапаможнік усталёўвання для гэтай прылады"
 
@@ -111,7 +111,7 @@ msgstr "Запусціць дапаможнік усталёўвання для 
 msgid "Setup..."
 msgstr "Наставіць..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Выдаліць гэтую прыладу са спісу вядомых"
 
@@ -292,7 +292,12 @@ msgstr "Не пазначаны"
 msgid "<b>Author:</b>"
 msgstr "<b>Аўтар</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -354,7 +359,7 @@ msgstr "_Скінуць"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Для працы кіраўніка Bluetooth-адаптар мусіць быць уключаны "
 
@@ -362,14 +367,12 @@ msgstr "Для працы кіраўніка Bluetooth-адаптар мусіц
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth-адаптары"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Заўсёды"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d хвіліна"
@@ -377,19 +380,19 @@ msgstr[1] "%d хвіліны"
 msgstr[2] "%d хвілін"
 msgstr[3] "%d хвілін"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Каб кіраўнік прыладамі працаваў, Bluetooth мае быць уключаным"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Злучыцца з BlueZ не выйшла"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -403,48 +406,48 @@ msgstr ""
 msgid "Searching"
 msgstr "Пошук"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Дапаможнік Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Настáўленні адаптара"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Адпраўнік файлаў"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Перадача файлаў праз Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Злучэнне"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "Няма obexd"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Скасаванне"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Дасыланне файла"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Засталося часу:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -453,94 +456,86 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Узнікла памылка падчас дасылання файла %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Абмінуць"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Паўтарыць"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Адбылася памылка"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Лакальныя службы"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Запыт звязвання з %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Аўтэнтыфікацыя"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Выкарыстоўваць PIN-код для аўтарызацыі"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Увядзіце PIN-код"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Увядзіце пароль аўтарызацыі"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Увядзіце пароль"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Звязвальны пароль для"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Звязвальны PIN-код для"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Запыт звязвання для:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Пацвердзіце пароль аўтарызацыі:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Пацвердзіць"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Забараніць"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Запыт аўтарызацыі для:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Служба:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Заўсёды прымаць"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Пацвердзіць"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -571,241 +566,239 @@ msgstr "Так"
 msgid "No"
 msgstr "Не"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Паведаміць пра хібу"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Кіраўнік прыладаў"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Паказваць _панэль начыння"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Паказваць _радок стану"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Плагіны"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Лакальные _сэрвісы"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Настáўленні сэрвіса"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Пошук"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Настáўленні адаптара"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "некласіфікавана"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Даверанае</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Кепска"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Горшы за аптымальны"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Аптымальны"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Добра"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Вельмі добра"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Нізкі"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Высокі"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Вельмі высокі"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Поспех!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Падлучаны паслядоўны порт на %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Няўдача"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Злучыцца не выйшла: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Злучэнне"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Адлучэнне…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Прымусова адлучыць прыладу"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Злучыцца з:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Адлучыцца:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Даслаць _файл..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Звязаць"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Давяраць"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Не давяраць"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Пераназваць прыладу"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Выдаліць"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Скасаваць аперацыю"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Індыкатар актыўнасці даных"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Агульны аб'ём прынятых даных і хуткасці перадачы"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Агульны аб'ём адпраўленых даных і хуткасці перадачы"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Выдаліць з давераных"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Абярыце прыладу"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Яшчэ"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -814,7 +807,7 @@ msgstr ""
 "Others:\n"
 "Mihas' Varantsou <meequz@gmail.com>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -822,17 +815,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr "Настáўленні GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Плагіны"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Праблема с залежнасцямі"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -843,7 +836,7 @@ msgstr ""
 "таксама адключыць <b>\"%(0)s\"</b>.\n"
 "Працягваць?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -854,884 +847,1258 @@ msgstr ""
 "будзе выгружаны <b>%(0)s</b>.\n"
 "Працягваць?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Выбар адаптара"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Адлучэнне…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "некласіфікавана"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Пункт доступу да сеткі"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "камп'ютар"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "сервер"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "лаптоп"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "прылада"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "мабільны"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "бесправадны"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "смартфон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "мадэм"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "Няма obexd"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "слухаўкі"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "гарнітура"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "невядомы"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "мікрафон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Крыніца гуку"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Крыніца гуку"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Крыніца гуку"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "клавіятура"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "маніпулятар"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "клавіятура"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "маніпулятар"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Далучыцца"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Далучыцца"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Далучыцца"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Далучыцца"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Перадача файлаў праз Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Далучыцца"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Перадача файлаў праз Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Перадача файлаў праз Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Групавая сетка"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Перадача файлаў праз Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Далучыцца"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Далучыцца"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Перадача файлаў праз Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Далучыцца"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Групавая сетка"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Паслядоўныя парты"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Перадача даных па Dial-Up"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Перадача файлаў праз Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "слухаўкі"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Крыніца гуку"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Прыёмнік гуку"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Пункт доступу да сеткі"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Групавая сетка"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "гарнітура"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Пункт доступу да сеткі (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Пункт доступу да сеткі (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Групавая сетка"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Перадача файлаў праз Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Крыніца гуку"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Прыёмнік гуку"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Крыніца гуку"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Пераназваць прыладу"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Лакальныя службы"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Перадача"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "аплет"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Лакальныя службы"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Пошук прылад вакол"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Перадача"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "аплет"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Local Services"
-msgid "Primary Service"
-msgstr "Лакальныя службы"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Пошук прылад вакол"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Кіраўнік прыладаў"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Ранейшыя _злучэнні"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Кіраўнік прыладаў"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Настáўленні адаптара"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "так"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "не"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1756,34 +2123,35 @@ msgstr "Аўдыё-профіль"
 msgid "Select audio profile for PulseAudio"
 msgstr "Выбраць аўдыё-профіль для PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Паслядоўны порт %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Аднавіць IP адрас"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Настáўленні dial-up"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Паслядоўныя парты"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Нявызначана"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Злучэнне ўсталяванае"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1858,64 +2226,59 @@ msgstr "Выкарыстанне _сеткі"
 msgid "Shows network traffic usage"
 msgstr "Паказвае статыстыку выкарыстання сеткавага трафіку"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth уключаны"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth адключаны"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Кіруе лакальнымі службамі сеткі, такімі як NAP-масты"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr "Дае падтрымку Dial Up Networking (DUN) з ModemManager і NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "Прадастаўляе меню хуткага доступу з раней карыстанымі злучэннямі "
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Максімальная колькасць элементаў"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Колькі максімальна элементаў паказваць ў меню \"Ранейшыя _злучэнні\""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Ранейшыя _злучэнні"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Злучана з %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Не выйшла злучыцца"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s на %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Адаптар для гэтага злучэння недаступны"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1923,74 +2286,72 @@ msgstr ""
 "Забяспечвае падтрымку Персанальнай Лакальнай Сеткі (PAN), што з'явілася ў "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Прадастаўляе DBus API для іншых кампанентаў Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Уваходны файл праз Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Уваходны файл %(0)s ад %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Адмовіць"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Атрыманне файла"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Атрыманне файла %(0)s ад %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Забяспечвае перадачу файлаў па пратаколе OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Зададзены каталог для ўваходных файлаў не існуе"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Файл атрыманы"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Паспяхова атрыманы файл %(0)s ад %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Перадаць не выйшла"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Перадаць файл %(0)s не выйшла"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Атрыманы файлы"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Атрыманы %d файл у фоне"
@@ -1998,10 +2359,8 @@ msgstr[1] "Атрыманы %d файлы ў фоне"
 msgstr[2] "Атрымана %d файлаў ў фоне"
 msgstr[3] "Атрымана %d файлаў ў фоне"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Атрыманы яшчэ %d файл у фоне"
@@ -2016,27 +2375,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Дадаць стандартныя пункты меню да меню значка ў трэі"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Адаслаць _файлы на прыладу"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Прылады"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "_Адаптары"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "аплет"
 
@@ -2048,34 +2407,34 @@ msgstr "Прадастаўляе пароль, сэрвісы аўтэнтыфі
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Дадае пункт меню выхаду з праграмы"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Прадастаўляе базавы dhcp-кліент для PAN-злучэнняў Bluetooth."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Сетка Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Інтэрфейсу %(0)s пастаўлены ў адпаведнасць IP-адрас %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Немагчыма атрымаць IP-адрас на %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2083,14 +2442,12 @@ msgstr ""
 "Дадаць індыкацыю ў значок трэя, калі Bluetooth актыўны, і паказваць "
 "колькасць злучэнняў у выплыўнай падказцы."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth актыўны"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d актыўнае злучэнне</b>"
@@ -2098,44 +2455,50 @@ msgstr[1] "<b>%d актыўныя злучэнні</b>"
 msgstr[2] "<b>%d актыўных злучэнняў</b>"
 msgstr[3] "<b>%d актыўных злучэнняў</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth адключаны"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Выкарыстоўвае libappindicator, каб паказваць значок стану"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 "Дадаць пункт меню, які робіць прыладу, якая звычайна схаваная, часова бачнай."
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Час шукання"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Час утрымання ў рэжыме бачнасці ў секундах"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Зрабіць бачным"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Зрабіць стандартны адаптар часова бачным"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "Прадастаўляе меню аплета і API для іншых плагінаў"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2144,23 +2507,23 @@ msgstr ""
 "Паспяхова злучана з мадэмнай службай (<b>DUN</b>) на прыладзе <b>%(0)s.</b>\n"
 "Стала даступна сетка праз <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Прадастаўляе базавую падтрымку падключэння да інтэрнэту праз DUN-профіль."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Стандартны апрацоўшчык злучэння SPP профілю, які дазваляе выконваць "
 "стандартныя дзеянні"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Скрыпт, што выконваецца пасля злучэння"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2178,21 +2541,21 @@ msgstr ""
 "\n"
 "Пасля адключэння прылады сцэнар адправіць сігнал HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Паслядоўны порт падлучаны"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr "Паслядоўны порт на прыладзе <b>%s</b> цяпер даступны праз <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Злучыцца праз паслядоўны порт не выйшла"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2201,58 +2564,57 @@ msgstr ""
 "З'явілася праблема пры выкананні сцэнара %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Кантраляваць стан сілкавання Bluetooth-адаптара"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Аўтаўключэнне"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Аўтаматычна ўключаць адаптары"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Адключыць Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Адключыць усе адаптары"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Уключыць Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Уключыць усе адаптары"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "Часова прыпыняе ахоўнік экрану, калі гульнявы bluetooth-кантролер падлучаны."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Сетка"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Памылковы IP-адрас"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP-адрас канфліктуе з інтэрфейсам %s, які мае такі самы адрас"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2260,8 +2622,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "У дадзены момант не падтрымліваецца"
 
@@ -2275,40 +2637,26 @@ msgstr "Плагін службы перадачы аплета адключан
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth-адаптары"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "аплет"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth уключаны"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth уключаны"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Прылады Bluetooth"
 
@@ -2344,6 +2692,31 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Увядзіце PIN-код"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Увядзіце пароль"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Падлучаны паслядоўны порт на %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "слухаўкі"
+
+#~ msgid "handsfree"
+#~ msgstr "гарнітура"
+
+#~ msgid "unknown"
+#~ msgstr "невядомы"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Прылады Bluetooth"
 
@@ -2368,11 +2741,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Выдаліць..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Далучыцца"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Каб працавала перадача файлаў, трэба ўключыць Bluetooth"

--- a/po/bg.po
+++ b/po/bg.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Bulgarian (http://www.transifex.com/mate/MATE/language/bg/)\n"
@@ -24,7 +24,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Настройка на видимостта</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Скрит"
 
@@ -68,8 +68,8 @@ msgstr "_Устройство"
 msgid "_View"
 msgstr "_Изглед"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Помощ"
 
@@ -82,7 +82,7 @@ msgstr "Търсене на близки устройства"
 msgid "Search"
 msgstr "Търсене"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Сдвояване с устройството"
 
@@ -91,17 +91,17 @@ msgstr "Сдвояване с устройството"
 msgid "Pair"
 msgstr "Сдвояване"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Добавяне/Премахване на сдвоение с устройството"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Доверяване"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Стартиране помощника за настройки към това устройство"
 
@@ -110,7 +110,7 @@ msgstr "Стартиране помощника за настройки към �
 msgid "Setup..."
 msgstr "Настройка…"
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Премахване на устройството от познатите устройства"
 
@@ -292,7 +292,12 @@ msgstr "Не е посочено"
 msgid "<b>Author:</b>"
 msgstr "<b>Автор:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -354,7 +359,7 @@ msgstr "_Възстановяване"
 msgid "Send note"
 msgstr "Изпращане на бележка"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Адаптерът за блутут трябва да бъде включен, за да работи мениджъра"
 
@@ -362,33 +367,31 @@ msgstr "Адаптерът за блутут трябва да бъде вклю
 msgid "Bluetooth Adapters"
 msgstr "Адаптери за блутут"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Винаги"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d минута"
 msgstr[1] "%d минути"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Адаптер"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "За да работи мениджъра на устройства, адаптерът за блутут трябва да е включен"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Свързването към BlueZ се провали"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -402,142 +405,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Търсене"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Помощник за блутут"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Настройки на адаптера"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Изпращач на файлове"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Файлов трансфер чрез блутут"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Свързване"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd не е наличен"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Отмяна"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Изпращане на файл"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Приблизително оставащо време:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "При изпращането на файла %s възникна грешка"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Пропускане"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Повторен опит"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Възникна грешка"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Местни услуги"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Запитване за сдвояване за %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Идентификация на блутут"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Въведете PIN код за идентификация"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Въведете PIN код"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Въведете парола за идентификация"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Въведете ключ за достъп"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Ключ за свъзрване с "
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "PIN код за свързване с"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Запитване за сдвояване за:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Потвърждаване на стойността за идентификация:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Потвърждение"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Отказ"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Искане на пълномощно за:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Услуга:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Винаги да се приема"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Приемане"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -571,242 +566,240 @@ msgstr "Да"
 msgid "No"
 msgstr "Не"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "Докладване на _проблем"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Мениджър на устройства"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Показване на _лентата с инструменти"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Показване на л_ентата за състоянието"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "П_одреждане по"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Име"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "Време на _добавяне"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "В _низходящ ред"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Приставки"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Локални услуги"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Настройки на услугите"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Търсене"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Настройки на адаптера"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "без категория"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Доверено и сдвоено</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Сдвоено</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Доверено</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Слабо"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Под оптималното"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Оптимално"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Добро"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Много добро"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Ниско"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Високо"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Много високо"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Успех!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Сериен порт свързан към %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Неуспех"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Неуспешно свързване "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Свързване"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Неуспешно прекъсване на връзката:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Прекъсване на връзката…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Свързва профилите за автоматично свързване A2DP-източник, A2DP-цел и HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Принудително изключва устройството"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Свързан към:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Прекъсване:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Изпращане на _файл…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Сдвояване"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Доверен"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Недоверен"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Преименуване на устройството"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Премахване"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Прекратяване на операцията"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Индикация за активността на данните"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Общо приети данни и скорост на предаване"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Общо изпратени данни и скорост на предаване"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Недоверено"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Избор на устройство"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Още"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -816,7 +809,7 @@ msgstr ""
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  Vladimir Kolev https://launchpad.net/~vladimir.kolev"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "„Blueman“ е мениджър на устройства с блутут, базиран на GTK+"
 
@@ -824,17 +817,17 @@ msgstr "„Blueman“ е мениджър на устройства с блут�
 msgid "GSM Settings"
 msgstr "GSM Настройки"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Приставки"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Проблем със зависимост"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -845,7 +838,7 @@ msgstr ""
 "b> ще премахне и <b>„%(0)s“</b>.\n"
 "Продължаване?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -856,886 +849,1259 @@ msgstr ""
 "%(1)s</b> ще изключи <b>%(0)s</b>.\n"
 "Продължаване?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Избор на адаптер"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Видимо… %sсек"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "без категория"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Мрежова точка за достъп"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "настолен компютър"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "сървър"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "преносим компютър"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "handheld устройство"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm устройство"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "мобилен телефон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "безжичен"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "смартфон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "модем"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd не е наличен"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "слушалка"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "слушалка „свободни ръце“"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "непознато"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "микрофон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Звуков източник"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Звуков източник"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Звуков източник"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "клавиатура"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "посочващо устройство"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "клавиатура"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "посочващо устройство"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Свързване"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Свързване"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Свързване"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Свързване"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Файлов трансфер чрез блутут"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Свързване"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Файлов трансфер чрез блутут"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Файлов трансфер чрез блутут"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Групова мрежа"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Файлов трансфер чрез блутут"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Свързване"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Свързване"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Файлов трансфер чрез блутут"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Свързване"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Групова мрежа"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Серийни портове"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Dialup Мрежа (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Файлов трансфер чрез блутут"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "слушалка"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Звуков източник"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Звуков поток"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Мрежова точка за достъп"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Групова мрежа"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "слушалка „свободни ръце“"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Групова мрежа"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Файлов трансфер чрез блутут"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Звуков източник"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Звуков поток"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Звуков източник"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Преименуване на устройството"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Показване на информация за устройството"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Местни услуги"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Прехвърляне"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "аплет"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Сдвояване на устройство"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Търсене на близки устройства"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Прехвърляне"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "аплет"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Сдвояване на устройство"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Търсене на близки устройства"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Мениджър на устройства"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Скорошни _Вързки"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Мениджър на устройства"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Настройки на адаптера"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Профили за авт. свързване"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Частно"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "да"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "не"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Информация"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Показване на информация за устройството"
 
@@ -1760,34 +2126,35 @@ msgstr "Звуков профил"
 msgid "Select audio profile for PulseAudio"
 msgstr "Изберете на аудио профил за PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Сериен порт %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Обновяване на IP адреса"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Настройки на Dialup"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Серийни портове"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Неопределено"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Свързан"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1854,29 +2221,24 @@ msgstr "_Използване на мрежата"
 msgid "Shows network traffic usage"
 msgstr "Показва използването на мрежата"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Блутут е включен"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Блутут е изключен"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Контролира локални мрежови услуги, като NAP мостове"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 "Осигурява поддръжка за Dial Up мрежи (DUN) чрез ModemManager и NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1884,37 +2246,37 @@ msgstr ""
 "достъп"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Максимален брой"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Максималния брой скорошни връзки, които менюто ще показва."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Скорошни _Вързки"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Свързан към %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Неуспех при свързване"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s на %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Адаптера за тази връзка не е наличен"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1922,83 +2284,79 @@ msgstr ""
 "Предоставя поддръжка за лична локална мрежа (PAN) представена в "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Осигурява DBus API за други компоненти на Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Получаване на файл през блутут"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Входящ файл %(0)s от %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Отхвърляне"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Приемане на файл"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Приемане на файл %(0)s от %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Предоставя OBEX възможности за трансфер на файлове"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Избраната папка за входящи файлове не съществува"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Файлът е приет"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Файлът %(0)s от %(1)s е приет успешно"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Прехвърлянето пропадна."
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Прехвърлянето на файла %(0)s се провали"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Получени файлове"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "%d получен файл на заден фон"
 msgstr[1] "%d получени файла на заден фон"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Още %d приет файл на заден фон"
@@ -2011,27 +2369,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Добавя стандартни елементи на меню към менюто на иконката за състояние"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Настройка на ново устройство"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Изпращане на _файлове към устройство"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Устройства"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "_Адаптери"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "аплет"
 
@@ -2043,27 +2401,27 @@ msgstr "Осигурява ключ, идентифициращи услуги �
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Добавя към менюто елемент за изход за напускане на аплета"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Осигурява основен клиент за DHCP за връзките през блутут PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Мрежа през блутут"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Интерфейсът %(0)s е достъпен от IP адрес %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Неуспешно присвояване на IP адрес през %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2072,7 +2430,7 @@ msgstr ""
 "Присвояване на IP адрес на %s\n"
 "Моля, изчакайте…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2080,24 +2438,27 @@ msgstr ""
 "Добавя индикация на иконката за състояние, когато има дейност по Блутут и "
 "показва броя на връзките в подсказката."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Адаптерът за блутут е активен"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d активна връзка</b>"
 msgstr[1] "<b>%d активни връзки</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Блутут е изключен"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Използва „libappindicator“ за показване на иконка за състоянието"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2105,33 +2466,34 @@ msgstr ""
 "Осигурява елемент в менюто, чрез който адаптерът по подразбиране да се "
 "направи временно видим, в случаите, когато е зададен като скрит."
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Период на видимост"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Продължителност в секунди, през която режимът на видимост ще трае"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Да е откриваем"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Включване на подразбиращият се адаптер да е временно видим"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Видимо… %sсек"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "Осигурява меню за аплета и API за други приставки да го управляват"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2140,22 +2502,22 @@ msgstr ""
 "Успешно свърздане към услугата <b>DUN</b> на <b>%(0)s.</b>\n"
 "Сега мрежата е налична чрез <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "Осигурява основна поддръжка за свързване към интернет чрез DUN профил."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Стандартен мрежови манипулатор за SPP профил; позволява изпълнението на "
 "лични действия"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Скрипт за пълнение върху връзката"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2174,11 +2536,11 @@ msgstr ""
 "При разединяване на устройството, на скрипта ще бъде изпратен сиглан HUP</"
 "span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Серийният порт е свързан"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2186,11 +2548,11 @@ msgstr ""
 "Услугата на серийният порт на устройството <b>%s</b> сега ще бъде налична "
 "чрез <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Скриптът за серийния порт се провали"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2199,37 +2561,37 @@ msgstr ""
 "Имаше проблем при пускането на скрипта %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Контролира енергийните нива на адаптера за блутут"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Автоматично пускане"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Автоматично пускане на адаптерите"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Изключване на блутут</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Изключване на всички адартори"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Включване на блутут</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Включване на всички адаптери"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2237,21 +2599,20 @@ msgstr ""
 "Временно премахва предпазителя на екрана, когато е свързан игрален "
 "контролера чрез блутут."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Мрежа"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Невалиден IP адрес"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP адресът съвпада с интерфейс %s, който има същия адрес"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2259,8 +2620,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "С тази настройка в момента не се поддържа"
 
@@ -2274,40 +2635,26 @@ msgstr "Приставката за трансфер на аплета е изк
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Адаптери за блутут"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "аплет"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "„Blueman“ е мениджър на устройства с блутут, базиран на GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Блутут е включен"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Устройства с блутут"
 
@@ -2343,6 +2690,31 @@ msgstr "Задаване на състояние на RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Задаването на състояние на RfKill изисква правомощия"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Въведете PIN код"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Въведете ключ за достъп"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Сериен порт свързан към %s"
+
+#~ msgid "palm"
+#~ msgstr "palm устройство"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "слушалка"
+
+#~ msgid "handsfree"
+#~ msgstr "слушалка „свободни ръце“"
+
+#~ msgid "unknown"
+#~ msgstr "непознато"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Устройства с блутут"
 
@@ -2363,11 +2735,6 @@ msgstr "Задаването на състояние на RfKill изисква 
 
 #~ msgid "_Remove..."
 #~ msgstr "_Премахване…"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Свързване"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -1,0 +1,1774 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2010-01-29 14:44+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: ../data/ui/adapters-tab.ui.h:1
+msgid "<b>Friendly Name</b>"
+msgstr ""
+
+#: ../data/ui/adapters-tab.ui.h:2
+msgid "<b>Visibility Setting</b>"
+msgstr ""
+
+#: ../data/ui/adapters-tab.ui.h:3
+msgid "Always visible"
+msgstr ""
+
+#: ../data/ui/adapters-tab.ui.h:4 ../apps/blueman-adapters:145
+msgid "Hidden"
+msgstr ""
+
+#: ../data/ui/adapters-tab.ui.h:5
+msgid "Temporarily visible"
+msgstr ""
+
+#: ../data/ui/adapters.ui.h:1
+msgid "Bluetooth Adapters"
+msgstr ""
+
+#: ../data/ui/applet-passkey.ui.h:1
+msgid "Pairing request"
+msgstr ""
+
+#: ../data/ui/applet-passkey.ui.h:2
+msgid "Pairing request for device:"
+msgstr ""
+
+#: ../data/ui/applet-passkey.ui.h:3
+msgid "Show input"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: ../data/ui/manager-main.ui.h:2
+msgid "Add"
+msgstr ""
+
+#: ../data/ui/manager-main.ui.h:3
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:274
+msgid "Add this device to known devices list"
+msgstr ""
+
+#: ../data/ui/manager-main.ui.h:4
+msgid "Bluetooth Devices"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: ../data/ui/manager-main.ui.h:6
+msgid "Browse"
+msgstr ""
+
+#: ../data/ui/manager-main.ui.h:7
+msgid "Browse the device using obex ftp"
+msgstr ""
+
+#: ../data/ui/manager-main.ui.h:8
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:386
+msgid "Create pairing with the device"
+msgstr ""
+
+#: ../data/ui/manager-main.ui.h:9
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:405
+msgid "Mark/Unmark this device as trusted"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: ../data/ui/manager-main.ui.h:11
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:283
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:385
+msgid "Pair"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: ../data/ui/manager-main.ui.h:13
+msgid "Remove"
+msgstr ""
+
+#: ../data/ui/manager-main.ui.h:14
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:442
+msgid "Remove this device from the known devices list"
+msgstr ""
+
+#: ../data/ui/manager-main.ui.h:15
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:281
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:411
+msgid "Run the setup assistant for this device"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: ../data/ui/manager-main.ui.h:17 ../blueman/gui/manager/ManagerMenu.py:199
+msgid "Search"
+msgstr ""
+
+#: ../data/ui/manager-main.ui.h:18
+msgid "Search for nearby devices"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: ../data/ui/manager-main.ui.h:20
+msgid "Send File"
+msgstr ""
+
+#: ../data/ui/manager-main.ui.h:21
+msgid "Send file(s) to the device"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: ../data/ui/manager-main.ui.h:23
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:276
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:407
+msgid "Setup..."
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: ../data/ui/manager-main.ui.h:25
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:396
+#: ../blueman/gui/manager/ManagerToolbar.py:47
+#: ../blueman/gui/manager/ManagerToolbar.py:120
+msgid "Trust"
+msgstr ""
+
+#: ../data/ui/services.ui.h:1
+msgid "Local Services"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:1
+msgid "<b>DUN Support</b>"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:2
+msgid "<b>NAP Settings</b>"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:3
+msgid "<b>Network Settings</b>"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:4
+msgid "<b>No DHCP servers installed</b>"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:5
+msgid "<b>PAN Support</b>"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:6 ../data/ui/services-audio.ui.h:3
+msgid "<b>Services</b>"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:7
+msgid "DHCP server type:"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:8
+msgid "Enable Routing (NAT)"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:9 ../blueman/Sdp.py:118
+#: ../blueman/plugins/manager/Services.py:212 ../apps/blueman-assistant:336
+msgid "Group Network"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:10
+msgid "IP Address:"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:11
+msgid "Network Access Point (NAP)"
+msgstr ""
+
+#: ../data/ui/services-network.ui.h:12
+msgid "Recommended"
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:1
+msgid "<b>Advanced</b>"
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:2
+msgid "<b>File Receiving (Object Push)</b>"
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:3
+msgid "<b>File Sharing (FTP)</b>"
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:4
+msgid "<b>Transfer Settings</b>"
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:5
+msgid "Accept files from trusted devices"
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:6
+msgid "Allow devices to write/delete"
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:8
+#, no-c-format
+msgid ""
+"Command to start an obex ftp browser.\n"
+"<i>%d</i> is substituted with device address."
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:10
+msgid "Enabled"
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:11
+msgid "Select Shared/Storage folder"
+msgstr ""
+
+#: ../data/ui/services-transfer.ui.h:12
+msgid "Shared Folder:"
+msgstr ""
+
+#: ../data/ui/services-audio.ui.h:1
+msgid ""
+"<b>After applying these settings Bluetooth daemon will be restarted.</b>"
+msgstr ""
+
+#: ../data/ui/services-audio.ui.h:2
+msgid "<b>Audio Settings</b>"
+msgstr ""
+
+#: ../data/ui/services-audio.ui.h:4
+msgid ""
+"Advanced Audio receiver <span weight='bold' color='#cc0000'>Experimental!</"
+"span>"
+msgstr ""
+
+#: ../data/ui/services-audio.ui.h:5
+msgid "Allows this computer to act like a handsfree headset."
+msgstr ""
+
+#: ../data/ui/services-audio.ui.h:6
+msgid ""
+"Allows you to receive a2dp audio from other Bluetooth devices and play it "
+"over the speakers."
+msgstr ""
+
+#: ../data/ui/services-audio.ui.h:7
+msgid ""
+"Headset Emulation <span weight='bold' color='#cc0000'>Very Experimental!</"
+"span>"
+msgstr ""
+
+#: ../data/ui/send-dialog.ui.h:1
+msgid "<b>File:</b>"
+msgstr ""
+
+#: ../data/ui/send-dialog.ui.h:2
+msgid "<b>To:</b>"
+msgstr ""
+
+#: ../data/ui/send-dialog.ui.h:3
+msgid "<span weight=\"bold\" size=\"large\">Sending files via Bluetooth</span>"
+msgstr ""
+
+#: ../data/ui/send-dialog.ui.h:4
+msgid "Bluetooth File Transfer"
+msgstr ""
+
+#: ../data/ui/assistant.ui.h:1
+msgid "<b>Congratulations, device successfully added</b>"
+msgstr ""
+
+#: ../data/ui/assistant.ui.h:2
+msgid "<b>Connect to:</b>"
+msgstr ""
+
+#: ../data/ui/assistant.ui.h:3
+msgid "<b>Please wait...</b>"
+msgstr ""
+
+#: ../data/ui/assistant.ui.h:4
+msgid "<b>Select pairing method to use:</b>"
+msgstr ""
+
+#: ../data/ui/assistant.ui.h:5
+msgid ""
+"<b>Welcome to the Bluetooth device setup assistant. </b>\n"
+"\n"
+"\n"
+"It will walk you through the process of configuring and connecting to your "
+"Bluetooth enabled devices."
+msgstr ""
+
+#: ../data/ui/assistant.ui.h:9
+msgid "Proceed Without Pairing"
+msgstr ""
+
+#: ../data/ui/assistant.ui.h:10
+msgid "Use Custom Passkey:"
+msgstr ""
+
+#: ../data/ui/assistant.ui.h:11
+msgid "Use Random Passkey"
+msgstr ""
+
+#: ../data/ui/device-list-widget.ui.h:1
+msgid "Adapter selection"
+msgstr ""
+
+#: ../data/ui/device-list-widget.ui.h:2
+msgid "Device search progress"
+msgstr ""
+
+#: ../data/ui/device-list-widget.ui.h:3
+msgid "Search for devices"
+msgstr ""
+
+#: ../data/ui/applet-plugins-widget.ui.h:1
+msgid "<b>Author:</b>"
+msgstr ""
+
+#: ../data/ui/applet-plugins-widget.ui.h:2
+msgid "<b>Conflicts with:</b>"
+msgstr ""
+
+#: ../data/ui/applet-plugins-widget.ui.h:3
+msgid "<b>Depends on:</b>"
+msgstr ""
+
+#: ../data/ui/applet-plugins-widget.ui.h:4
+msgid "<b>Plugin description:</b>"
+msgstr ""
+
+#: ../data/ui/applet-plugins-widget.ui.h:5
+msgid "Configuration"
+msgstr ""
+
+#: ../data/ui/applet-plugins-widget.ui.h:6
+msgid "Configure selected plugin's preferences"
+msgstr ""
+
+#: ../data/ui/applet-plugins-widget.ui.h:7
+msgid "Not specified"
+msgstr ""
+
+#: ../data/ui/applet-plugins-widget.ui.h:8 ../blueman/Sdp.py:257
+#: ../blueman/Sdp.py:360 ../blueman/Sdp.py:365
+#: ../blueman/plugins/applet/NetUsage.py:247
+#: ../blueman/plugins/applet/NetUsage.py:248
+msgid "Unknown"
+msgstr ""
+
+#: ../data/ui/gsm-settings.ui.h:1
+msgid "<b>GSM settings</b>"
+msgstr ""
+
+#: ../data/ui/gsm-settings.ui.h:2
+msgid "APN:"
+msgstr ""
+
+#: ../data/ui/gsm-settings.ui.h:3
+msgid "Number:"
+msgstr ""
+
+#: ../data/ui/net-usage.ui.h:1
+msgid "<b>Downloaded:</b>"
+msgstr ""
+
+#: ../data/ui/net-usage.ui.h:2
+msgid "<b>Log duration:</b>"
+msgstr ""
+
+#: ../data/ui/net-usage.ui.h:3
+msgid "<b>Log started:</b>"
+msgstr ""
+
+#: ../data/ui/net-usage.ui.h:4
+msgid "<b>Total:</b>"
+msgstr ""
+
+#: ../data/ui/net-usage.ui.h:5
+msgid "<b>Uploaded:</b>"
+msgstr ""
+
+#: ../data/ui/net-usage.ui.h:6
+msgid "Reset"
+msgstr ""
+
+#: ../data/ui/net-usage.ui.h:7
+msgid "Traffic statistics"
+msgstr ""
+
+#: ../data/ui/net-usage.ui.h:8
+msgid "gtk-close"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:170
+msgid "Incoming file over Bluetooth"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:171
+#, python-format
+msgid "Incoming file %(0)s from %(1)s"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:172
+#: ../blueman/main/applet/BluezAgent.py:240
+msgid "Accept"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:172
+msgid "Reject"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:180
+msgid "Receiving file"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:181
+#, python-format
+msgid "Receiving file %(0)s from %(1)s"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:218
+#: ../blueman/main/applet/Transfer.py:244
+msgid "File received"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:219
+#: ../blueman/main/applet/Transfer.py:245
+#, python-format
+msgid "File %(0)s from %(1)s successfully received"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:232
+msgid "Transfer failed"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:233
+#, python-format
+msgid "Transfer of file %(0)s failed"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:251
+#: ../blueman/main/applet/Transfer.py:261
+msgid "Files received"
+msgstr ""
+
+#: ../blueman/main/applet/Transfer.py:252
+#, python-format
+msgid "Received %d file in the background"
+msgid_plural "Received %d files in the background"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../blueman/main/applet/Transfer.py:262
+#, python-format
+msgid "Received %d more file in the background"
+msgid_plural "Received %d more files in the background"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../blueman/main/applet/BluezAgent.py:125
+#, python-format
+msgid "Pairing request for %s"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:137
+#: ../blueman/main/applet/BluezAgent.py:243
+msgid "Bluetooth Authentication"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:178
+#: ../blueman/main/applet/BluezAgent.py:261
+msgid "Enter PIN code for authentication:"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:179
+#: ../blueman/main/applet/BluezAgent.py:262
+msgid "Enter PIN code"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:187
+#: ../blueman/main/applet/BluezAgent.py:270
+msgid "Enter passkey for authentication:"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:188
+#: ../blueman/main/applet/BluezAgent.py:271
+msgid "Enter passkey"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:208
+msgid "Pairing request for:"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:208
+#: ../blueman/main/applet/BluezAgent.py:287
+msgid "Confirm value for authentication:"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:209
+msgid "Confirm"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:209
+#: ../blueman/main/applet/BluezAgent.py:241
+msgid "Deny"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:238
+msgid "Authorization request for:"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:238
+msgid "Service:"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:239
+msgid "Always accept"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:285
+msgid "Confirm value"
+msgstr ""
+
+#: ../blueman/main/applet/BluezAgent.py:286
+#, python-format
+msgid "Pairing with: %s"
+msgstr ""
+
+#: ../blueman/main/PluginManager.py:78
+msgid ""
+"<b>An error has occured while loading a plugin. Please notify the developers "
+"with the content of this message.</b>"
+msgstr ""
+
+#: ../blueman/Functions.py:77
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: ../blueman/Functions.py:81
+msgid "Enable Bluetooth"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:38
+msgid "_Adapter"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:39
+msgid "_Device"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:41
+msgid "_View"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:42
+msgid "_Help"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:55
+msgid "Get Help Online..."
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:60
+msgid "Translate This Application..."
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:65
+msgid "Report a Problem"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:75
+msgid "Device Manager"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:83
+msgid "Show Toolbar"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:95
+msgid "Show Statusbar"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:111
+msgid "Latest Device First"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerMenu.py:115
+msgid "Latest Device Last"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:451
+msgid "<b>Trusted and Bonded</b>"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:453
+msgid "<b>Bonded</b>"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:455
+msgid "<b>Trusted</b>"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:476
+msgid "Poor"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:479
+#: ../blueman/gui/manager/ManagerDeviceList.py:495
+msgid "Sub-optimal"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:482
+#: ../blueman/gui/manager/ManagerDeviceList.py:498
+msgid "Optimal"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:485
+msgid "Much"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:488
+msgid "Too much"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:492
+msgid "Low"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:501
+msgid "High"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:504
+msgid "Very High"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:507
+#, python-format
+msgid ""
+"<b>Connected</b>\n"
+"Received Signal Strength: %(rssi)u%% <i>(%(rssi_state)s)</i>\n"
+"Link Quality: %(lq)u%%\n"
+"<b>Transmit Power Level: %(tpl)u%%</b> <i>(%(tpl_state)s)</i>"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:509
+#, python-format
+msgid ""
+"<b>Connected</b>\n"
+"Received Signal Strength: %(rssi)u%% <i>(%(rssi_state)s)</i>\n"
+"<b>Link Quality: %(lq)u%%</b>\n"
+"Transmit Power Level: %(tpl)u%% <i>(%(tpl_state)s)</i>"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceList.py:511
+#, python-format
+msgid ""
+"<b>Connected</b>\n"
+"<b>Received Signal Strength: %(rssi)u%%</b> <i>(%(rssi_state)s)</i>\n"
+"Link Quality: %(lq)u%%\n"
+"Transmit Power Level: %(tpl)u%% <i>(%(tpl_state)s)</i>"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:124
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:416
+msgid "Success!"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:128
+#, python-format
+msgid "Serial port connected to %s"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:135
+msgid "Failed"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:139
+msgid "Connection Failed: "
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:146
+msgid "Cancelled"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:150
+msgid "Connecting..."
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:269
+msgid "Add Device"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:288
+msgid "Pair with the device"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:294
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:357
+msgid "Send a File..."
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:325
+msgid "<b>Connect To:</b>"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:337
+msgid "<b>Disconnect:</b>"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:362
+msgid "Browse Device..."
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:401
+#: ../blueman/gui/manager/ManagerToolbar.py:45
+#: ../blueman/gui/manager/ManagerToolbar.py:115
+msgid "Untrust"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:421
+msgid "Fail"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:424
+msgid "Refreshing"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:426
+msgid "Refreshing Services..."
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:429
+msgid "Refresh Services"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:438
+msgid "Remove..."
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:448
+msgid "Disconnect"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:449
+msgid "Forcefully disconnect the device"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerDeviceMenu.py:458
+msgid "Disconnecting..."
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerProgressbar.py:32 ../apps/blueman-sendto:70
+msgid "Connecting"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerProgressbar.py:59
+msgid "Cancel Operation"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerStats.py:53
+#: ../blueman/gui/manager/ManagerStats.py:56
+msgid "Data activity indication"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerStats.py:66
+#: ../blueman/gui/manager/ManagerStats.py:79
+msgid "Total data received and rate of transmission"
+msgstr ""
+
+#: ../blueman/gui/manager/ManagerStats.py:71
+#: ../blueman/gui/manager/ManagerStats.py:74
+msgid "Total data sent and rate of transmission"
+msgstr ""
+
+#: ../blueman/gui/DeviceSelectorDialog.py:27
+msgid "Select Device"
+msgstr ""
+
+#: ../blueman/gui/MessageArea.py:60
+msgid "More"
+msgstr ""
+
+#: ../blueman/gui/MessageArea.py:73
+msgid "Close"
+msgstr ""
+
+#: ../blueman/gui/CommonUi.py:45
+msgid "translator-credits"
+msgstr ""
+
+#: ../blueman/gui/CommonUi.py:48
+msgid "Blueman is a GTK based Bluetooth manager"
+msgstr ""
+
+#: ../blueman/gui/GsmSettings.py:38
+msgid "GSM Settings"
+msgstr ""
+
+#: ../blueman/gui/applet/PluginDialog.py:123
+#: ../blueman/plugins/applet/StandardItems.py:139
+msgid "Plugins"
+msgstr ""
+
+#: ../blueman/gui/applet/PluginDialog.py:216
+#: ../blueman/gui/applet/PluginDialog.py:217
+msgid "Unspecified"
+msgstr ""
+
+#: ../blueman/gui/applet/PluginDialog.py:307
+#: ../blueman/gui/applet/PluginDialog.py:327
+msgid "Dependency issue"
+msgstr ""
+
+#: ../blueman/gui/applet/PluginDialog.py:308
+#, python-format
+msgid ""
+"Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
+"also unload <b>\"%(0)s\"</b>.\n"
+"Proceed?"
+msgstr ""
+
+#: ../blueman/gui/applet/PluginDialog.py:328
+#, python-format
+msgid ""
+"Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
+"unload <b>%(0)s</b>.\n"
+"Proceed?"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:36 ../blueman/DeviceClass.py:61
+msgid "uncategorized"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:38
+msgid "desktop"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:40
+msgid "server"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:42
+msgid "laptop"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:44
+msgid "handheld"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:46
+msgid "palm"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:63
+msgid "cellular"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:65
+msgid "cordless"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:67
+msgid "smart phone"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:69
+msgid "modem"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:71
+msgid "isdn"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:108
+msgid "headset"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:110
+msgid "handsfree"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:112 ../blueman/DeviceClass.py:180
+#: ../blueman/DeviceClass.py:246
+msgid "unknown"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:114
+msgid "microphone"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:139
+msgid "keyboard"
+msgstr ""
+
+#. translators: device class
+#: ../blueman/DeviceClass.py:141
+msgid "pointing"
+msgstr ""
+
+#: ../blueman/Sdp.py:98
+msgid "Dialup Networking (DUN)"
+msgstr ""
+
+#: ../blueman/Sdp.py:105 ../blueman/plugins/manager/Services.py:332
+#: ../blueman/plugins/manager/Services.py:340
+msgid "Audio Source"
+msgstr ""
+
+#: ../blueman/Sdp.py:106 ../blueman/plugins/manager/Services.py:307
+#: ../blueman/plugins/manager/Services.py:315
+msgid "Audio Sink"
+msgstr ""
+
+#: ../blueman/Sdp.py:117 ../blueman/plugins/manager/Services.py:223
+#: ../apps/blueman-assistant:341
+msgid "Network Access Point"
+msgstr ""
+
+#: ../blueman/plugins/manager/PulseAudioProfile.py:119
+#, python-format
+msgid "Failed to change profile to %s"
+msgstr ""
+
+#: ../blueman/plugins/manager/PulseAudioProfile.py:155
+msgid "Audio Profile"
+msgstr ""
+
+#: ../blueman/plugins/manager/PulseAudioProfile.py:156
+msgid "Select audio profile for PulseAudio"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:122
+msgid "Dialup Service"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:135
+msgid "Serial Service"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:150
+#, python-format
+msgid "Serial Port %s"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:173
+msgid "Dialup Settings"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:186
+msgid "Serial Ports"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:235
+#: ../blueman/plugins/services/Network.py:34
+#: ../blueman/plugins/services/Network.py:59
+msgid "Network"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:247
+msgid "Renew IP Address"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:259
+#: ../blueman/plugins/manager/Services.py:268 ../apps/blueman-assistant:328
+msgid "Input Service"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:283
+#: ../blueman/plugins/manager/Services.py:291 ../apps/blueman-assistant:356
+msgid "Headset Service"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:317
+msgid "Allows to send audio to remote device"
+msgstr ""
+
+#: ../blueman/plugins/manager/Services.py:342
+msgid "Allows to receive audio from remote device"
+msgstr ""
+
+#: ../blueman/plugins/applet/NetUsage.py:196
+#: ../blueman/plugins/applet/NetUsage.py:298
+#: ../blueman/plugins/applet/NetUsage.py:301
+msgid "Connected:"
+msgstr ""
+
+#: ../blueman/plugins/applet/NetUsage.py:212
+#: ../blueman/plugins/applet/NetUsage.py:309
+msgid "Not Connected"
+msgstr ""
+
+#: ../blueman/plugins/applet/NetUsage.py:218
+msgid ""
+"No usage statistics are available yet. Try establishing a connection first "
+"and then check this page."
+msgstr ""
+
+#: ../blueman/plugins/applet/NetUsage.py:241
+msgid "day"
+msgid_plural "days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../blueman/plugins/applet/NetUsage.py:242
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../blueman/plugins/applet/NetUsage.py:243
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../blueman/plugins/applet/NetUsage.py:245
+#, python-format
+msgid "%d %s %d %s and %d %s"
+msgstr ""
+
+#: ../blueman/plugins/applet/NetUsage.py:276
+msgid "Are you sure you want to reset the counter?"
+msgstr ""
+
+#: ../blueman/plugins/applet/NetUsage.py:315
+msgid ""
+"Allows you to monitor your (mobile broadband) network traffic usage. Useful "
+"for limited data access plans. This plugin tracks every device seperately."
+msgstr ""
+
+#: ../blueman/plugins/applet/NetUsage.py:333
+msgid "Network Usage"
+msgstr ""
+
+#: ../blueman/plugins/applet/NetUsage.py:334
+msgid "Shows network traffic usage"
+msgstr ""
+
+#: ../blueman/plugins/applet/StatusIcon.py:72
+msgid "Icon Name"
+msgstr ""
+
+#: ../blueman/plugins/applet/StatusIcon.py:73
+msgid "Custom icon to use for the notification area"
+msgstr ""
+
+#: ../blueman/plugins/applet/StatusIcon.py:90
+#: ../blueman/plugins/applet/StatusIcon.py:103
+#: ../blueman/plugins/applet/Indicator.py:106
+#: ../blueman/plugins/applet/Indicator.py:111
+msgid "Bluetooth Enabled"
+msgstr ""
+
+#: ../blueman/plugins/applet/StatusIcon.py:105
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: ../blueman/plugins/applet/Networking.py:31
+msgid "Manages local network services, like NAP bridges"
+msgstr ""
+
+#: ../blueman/plugins/applet/Networking.py:54
+#: ../blueman/plugins/services/Network.py:129
+msgid "Failed to apply network settings"
+msgstr ""
+
+#: ../blueman/plugins/applet/Networking.py:55
+msgid ""
+"You might not be able to connect to the Bluetooth network via this machine"
+msgstr ""
+
+#: ../blueman/plugins/applet/NMDUNSupport.py:85
+msgid "Bluetooth Dialup"
+msgstr ""
+
+#: ../blueman/plugins/applet/NMDUNSupport.py:86
+#, python-format
+msgid "DUN connection on %s will now be available in Network Manager"
+msgstr ""
+
+#: ../blueman/plugins/applet/NMDUNSupport.py:96
+msgid "Modem Manager did not support the connection"
+msgstr ""
+
+#: ../blueman/plugins/applet/NMDUNSupport.py:104
+msgid ""
+"Provides support for Dial Up Networking (DUN) with ModemManager and "
+"NetworkManager 0.8"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:57
+msgid ""
+"Provides a menu item that contains last used connections for quick access"
+msgstr ""
+
+#. the maximum number of items RecentConns menu will display
+#: ../blueman/plugins/applet/RecentConns.py:64
+msgid "Maximum items"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:65
+msgid "The maximum number of items recent connections menu will display."
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:83
+msgid "Recent Connections"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:296
+#, python-format
+msgid "Connecting to %s"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:302
+#: ../blueman/plugins/applet/PPPSupport.py:68
+msgid "Connected"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:302
+#, python-format
+msgid "Connected to %s"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:308
+msgid "Failed to connect"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:326
+#, python-format
+msgid "Network Access (%s)"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:331
+msgid "Service"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:343
+#, python-format
+msgid "%(service)s on %(device)s"
+msgstr ""
+
+#: ../blueman/plugins/applet/RecentConns.py:362
+msgid "Adapter for this connection is not available"
+msgstr ""
+
+#: ../blueman/plugins/applet/NMPANSupport.py:182
+msgid ""
+"Provides support for Personal Area Networking (PAN) introduced in "
+"NetworkManager 0.8"
+msgstr ""
+
+#: ../blueman/plugins/applet/NMPANSupport.py:335
+msgid "Already connected"
+msgstr ""
+
+#: ../blueman/plugins/applet/DBusService.py:39
+msgid "Provides DBus API for other Blueman components"
+msgstr ""
+
+#: ../blueman/plugins/applet/NMMonitor.py:106
+msgid ""
+"Monitors NetworkManager's modem connections and automatically disconnects "
+"Bluetooth link after the network connection is closed"
+msgstr ""
+
+#: ../blueman/plugins/applet/TransferService.py:29
+msgid "Provides OBEX file transfer capabilities"
+msgstr ""
+
+#: ../blueman/plugins/applet/KillSwitch.py:33
+msgid ""
+"Toggles a platform Bluetooth killswitch when Bluetooth power state changes. "
+"Useless with USB dongles."
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:30
+msgid "Adds standard menu items to the status icon menu"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:38
+msgid "_Setup New Device"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:45
+msgid "Send _Files to Device"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:50
+msgid "_Browse Files on Device"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:58
+msgid "_Devices"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:63
+msgid "Adap_ters"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:68
+msgid "_Local Services"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:78
+msgid "_Plugins"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:113 ../apps/blueman-manager:237
+msgid "Starting Bluetooth Assistant"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:117 ../apps/blueman-manager:278
+msgid "Starting File Sender"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:121
+msgid "Starting File Browser"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:125
+msgid "Starting Device Manager"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:129 ../apps/blueman-manager:269
+msgid "Starting Adapter Preferences"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:133
+msgid "Starting Service Preferences"
+msgstr ""
+
+#: ../blueman/plugins/applet/StandardItems.py:137
+msgid "applet"
+msgstr ""
+
+#: ../blueman/plugins/applet/AuthAgent.py:28
+msgid "Provides passkey, authentication services for BlueZ daemon"
+msgstr ""
+
+#: ../blueman/plugins/applet/PulseAudio.py:139
+msgid ""
+"Automatically manages Pulseaudio Bluetooth sinks/sources.\n"
+"<b>Note:</b> Requires pulseaudio 0.9.15 or higher"
+msgstr ""
+
+#: ../blueman/plugins/applet/PulseAudio.py:146
+msgid "Make default sink"
+msgstr ""
+
+#: ../blueman/plugins/applet/PulseAudio.py:147
+msgid "Make the a2dp audio sink the default after connection"
+msgstr ""
+
+#: ../blueman/plugins/applet/PulseAudio.py:150
+msgid "Move streams"
+msgstr ""
+
+#: ../blueman/plugins/applet/PulseAudio.py:151
+msgid "Move existing audio streams to bluetooth device"
+msgstr ""
+
+#: ../blueman/plugins/applet/PulseAudio.py:312
+#: ../blueman/plugins/applet/PulseAudio.py:317
+msgid "Bluetooth Audio"
+msgstr ""
+
+#: ../blueman/plugins/applet/PulseAudio.py:313
+msgid ""
+"Failed to initialize PulseAudio Bluetooth module. Bluetooth audio over "
+"PulseAudio will not work."
+msgstr ""
+
+#: ../blueman/plugins/applet/PulseAudio.py:318
+msgid ""
+"Successfully connected to a Bluetooth audio device. This device will now be "
+"available in the PulseAudio mixer"
+msgstr ""
+
+#: ../blueman/plugins/applet/ExitItem.py:24
+msgid "Adds an exit menu item to quit the applet"
+msgstr ""
+
+#: ../blueman/plugins/applet/DhcpClient.py:26
+msgid "Provides a basic dhcp client for Bluetooth PAN connections."
+msgstr ""
+
+#: ../blueman/plugins/applet/DhcpClient.py:63
+#: ../blueman/plugins/applet/DhcpClient.py:71
+#: ../blueman/plugins/applet/DhcpClient.py:77
+msgid "Bluetooth Network"
+msgstr ""
+
+#: ../blueman/plugins/applet/DhcpClient.py:63
+#, python-format
+msgid "Interface %(0)s bound to IP address %(1)s"
+msgstr ""
+
+#: ../blueman/plugins/applet/DhcpClient.py:71
+#, python-format
+msgid "Failed to obtain an IP address on %s"
+msgstr ""
+
+#: ../blueman/plugins/applet/DhcpClient.py:77
+#, python-format
+msgid ""
+"Trying to obtain an IP address on %s\n"
+"Please wait..."
+msgstr ""
+
+#: ../blueman/plugins/applet/NMIntegration.py:39
+msgid ""
+"<b>Deprecated</b>\n"
+"Makes DUN/PAN connections available for NetworkManager 0.7"
+msgstr ""
+
+#: ../blueman/plugins/applet/NMIntegration.py:79
+msgid "CDMA or GSM not supported"
+msgstr ""
+
+#: ../blueman/plugins/applet/NMIntegration.py:80
+#, python-format
+msgid ""
+"The device %s does not appear to support GSM/CDMA.\n"
+"This connection will not work."
+msgstr ""
+
+#: ../blueman/plugins/applet/Indicator.py:31
+msgid ""
+"Adds an indication on the status icon when Bluetooth is active and shows the "
+"number of connections in the tooltip."
+msgstr ""
+
+#: ../blueman/plugins/applet/Indicator.py:35
+msgid "Show overlay icon"
+msgstr ""
+
+#: ../blueman/plugins/applet/Indicator.py:36
+msgid "Whether to show a composition over the status icon when connected"
+msgstr ""
+
+#: ../blueman/plugins/applet/Indicator.py:96
+msgid "Bluetooth Active"
+msgstr ""
+
+#: ../blueman/plugins/applet/Indicator.py:98
+#, python-format
+msgid "<b>%d Active Connection</b>"
+msgid_plural "<b>%d Active Connections</b>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../blueman/plugins/applet/Headset.py:26
+msgid "Runs a command when answer button is pressed on a headset"
+msgstr ""
+
+#: ../blueman/plugins/applet/Headset.py:32
+msgid "Command"
+msgstr ""
+
+#: ../blueman/plugins/applet/Headset.py:33
+msgid "Command to execute when answer button is pressed:"
+msgstr ""
+
+#: ../blueman/plugins/applet/DiscvManager.py:32
+msgid ""
+"Provides a menu item for making the default adapter temporarily visible when "
+"it is set to hidden by default"
+msgstr ""
+
+#: ../blueman/plugins/applet/DiscvManager.py:37
+msgid "Discoverable timeout"
+msgstr ""
+
+#: ../blueman/plugins/applet/DiscvManager.py:38
+msgid "Amount of time in seconds discoverable mode will last"
+msgstr ""
+
+#: ../blueman/plugins/applet/DiscvManager.py:46
+#: ../blueman/plugins/applet/DiscvManager.py:142
+msgid "_Make Discoverable"
+msgstr ""
+
+#: ../blueman/plugins/applet/DiscvManager.py:54
+msgid "Make the default adapter temporarily visible"
+msgstr ""
+
+#: ../blueman/plugins/applet/DiscvManager.py:80
+#, python-format
+msgid "Discoverable... %ss"
+msgstr ""
+
+#: ../blueman/plugins/applet/Menu.py:27
+msgid ""
+"Provides a menu for the applet and an API for other plugins to manipulate it"
+msgstr ""
+
+#: ../blueman/plugins/applet/PPPSupport.py:68
+#, python-format
+msgid ""
+"Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
+"Network is now available through <b>%(1)s</b>"
+msgstr ""
+
+#: ../blueman/plugins/applet/PPPSupport.py:75
+msgid "Provides basic support for connecting to the internet via DUN profile."
+msgstr ""
+
+#: ../blueman/plugins/applet/SerialManager.py:39
+msgid ""
+"Standard SPP profile connection handler, allows executing custom actions"
+msgstr ""
+
+#: ../blueman/plugins/applet/SerialManager.py:43
+msgid "Script to execute on connection"
+msgstr ""
+
+#: ../blueman/plugins/applet/SerialManager.py:44
+msgid ""
+"<span size=\"small\">The following arguments will be passed:\n"
+"Address, Name, service name, uuid16s, rfcomm node\n"
+"For example:\n"
+"AA:BB:CC:DD:EE:FF, Phone, DUN service, 0x1103, /dev/rfcomm0\n"
+"uuid16s are returned as a comma seperated list\n"
+"\n"
+"Upon device disconnection the script will be sent a HUP signal</span>"
+msgstr ""
+
+#: ../blueman/plugins/applet/SerialManager.py:77
+msgid "Serial port connected"
+msgstr ""
+
+#: ../blueman/plugins/applet/SerialManager.py:78
+#, python-format
+msgid ""
+"Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
+msgstr ""
+
+#: ../blueman/plugins/applet/SerialManager.py:123
+msgid "Serial port connection script failed"
+msgstr ""
+
+#: ../blueman/plugins/applet/SerialManager.py:124
+#, python-format
+msgid ""
+"There was a problem launching script %s\n"
+"%s"
+msgstr ""
+
+#: ../blueman/plugins/applet/PowerManager.py:30
+msgid "Controls Bluetooth adapter power states"
+msgstr ""
+
+#: ../blueman/plugins/applet/PowerManager.py:53
+msgid "<b>Bluetooth Off</b>"
+msgstr ""
+
+#: ../blueman/plugins/applet/PowerManager.py:54
+#: ../blueman/plugins/applet/PowerManager.py:196
+msgid "<b>Turn Bluetooth Off</b>"
+msgstr ""
+
+#: ../blueman/plugins/applet/PowerManager.py:56
+#: ../blueman/plugins/applet/PowerManager.py:197
+msgid "Turn off all adapters"
+msgstr ""
+
+#: ../blueman/plugins/applet/PowerManager.py:184
+msgid "<b>Turn Bluetooth On</b>"
+msgstr ""
+
+#: ../blueman/plugins/applet/PowerManager.py:185
+msgid "Turn on all adapters"
+msgstr ""
+
+#: ../blueman/plugins/services/Network.py:152
+msgid "Invalid IP address"
+msgstr ""
+
+#: ../blueman/plugins/services/Network.py:164
+#, python-format
+msgid "IP address conflicts with interface %s which has the same address"
+msgstr ""
+
+#: ../blueman/plugins/services/Network.py:169
+#, python-format
+msgid ""
+"IP address overlaps with subnet of interface %s, which has the following "
+"configuration %s/%s\n"
+"This may cause incorrect network behavior"
+msgstr ""
+
+#: ../blueman/plugins/services/Network.py:314
+#: ../blueman/plugins/services/Network.py:317
+#: ../blueman/plugins/services/Network.py:323
+#: ../blueman/plugins/services/Network.py:329
+msgid "Not currently supported with this setup"
+msgstr ""
+
+#: ../blueman/plugins/services/Audio.py:33
+msgid "Audio"
+msgstr ""
+
+#: ../blueman/plugins/services/Transfer.py:30
+msgid "Transfer"
+msgstr ""
+
+#: ../blueman/plugins/services/Transfer.py:46
+msgid "Applet's transfer service plugin is disabled"
+msgstr ""
+
+#: ../blueman/plugins/services/Transfer.py:135 ../apps/blueman-sendto:110
+msgid "obex-data-server not available"
+msgstr ""
+
+#: ../data/blueman.desktop.in.h:1
+msgid "Blueman Applet"
+msgstr ""
+
+#: ../data/blueman.desktop.in.h:2 ../data/blueman-manager.desktop.in.h:1
+msgid "Blueman Bluetooth Manager"
+msgstr ""
+
+#: ../data/blueman-manager.desktop.in.h:2
+msgid "Bluetooth Manager"
+msgstr ""
+
+#: ../data/configs/org.blueman.policy.in.h:1
+msgid "Bluetooth Configuration"
+msgstr ""
+
+#: ../data/configs/org.blueman.policy.in.h:2
+msgid "Changing Bluetooth system settings requires privileges"
+msgstr ""
+
+#: ../data/configs/org.blueman.policy.in.h:3
+msgid "Configure Bluetooth Modems"
+msgstr ""
+
+#: ../data/configs/org.blueman.policy.in.h:4
+msgid "Configure Bluetooth Network"
+msgstr ""
+
+#: ../data/configs/org.blueman.policy.in.h:5
+msgid "Configuring networking requires privileges"
+msgstr ""
+
+#: ../data/configs/org.blueman.policy.in.h:6
+msgid "Launch DHCP client"
+msgstr ""
+
+#: ../data/configs/org.blueman.policy.in.h:7
+msgid "Launching DHCP client requires privileges"
+msgstr ""
+
+#: ../data/configs/org.blueman.policy.in.h:8
+msgid "System policy prevents modifying the configuration"
+msgstr ""
+
+#: ../data/configs/org.blueman.policy.in.h:9
+msgid "The Blueman Project"
+msgstr ""
+
+#: ../apps/blueman-manager:106
+msgid "Bluetooth needs to be turned on for the device manager to function"
+msgstr ""
+
+#: ../apps/blueman-manager:116
+msgid "Connection to BlueZ failed"
+msgstr ""
+
+#: ../apps/blueman-manager:118
+msgid ""
+"Bluez daemon is not running, blueman-manager cannot continue.\n"
+"This probably means that there were no Bluetooth adapters detected or "
+"Bluetooth daemon was not started."
+msgstr ""
+
+#: ../apps/blueman-manager:205 ../apps/blueman-assistant:276
+msgid "Adding"
+msgstr ""
+
+#: ../apps/blueman-manager:225
+msgid "Searching"
+msgstr ""
+
+#: ../apps/blueman-manager:244
+msgid "Success"
+msgstr ""
+
+#: ../apps/blueman-manager:249
+msgid "Failure"
+msgstr ""
+
+#: ../apps/blueman-manager:257
+msgid "Pairing"
+msgstr ""
+
+#: ../apps/blueman-adapters:55
+msgid "Bluetooth needs to be turned on for the adapter manager to work"
+msgstr ""
+
+#: ../apps/blueman-adapters:143
+msgid "Always"
+msgstr ""
+
+#: ../apps/blueman-adapters:147
+#, c-format
+msgid "%d Minute"
+msgid_plural "%d Minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../apps/blueman-sendto:111
+msgid "obex-data-server is probably not installed"
+msgstr ""
+
+#: ../apps/blueman-sendto:139
+msgid "Error occurred"
+msgstr ""
+
+#: ../apps/blueman-sendto:155
+msgid "Cancelling"
+msgstr ""
+
+#: ../apps/blueman-sendto:175 ../apps/blueman-sendto:209
+msgid "Sending File"
+msgstr ""
+
+#: ../apps/blueman-sendto:175 ../apps/blueman-sendto:209
+msgid "ETA:"
+msgstr ""
+
+#: ../apps/blueman-sendto:203
+#, c-format
+msgid "%.0f Minute"
+msgid_plural "%.0f Minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../apps/blueman-sendto:205
+#, c-format
+msgid "%.0f Second"
+msgid_plural "%.0f Seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../apps/blueman-sendto:261
+#, c-format
+msgid "Error occurred while sending file %s"
+msgstr ""
+
+#: ../apps/blueman-sendto:265
+msgid "Skip"
+msgstr ""
+
+#: ../apps/blueman-sendto:266
+msgid "Retry"
+msgstr ""
+
+#: ../apps/blueman-sendto:316
+msgid "Send files to this device"
+msgstr ""
+
+#: ../apps/blueman-sendto:323
+msgid "Bluetooth needs to be turned on for file sending to work"
+msgstr ""
+
+#: ../apps/blueman-sendto:377
+msgid "Select files to send"
+msgstr ""
+
+#: ../apps/blueman-assistant:61
+msgid "Start configuration assistant for this device"
+msgstr ""
+
+#: ../apps/blueman-assistant:65
+msgid "Bluetooth needs to be turned on for the Bluetooth assistant to work"
+msgstr ""
+
+#: ../apps/blueman-assistant:79
+msgid "Bluetooth Assistant"
+msgstr ""
+
+#: ../apps/blueman-assistant:131
+msgid "No adapters found"
+msgstr ""
+
+#: ../apps/blueman-assistant:275
+msgid "<b>Adding Device...</b>"
+msgstr ""
+
+#: ../apps/blueman-assistant:281
+#, c-format
+msgid ""
+"<b>Pairing in progress...</b>\n"
+"\n"
+"Enter passkey <b>%s</b> on the device."
+msgstr ""
+
+#: ../apps/blueman-assistant:293
+msgid "<b>Failed to add device</b>"
+msgstr ""
+
+#: ../apps/blueman-assistant:346
+msgid "A2DP Sink (Send Audio)"
+msgstr ""
+
+#: ../apps/blueman-assistant:351
+msgid "A2DP Source (Receive Audio)"
+msgstr ""
+
+#: ../apps/blueman-assistant:360
+msgid "Don't connect"
+msgstr ""
+
+#: ../apps/blueman-assistant:375
+msgid "<b>Device added and connected successfuly</b>"
+msgstr ""
+
+#: ../apps/blueman-assistant:381
+msgid "<b>Device added successfuly, but failed to connect</b>"
+msgstr ""
+
+#: ../apps/blueman-browse:47
+msgid "Browse this device"
+msgstr ""
+
+#: ../apps/blueman-browse:74
+#, c-format
+msgid "Failed to launch \"%s\""
+msgstr ""
+
+#: ../apps/blueman-browse:75
+msgid "You can enter an alternate browser in service settings"
+msgstr ""

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -1,307 +1,212 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) YEAR Copyright © 2008 - 2020 blueman project
+# This file is distributed under the same license as the blueman package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-01-29 14:44+0200\n"
+"Project-Id-Version: blueman 2.2\n"
+"Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../data/ui/adapters-tab.ui.h:1
-msgid "<b>Friendly Name</b>"
-msgstr ""
-
-#: ../data/ui/adapters-tab.ui.h:2
+#: data/ui/adapters-tab.ui:29
 msgid "<b>Visibility Setting</b>"
 msgstr ""
 
-#: ../data/ui/adapters-tab.ui.h:3
-msgid "Always visible"
-msgstr ""
-
-#: ../data/ui/adapters-tab.ui.h:4 ../apps/blueman-adapters:145
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr ""
 
-#: ../data/ui/adapters-tab.ui.h:5
+#: data/ui/adapters-tab.ui:54
+msgid "Always visible"
+msgstr ""
+
+#: data/ui/adapters-tab.ui:70
 msgid "Temporarily visible"
 msgstr ""
 
-#: ../data/ui/adapters.ui.h:1
-msgid "Bluetooth Adapters"
+#: data/ui/adapters-tab.ui:101
+msgid "<b>Friendly Name</b>"
 msgstr ""
 
-#: ../data/ui/applet-passkey.ui.h:1
+#: data/ui/applet-passkey.ui:8
 msgid "Pairing request"
 msgstr ""
 
-#: ../data/ui/applet-passkey.ui.h:2
+#: data/ui/applet-passkey.ui:91
 msgid "Pairing request for device:"
 msgstr ""
 
-#: ../data/ui/applet-passkey.ui.h:3
+#: data/ui/applet-passkey.ui:120
+msgid "This should be overwritten"
+msgstr ""
+
+#: data/ui/applet-passkey.ui:140
 msgid "Show input"
 msgstr ""
 
-#. translators: toolbar item: keep it as short as possible
-#: ../data/ui/manager-main.ui.h:2
-msgid "Add"
+#: data/ui/manager-main.ui:53
+msgid "_Adapter"
 msgstr ""
 
-#: ../data/ui/manager-main.ui.h:3
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:274
-msgid "Add this device to known devices list"
+#: data/ui/manager-main.ui:61
+msgid "_Device"
 msgstr ""
 
-#: ../data/ui/manager-main.ui.h:4
-msgid "Bluetooth Devices"
+#: data/ui/manager-main.ui:69
+msgid "_View"
 msgstr ""
 
-#. translators: toolbar item: keep it as short as possible
-#: ../data/ui/manager-main.ui.h:6
-msgid "Browse"
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
+msgid "_Help"
 msgstr ""
 
-#: ../data/ui/manager-main.ui.h:7
-msgid "Browse the device using obex ftp"
-msgstr ""
-
-#: ../data/ui/manager-main.ui.h:8
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:386
-msgid "Create pairing with the device"
-msgstr ""
-
-#: ../data/ui/manager-main.ui.h:9
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:405
-msgid "Mark/Unmark this device as trusted"
-msgstr ""
-
-#. translators: toolbar item: keep it as short as possible
-#: ../data/ui/manager-main.ui.h:11
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:283
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:385
-msgid "Pair"
-msgstr ""
-
-#. translators: toolbar item: keep it as short as possible
-#: ../data/ui/manager-main.ui.h:13
-msgid "Remove"
-msgstr ""
-
-#: ../data/ui/manager-main.ui.h:14
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:442
-msgid "Remove this device from the known devices list"
-msgstr ""
-
-#: ../data/ui/manager-main.ui.h:15
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:281
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:411
-msgid "Run the setup assistant for this device"
-msgstr ""
-
-#. translators: toolbar item: keep it as short as possible
-#: ../data/ui/manager-main.ui.h:17 ../blueman/gui/manager/ManagerMenu.py:199
-msgid "Search"
-msgstr ""
-
-#: ../data/ui/manager-main.ui.h:18
+#: data/ui/manager-main.ui:96
 msgid "Search for nearby devices"
 msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
-#: ../data/ui/manager-main.ui.h:20
-msgid "Send File"
+#: data/ui/manager-main.ui:98
+msgid "Search"
 msgstr ""
 
-#: ../data/ui/manager-main.ui.h:21
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
+msgid "Create pairing with the device"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: data/ui/manager-main.ui:122
+msgid "Pair"
+msgstr ""
+
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
+msgid "Mark/Unmark this device as trusted"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
+msgid "Trust"
+msgstr ""
+
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
+msgid "Run the setup assistant for this device"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: data/ui/manager-main.ui:151
+msgid "Setup..."
+msgstr ""
+
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
+msgid "Remove this device from the known devices list"
+msgstr ""
+
+#. translators: toolbar item: keep it as short as possible
+#: data/ui/manager-main.ui:165
+msgid "Remove"
+msgstr ""
+
+#: data/ui/manager-main.ui:187
 msgid "Send file(s) to the device"
 msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
-#: ../data/ui/manager-main.ui.h:23
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:276
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:407
-msgid "Setup..."
+#: data/ui/manager-main.ui:189
+msgid "Send File"
 msgstr ""
 
-#. translators: toolbar item: keep it as short as possible
-#: ../data/ui/manager-main.ui.h:25
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:396
-#: ../blueman/gui/manager/ManagerToolbar.py:47
-#: ../blueman/gui/manager/ManagerToolbar.py:120
-msgid "Trust"
+#: data/ui/rename-device.ui:8
+msgid "Rename device"
 msgstr ""
 
-#: ../data/ui/services.ui.h:1
-msgid "Local Services"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:1
-msgid "<b>DUN Support</b>"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:2
-msgid "<b>NAP Settings</b>"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:3
-msgid "<b>Network Settings</b>"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:4
-msgid "<b>No DHCP servers installed</b>"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:5
-msgid "<b>PAN Support</b>"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:6 ../data/ui/services-audio.ui.h:3
-msgid "<b>Services</b>"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:7
-msgid "DHCP server type:"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:8
-msgid "Enable Routing (NAT)"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:9 ../blueman/Sdp.py:118
-#: ../blueman/plugins/manager/Services.py:212 ../apps/blueman-assistant:336
-msgid "Group Network"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:10
-msgid "IP Address:"
-msgstr ""
-
-#: ../data/ui/services-network.ui.h:11
+#: data/ui/services-network.ui:37
 msgid "Network Access Point (NAP)"
 msgstr ""
 
-#: ../data/ui/services-network.ui.h:12
+#: data/ui/services-network.ui:57
+msgid "<b>Services</b>"
+msgstr ""
+
+#: data/ui/services-network.ui:87
+msgid "DHCP server type:"
+msgstr ""
+
+#: data/ui/services-network.ui:114
 msgid "Recommended"
 msgstr ""
 
-#: ../data/ui/services-transfer.ui.h:1
-msgid "<b>Advanced</b>"
+#: data/ui/services-network.ui:138
+msgid "IP Address:"
 msgstr ""
 
-#: ../data/ui/services-transfer.ui.h:2
+#: data/ui/services-network.ui:181
+msgid "<b>No DHCP servers installed</b>"
+msgstr ""
+
+#: data/ui/services-network.ui:199
+msgid "udhcpd"
+msgstr ""
+
+#: data/ui/services-network.ui:218
+msgid "<b>NAP Settings</b>"
+msgstr ""
+
+#: data/ui/services-network.ui:282
+msgid "<b>PAN Support</b>"
+msgstr ""
+
+#: data/ui/services-network.ui:357
+msgid "<b>DUN Support</b>"
+msgstr ""
+
+#: data/ui/services-network.ui:391
+msgid "<b>Network Settings</b>"
+msgstr ""
+
+#: data/ui/services-transfer.ui:24
 msgid "<b>File Receiving (Object Push)</b>"
 msgstr ""
 
-#: ../data/ui/services-transfer.ui.h:3
-msgid "<b>File Sharing (FTP)</b>"
+#: data/ui/services-transfer.ui:37
+msgid "Incoming Folder:"
 msgstr ""
 
-#: ../data/ui/services-transfer.ui.h:4
-msgid "<b>Transfer Settings</b>"
+#: data/ui/services-transfer.ui:49
+msgid "Select folder for incoming file transfers"
 msgstr ""
 
-#: ../data/ui/services-transfer.ui.h:5
+#: data/ui/services-transfer.ui:58
 msgid "Accept files from trusted devices"
 msgstr ""
 
-#: ../data/ui/services-transfer.ui.h:6
-msgid "Allow devices to write/delete"
+#: data/ui/services-transfer.ui:96
+msgid "<b>Transfer Settings</b>"
 msgstr ""
 
-#: ../data/ui/services-transfer.ui.h:8
-#, no-c-format
-msgid ""
-"Command to start an obex ftp browser.\n"
-"<i>%d</i> is substituted with device address."
-msgstr ""
-
-#: ../data/ui/services-transfer.ui.h:10
-msgid "Enabled"
-msgstr ""
-
-#: ../data/ui/services-transfer.ui.h:11
-msgid "Select Shared/Storage folder"
-msgstr ""
-
-#: ../data/ui/services-transfer.ui.h:12
-msgid "Shared Folder:"
-msgstr ""
-
-#: ../data/ui/services-audio.ui.h:1
-msgid ""
-"<b>After applying these settings Bluetooth daemon will be restarted.</b>"
-msgstr ""
-
-#: ../data/ui/services-audio.ui.h:2
-msgid "<b>Audio Settings</b>"
-msgstr ""
-
-#: ../data/ui/services-audio.ui.h:4
-msgid ""
-"Advanced Audio receiver <span weight='bold' color='#cc0000'>Experimental!</"
-"span>"
-msgstr ""
-
-#: ../data/ui/services-audio.ui.h:5
-msgid "Allows this computer to act like a handsfree headset."
-msgstr ""
-
-#: ../data/ui/services-audio.ui.h:6
-msgid ""
-"Allows you to receive a2dp audio from other Bluetooth devices and play it "
-"over the speakers."
-msgstr ""
-
-#: ../data/ui/services-audio.ui.h:7
-msgid ""
-"Headset Emulation <span weight='bold' color='#cc0000'>Very Experimental!</"
-"span>"
-msgstr ""
-
-#: ../data/ui/send-dialog.ui.h:1
-msgid "<b>File:</b>"
-msgstr ""
-
-#: ../data/ui/send-dialog.ui.h:2
-msgid "<b>To:</b>"
-msgstr ""
-
-#: ../data/ui/send-dialog.ui.h:3
+#: data/ui/send-dialog.ui:32
 msgid "<span weight=\"bold\" size=\"large\">Sending files via Bluetooth</span>"
 msgstr ""
 
-#: ../data/ui/send-dialog.ui.h:4
-msgid "Bluetooth File Transfer"
+#: data/ui/send-dialog.ui:68
+msgid "<b>To:</b>"
 msgstr ""
 
-#: ../data/ui/assistant.ui.h:1
-msgid "<b>Congratulations, device successfully added</b>"
+#: data/ui/send-dialog.ui:106
+msgid "<b>File:</b>"
 msgstr ""
 
-#: ../data/ui/assistant.ui.h:2
-msgid "<b>Connect to:</b>"
-msgstr ""
-
-#: ../data/ui/assistant.ui.h:3
-msgid "<b>Please wait...</b>"
-msgstr ""
-
-#: ../data/ui/assistant.ui.h:4
-msgid "<b>Select pairing method to use:</b>"
-msgstr ""
-
-#: ../data/ui/assistant.ui.h:5
+#: data/ui/assistant.ui:16
 msgid ""
 "<b>Welcome to the Bluetooth device setup assistant. </b>\n"
 "\n"
@@ -310,531 +215,589 @@ msgid ""
 "Bluetooth enabled devices."
 msgstr ""
 
-#: ../data/ui/assistant.ui.h:9
+#: data/ui/assistant.ui:25
+msgid "Introduction"
+msgstr ""
+
+#: data/ui/assistant.ui:38
+msgid "Device"
+msgstr ""
+
+#: data/ui/assistant.ui:54
+msgid "<b>Select pairing method to use:</b>"
+msgstr ""
+
+#: data/ui/assistant.ui:65
+msgid "Pair Device"
+msgstr ""
+
+#: data/ui/assistant.ui:81
 msgid "Proceed Without Pairing"
 msgstr ""
 
-#: ../data/ui/assistant.ui.h:10
-msgid "Use Custom Passkey:"
+#: data/ui/assistant.ui:97 data/ui/assistant.ui:111
+msgid "Pairing"
 msgstr ""
 
-#: ../data/ui/assistant.ui.h:11
-msgid "Use Random Passkey"
+#: data/ui/assistant.ui:128
+msgid "<b>Connect to:</b>"
 msgstr ""
 
-#: ../data/ui/device-list-widget.ui.h:1
-msgid "Adapter selection"
+#: data/ui/assistant.ui:154
+msgid "Connect"
 msgstr ""
 
-#: ../data/ui/device-list-widget.ui.h:2
-msgid "Device search progress"
+#: data/ui/assistant.ui:161
+msgid "<b>Please wait...</b>"
 msgstr ""
 
-#: ../data/ui/device-list-widget.ui.h:3
-msgid "Search for devices"
+#: data/ui/assistant.ui:166
+msgid "Connecting..."
 msgstr ""
 
-#: ../data/ui/applet-plugins-widget.ui.h:1
-msgid "<b>Author:</b>"
+#: data/ui/assistant.ui:173
+msgid "<b>Congratulations, device successfully added</b>"
 msgstr ""
 
-#: ../data/ui/applet-plugins-widget.ui.h:2
-msgid "<b>Conflicts with:</b>"
+#: data/ui/assistant.ui:180
+msgid "Finished"
 msgstr ""
 
-#: ../data/ui/applet-plugins-widget.ui.h:3
-msgid "<b>Depends on:</b>"
-msgstr ""
-
-#: ../data/ui/applet-plugins-widget.ui.h:4
-msgid "<b>Plugin description:</b>"
-msgstr ""
-
-#: ../data/ui/applet-plugins-widget.ui.h:5
+#: data/ui/applet-plugins-widget.ui:69
 msgid "Configuration"
 msgstr ""
 
-#: ../data/ui/applet-plugins-widget.ui.h:6
+#: data/ui/applet-plugins-widget.ui:73
 msgid "Configure selected plugin's preferences"
 msgstr ""
 
-#: ../data/ui/applet-plugins-widget.ui.h:7
+#: data/ui/applet-plugins-widget.ui:115
+msgid "<b>Plugin description:</b>"
+msgstr ""
+
+#: data/ui/applet-plugins-widget.ui:130
 msgid "Not specified"
 msgstr ""
 
-#: ../data/ui/applet-plugins-widget.ui.h:8 ../blueman/Sdp.py:257
-#: ../blueman/Sdp.py:360 ../blueman/Sdp.py:365
-#: ../blueman/plugins/applet/NetUsage.py:247
-#: ../blueman/plugins/applet/NetUsage.py:248
+#: data/ui/applet-plugins-widget.ui:146
+msgid "<b>Author:</b>"
+msgstr ""
+
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
+#: blueman/plugins/applet/NetUsage.py:211
+#: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
 msgstr ""
 
-#: ../data/ui/gsm-settings.ui.h:1
+#: data/ui/applet-plugins-widget.ui:174
+msgid "<b>Depends on:</b>"
+msgstr ""
+
+#: data/ui/applet-plugins-widget.ui:202
+msgid "<b>Conflicts with:</b>"
+msgstr ""
+
+#: data/ui/gsm-settings.ui:34
 msgid "<b>GSM settings</b>"
 msgstr ""
 
-#: ../data/ui/gsm-settings.ui.h:2
-msgid "APN:"
-msgstr ""
-
-#: ../data/ui/gsm-settings.ui.h:3
+#: data/ui/gsm-settings.ui:55
 msgid "Number:"
 msgstr ""
 
-#: ../data/ui/net-usage.ui.h:1
-msgid "<b>Downloaded:</b>"
+#: data/ui/gsm-settings.ui:78
+msgid "APN:"
 msgstr ""
 
-#: ../data/ui/net-usage.ui.h:2
-msgid "<b>Log duration:</b>"
-msgstr ""
-
-#: ../data/ui/net-usage.ui.h:3
-msgid "<b>Log started:</b>"
-msgstr ""
-
-#: ../data/ui/net-usage.ui.h:4
-msgid "<b>Total:</b>"
-msgstr ""
-
-#: ../data/ui/net-usage.ui.h:5
-msgid "<b>Uploaded:</b>"
-msgstr ""
-
-#: ../data/ui/net-usage.ui.h:6
-msgid "Reset"
-msgstr ""
-
-#: ../data/ui/net-usage.ui.h:7
+#: data/ui/net-usage.ui:14
 msgid "Traffic statistics"
 msgstr ""
 
-#: ../data/ui/net-usage.ui.h:8
-msgid "gtk-close"
+#: data/ui/net-usage.ui:33
+msgid "_Close"
 msgstr ""
 
-#: ../blueman/main/applet/Transfer.py:170
-msgid "Incoming file over Bluetooth"
+#: data/ui/net-usage.ui:79
+msgid "<b>Downloaded:</b>"
 msgstr ""
 
-#: ../blueman/main/applet/Transfer.py:171
+#: data/ui/net-usage.ui:119
+msgid "<b>Uploaded:</b>"
+msgstr ""
+
+#: data/ui/net-usage.ui:159
+msgid "<b>Total:</b>"
+msgstr ""
+
+#: data/ui/net-usage.ui:196
+msgid "<b>Log started:</b>"
+msgstr ""
+
+#: data/ui/net-usage.ui:209
+msgid "<b>Log duration:</b>"
+msgstr ""
+
+#: data/ui/net-usage.ui:243
+msgid "_Reset"
+msgstr ""
+
+#: data/ui/note.ui:8
+msgid "Send note"
+msgstr ""
+
+#: blueman/main/Adapter.py:50
+msgid "Bluetooth needs to be turned on for the adapter manager to work"
+msgstr ""
+
+#: blueman/main/Adapter.py:86 data/blueman-adapters.desktop.in:3
+msgid "Bluetooth Adapters"
+msgstr ""
+
+#: blueman/main/Adapter.py:143
+msgid "Always"
+msgstr ""
+
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
-msgid "Incoming file %(0)s from %(1)s"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:172
-#: ../blueman/main/applet/BluezAgent.py:240
-msgid "Accept"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:172
-msgid "Reject"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:180
-msgid "Receiving file"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:181
-#, python-format
-msgid "Receiving file %(0)s from %(1)s"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:218
-#: ../blueman/main/applet/Transfer.py:244
-msgid "File received"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:219
-#: ../blueman/main/applet/Transfer.py:245
-#, python-format
-msgid "File %(0)s from %(1)s successfully received"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:232
-msgid "Transfer failed"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:233
-#, python-format
-msgid "Transfer of file %(0)s failed"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:251
-#: ../blueman/main/applet/Transfer.py:261
-msgid "Files received"
-msgstr ""
-
-#: ../blueman/main/applet/Transfer.py:252
-#, python-format
-msgid "Received %d file in the background"
-msgid_plural "Received %d files in the background"
+msgid "%(minutes)d Minute"
+msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../blueman/main/applet/Transfer.py:262
+#: blueman/main/Adapter.py:214
+msgid "Adapter"
+msgstr ""
+
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
+msgid "Bluetooth needs to be turned on for the device manager to function"
+msgstr ""
+
+#: blueman/main/Manager.py:109
+msgid "Connection to BlueZ failed"
+msgstr ""
+
+#: blueman/main/Manager.py:110
+msgid ""
+"Bluez daemon is not running, blueman-manager cannot continue.\n"
+"This probably means that there were no Bluetooth adapters detected or "
+"Bluetooth daemon was not started."
+msgstr ""
+
+#: blueman/main/Manager.py:198
+msgid "Searching"
+msgstr ""
+
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
+msgid "Bluetooth Assistant"
+msgstr ""
+
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
+msgid "Adapter Preferences"
+msgstr ""
+
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
+msgid "File Sender"
+msgstr ""
+
+#: blueman/main/Sendto.py:40
+msgid "Bluetooth File Transfer"
+msgstr ""
+
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
+msgid "Connecting"
+msgstr ""
+
+#: blueman/main/Sendto.py:117
+msgid "obexd not available"
+msgstr ""
+
+#: blueman/main/Sendto.py:117
+msgid "Failed to autostart obex service. Make sure the obex daemon is running"
+msgstr ""
+
+#: blueman/main/Sendto.py:146
+msgid "Cancelling"
+msgstr ""
+
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
+msgid "Sending File"
+msgstr ""
+
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
+msgid "ETA:"
+msgstr ""
+
+#: blueman/main/Sendto.py:195
 #, python-format
-msgid "Received %d more file in the background"
-msgid_plural "Received %d more files in the background"
+msgid "%(seconds)d Second"
+msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../blueman/main/applet/BluezAgent.py:125
+#: blueman/main/Sendto.py:229
+#, python-format
+msgid "Error occurred while sending file %s"
+msgstr ""
+
+#: blueman/main/Sendto.py:233
+msgid "Skip"
+msgstr ""
+
+#: blueman/main/Sendto.py:234
+msgid "Retry"
+msgstr ""
+
+#: blueman/main/Sendto.py:283
+msgid "Error occurred"
+msgstr ""
+
+#: blueman/main/Services.py:24
+msgid "Local Services"
+msgstr ""
+
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:137
-#: ../blueman/main/applet/BluezAgent.py:243
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:178
-#: ../blueman/main/applet/BluezAgent.py:261
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:179
-#: ../blueman/main/applet/BluezAgent.py:262
-msgid "Enter PIN code"
-msgstr ""
-
-#: ../blueman/main/applet/BluezAgent.py:187
-#: ../blueman/main/applet/BluezAgent.py:270
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:188
-#: ../blueman/main/applet/BluezAgent.py:271
-msgid "Enter passkey"
+#: blueman/main/applet/BluezAgent.py:257
+msgid "Pairing passkey for"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:208
+#: blueman/main/applet/BluezAgent.py:266
+msgid "Pairing PIN code for"
+msgstr ""
+
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:208
-#: ../blueman/main/applet/BluezAgent.py:287
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:209
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:209
-#: ../blueman/main/applet/BluezAgent.py:241
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:238
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:238
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:239
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:285
-msgid "Confirm value"
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
+msgid "Accept"
 msgstr ""
 
-#: ../blueman/main/applet/BluezAgent.py:286
-#, python-format
-msgid "Pairing with: %s"
-msgstr ""
-
-#: ../blueman/main/PluginManager.py:78
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
-"with the content of this message.</b>"
+"with the content of this message to our </b>\n"
+"<a href=\"http://github.com/blueman-project/blueman/issues\">website.</a>"
 msgstr ""
 
-#: ../blueman/Functions.py:77
+#: blueman/Functions.py:71
 msgid "Bluetooth Turned Off"
 msgstr ""
 
-#: ../blueman/Functions.py:81
+#: blueman/Functions.py:72
+msgid "Exit"
+msgstr ""
+
+#: blueman/Functions.py:73
 msgid "Enable Bluetooth"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerMenu.py:38
-msgid "_Adapter"
+#: blueman/Functions.py:92
+msgid "Shall bluetooth get enabled automatically?"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerMenu.py:39
-msgid "_Device"
+#: blueman/Functions.py:93
+msgid "Yes"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerMenu.py:41
-msgid "_View"
+#: blueman/Functions.py:94
+msgid "No"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerMenu.py:42
-msgid "_Help"
+#: blueman/gui/manager/ManagerMenu.py:45
+msgid "_Report a Problem"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerMenu.py:55
-msgid "Get Help Online..."
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerMenu.py:60
-msgid "Translate This Application..."
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerMenu.py:65
-msgid "Report a Problem"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerMenu.py:83
-msgid "Show Toolbar"
+#: blueman/gui/manager/ManagerMenu.py:66
+msgid "Show _Toolbar"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerMenu.py:95
-msgid "Show Statusbar"
+#: blueman/gui/manager/ManagerMenu.py:71
+msgid "Show _Statusbar"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerMenu.py:111
-msgid "Latest Device First"
+#: blueman/gui/manager/ManagerMenu.py:81
+msgid "S_ort By"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerMenu.py:115
-msgid "Latest Device Last"
+#: blueman/gui/manager/ManagerMenu.py:88
+msgid "_Name"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:451
-msgid "<b>Trusted and Bonded</b>"
+#: blueman/gui/manager/ManagerMenu.py:93
+msgid "_Added"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:453
-msgid "<b>Bonded</b>"
+#: blueman/gui/manager/ManagerMenu.py:107
+msgid "_Descending"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:455
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
+msgid "_Plugins"
+msgstr ""
+
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
+msgid "_Local Services"
+msgstr ""
+
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
+msgid "Service Preferences"
+msgstr ""
+
+#: blueman/gui/manager/ManagerMenu.py:134
+msgid "_Search"
+msgstr ""
+
+#: blueman/gui/manager/ManagerMenu.py:148
+msgid "_Preferences"
+msgstr ""
+
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
+msgid "_Exit"
+msgstr ""
+
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
+msgid "<b>Trusted and Paired</b>"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:440
+msgid "<b>Paired</b>"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:479
-#: ../blueman/gui/manager/ManagerDeviceList.py:495
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:482
-#: ../blueman/gui/manager/ManagerDeviceList.py:498
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:485
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:488
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:492
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:501
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:504
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceList.py:507
-#, python-format
-msgid ""
-"<b>Connected</b>\n"
-"Received Signal Strength: %(rssi)u%% <i>(%(rssi_state)s)</i>\n"
-"Link Quality: %(lq)u%%\n"
-"<b>Transmit Power Level: %(tpl)u%%</b> <i>(%(tpl_state)s)</i>"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceList.py:509
-#, python-format
-msgid ""
-"<b>Connected</b>\n"
-"Received Signal Strength: %(rssi)u%% <i>(%(rssi_state)s)</i>\n"
-"<b>Link Quality: %(lq)u%%</b>\n"
-"Transmit Power Level: %(tpl)u%% <i>(%(tpl_state)s)</i>"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceList.py:511
-#, python-format
-msgid ""
-"<b>Connected</b>\n"
-"<b>Received Signal Strength: %(rssi)u%%</b> <i>(%(rssi_state)s)</i>\n"
-"Link Quality: %(lq)u%%\n"
-"Transmit Power Level: %(tpl)u%% <i>(%(tpl_state)s)</i>"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:124
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:416
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:128
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:135
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:139
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:146
-msgid "Cancelled"
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
+msgid "Connecting…"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:150
-msgid "Connecting..."
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
+msgid "Disconnection Failed: "
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:269
-msgid "Add Device"
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
+msgid "Disconnecting…"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:288
-msgid "Pair with the device"
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
+msgid "_<b>Connect</b>"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:294
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:357
-msgid "Send a File..."
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
+msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:325
-msgid "<b>Connect To:</b>"
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
+msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:337
-msgid "<b>Disconnect:</b>"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:362
-msgid "Browse Device..."
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:401
-#: ../blueman/gui/manager/ManagerToolbar.py:45
-#: ../blueman/gui/manager/ManagerToolbar.py:115
-msgid "Untrust"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:421
-msgid "Fail"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:424
-msgid "Refreshing"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:426
-msgid "Refreshing Services..."
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:429
-msgid "Refresh Services"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:438
-msgid "Remove..."
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:448
-msgid "Disconnect"
-msgstr ""
-
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:449
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerDeviceMenu.py:458
-msgid "Disconnecting..."
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
+msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerProgressbar.py:32 ../apps/blueman-sendto:70
-msgid "Connecting"
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
+msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerProgressbar.py:59
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
+msgid "Send a _File…"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
+msgid "_Pair"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
+msgid "_Trust"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
+msgid "_Untrust"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
+msgid "_Set up…"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
+msgid "R_ename device…"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
+msgid "_Remove…"
+msgstr ""
+
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerStats.py:53
-#: ../blueman/gui/manager/ManagerStats.py:56
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerStats.py:66
-#: ../blueman/gui/manager/ManagerStats.py:79
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: ../blueman/gui/manager/ManagerStats.py:71
-#: ../blueman/gui/manager/ManagerStats.py:74
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: ../blueman/gui/DeviceSelectorDialog.py:27
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
+msgid "Untrust"
+msgstr ""
+
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr ""
 
-#: ../blueman/gui/MessageArea.py:60
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: ../blueman/gui/MessageArea.py:73
-msgid "Close"
-msgstr ""
-
-#: ../blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 
-#: ../blueman/gui/CommonUi.py:48
-msgid "Blueman is a GTK based Bluetooth manager"
+#: blueman/gui/CommonUi.py:60
+msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
-#: ../blueman/gui/GsmSettings.py:38
+#: blueman/gui/GsmSettings.py:26
 msgid "GSM Settings"
 msgstr ""
 
-#: ../blueman/gui/applet/PluginDialog.py:123
-#: ../blueman/plugins/applet/StandardItems.py:139
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr ""
 
-#: ../blueman/gui/applet/PluginDialog.py:216
-#: ../blueman/gui/applet/PluginDialog.py:217
-msgid "Unspecified"
-msgstr ""
-
-#: ../blueman/gui/applet/PluginDialog.py:307
-#: ../blueman/gui/applet/PluginDialog.py:327
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: ../blueman/gui/applet/PluginDialog.py:308
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -842,7 +805,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: ../blueman/gui/applet/PluginDialog.py:328
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -850,610 +813,1602 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#. translators: device class
-#: ../blueman/DeviceClass.py:36 ../blueman/DeviceClass.py:61
-msgid "uncategorized"
+#: blueman/gui/DeviceSelectorWidget.py:39
+msgid "Adapter selection"
+msgstr ""
+
+#: blueman/gui/DeviceSelectorWidget.py:45
+msgid "Discovering…"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:38
-msgid "desktop"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:40
-msgid "server"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:42
-msgid "laptop"
+#: blueman/DeviceClass.py:10
+msgid "Phone"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:44
-msgid "handheld"
+#: blueman/DeviceClass.py:12
+msgid "Access point"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:46
-msgid "palm"
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:63
-msgid "cellular"
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:65
-msgid "cordless"
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:67
-msgid "smart phone"
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:69
-msgid "modem"
+#: blueman/DeviceClass.py:22
+msgid "Toy"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:71
-msgid "isdn"
+#: blueman/DeviceClass.py:31
+msgid "Desktop"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:108
-msgid "headset"
+#: blueman/DeviceClass.py:33
+msgid "Server"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:110
-msgid "handsfree"
+#: blueman/DeviceClass.py:35
+msgid "Laptop"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:112 ../blueman/DeviceClass.py:180
-#: ../blueman/DeviceClass.py:246
-msgid "unknown"
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:114
-msgid "microphone"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:139
-msgid "keyboard"
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
 msgstr ""
 
 #. translators: device class
-#: ../blueman/DeviceClass.py:141
-msgid "pointing"
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
 msgstr ""
 
-#: ../blueman/Sdp.py:98
+#. translators: device class
+#: blueman/DeviceClass.py:52
+msgid "Smart phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+msgid "Not available"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:88
+msgid "Microphone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+msgid "Video camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+msgid "Video monitor"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+msgid "Video conferencing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+msgid "Keyboard"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+msgid "Pointing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+msgid "Combo"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+msgid "Display"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+msgid "Generic Phone"
+msgstr ""
+
+#: blueman/DeviceClass.py:170
+msgid "Generic Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:171
+msgid "Generic Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+msgid "Generic Clock"
+msgstr ""
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+msgid "Generic Remote Control"
+msgstr ""
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+msgid "Generic Tag"
+msgstr ""
+
+#: blueman/DeviceClass.py:178
+msgid "Generic Keyring"
+msgstr ""
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+msgid "Generic Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:181
+msgid "Generic Thermometer"
+msgstr ""
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+msgid "Generic Glucose Meter"
+msgstr ""
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+msgid "Generic: Cycling"
+msgstr ""
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
+msgid "SDP"
+msgstr ""
+
+#: blueman/Sdp.py:88
+msgid "UDP"
+msgstr ""
+
+#: blueman/Sdp.py:89
+msgid "RFCOMM"
+msgstr ""
+
+#: blueman/Sdp.py:90
+msgid "TCP"
+msgstr ""
+
+#: blueman/Sdp.py:91
+msgid "TCS-BIN"
+msgstr ""
+
+#: blueman/Sdp.py:92
+msgid "TCS-AT"
+msgstr ""
+
+#: blueman/Sdp.py:93
+msgid "ATT"
+msgstr ""
+
+#: blueman/Sdp.py:94
+msgid "OBEX"
+msgstr ""
+
+#: blueman/Sdp.py:95
+msgid "IP"
+msgstr ""
+
+#: blueman/Sdp.py:96
+msgid "FTP"
+msgstr ""
+
+#: blueman/Sdp.py:97
+msgid "HTTP"
+msgstr ""
+
+#: blueman/Sdp.py:98
+msgid "WSP"
+msgstr ""
+
+#: blueman/Sdp.py:99
+msgid "BNEP"
+msgstr ""
+
+#: blueman/Sdp.py:100
+msgid "UPnP/ESDP"
+msgstr ""
+
+#: blueman/Sdp.py:101
+msgid "HIDP"
+msgstr ""
+
+#: blueman/Sdp.py:102
+msgid "Hardcopy Control Channel"
+msgstr ""
+
+#: blueman/Sdp.py:103
+msgid "Hardcopy Data Channel"
+msgstr ""
+
+#: blueman/Sdp.py:104
+msgid "Hardcopy Notification"
+msgstr ""
+
+#: blueman/Sdp.py:105
+msgid "AVCTP"
+msgstr ""
+
+#: blueman/Sdp.py:106
+msgid "AVDTP"
+msgstr ""
+
+#: blueman/Sdp.py:107
+msgid "CMTP"
+msgstr ""
+
+#: blueman/Sdp.py:108
+msgid "UDI_C-Plane"
+msgstr ""
+
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
+msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgstr ""
+
+#: blueman/Sdp.py:111
+msgid "L2CAP"
+msgstr ""
+
+#: blueman/Sdp.py:112
+msgid "ServiceDiscoveryServerServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:113
+msgid "BrowseGroupDescriptorServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:114
+msgid "Public Browse Group"
+msgstr ""
+
+#: blueman/Sdp.py:115
+msgid "Serial Port"
+msgstr ""
+
+#: blueman/Sdp.py:116
+msgid "LAN Access Using PPP"
+msgstr ""
+
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: ../blueman/Sdp.py:105 ../blueman/plugins/manager/Services.py:332
-#: ../blueman/plugins/manager/Services.py:340
+#: blueman/Sdp.py:118
+msgid "IrMC Sync"
+msgstr ""
+
+#: blueman/Sdp.py:119
+msgid "OBEX Object Push"
+msgstr ""
+
+#: blueman/Sdp.py:120
+msgid "OBEX File Transfer"
+msgstr ""
+
+#: blueman/Sdp.py:121
+msgid "IrMC Sync Command"
+msgstr ""
+
+#: blueman/Sdp.py:123
+msgid "Cordless Telephony"
+msgstr ""
+
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr ""
 
-#: ../blueman/Sdp.py:106 ../blueman/plugins/manager/Services.py:307
-#: ../blueman/plugins/manager/Services.py:315
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: ../blueman/Sdp.py:117 ../blueman/plugins/manager/Services.py:223
-#: ../apps/blueman-assistant:341
+#: blueman/Sdp.py:126
+msgid "Remote Control Target"
+msgstr ""
+
+#: blueman/Sdp.py:127
+msgid "Advanced Audio"
+msgstr ""
+
+#: blueman/Sdp.py:128
+msgid "Remote Control"
+msgstr ""
+
+#: blueman/Sdp.py:129
+msgid "Video Conferencing"
+msgstr ""
+
+#: blueman/Sdp.py:130
+msgid "Intercom"
+msgstr ""
+
+#: blueman/Sdp.py:131
+msgid "Fax"
+msgstr ""
+
+#: blueman/Sdp.py:132
+msgid "Headset Audio Gateway"
+msgstr ""
+
+#: blueman/Sdp.py:133
+msgid "WAP"
+msgstr ""
+
+#: blueman/Sdp.py:134
+msgid "WAP Client"
+msgstr ""
+
+#: blueman/Sdp.py:135
+msgid "PANU"
+msgstr ""
+
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: ../blueman/plugins/manager/PulseAudioProfile.py:119
+#: blueman/Sdp.py:137
+msgid "Group Network"
+msgstr ""
+
+#: blueman/Sdp.py:138
+msgid "DirectPrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:139
+msgid "ReferencePrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:140
+msgid "Imaging (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:141
+msgid "ImagingResponder (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:142
+msgid "ImagingAutomaticArchive (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:143
+msgid "ImagingReferencedObjects (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:145
+msgid "Handsfree Audio Gateway"
+msgstr ""
+
+#: blueman/Sdp.py:146
+msgid "DirectPrintingReferenceObjectsService (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:147
+msgid "ReflectedUI (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:148
+msgid "Basic Printing (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:149
+msgid "Printing Status (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:150
+msgid "Human Interface Device Service (HID)"
+msgstr ""
+
+#: blueman/Sdp.py:151
+msgid "HardcopyCableReplacement (HCR)"
+msgstr ""
+
+#: blueman/Sdp.py:152
+msgid "HCR_Print (HCR)"
+msgstr ""
+
+#: blueman/Sdp.py:153
+msgid "HCR_Scan (HCR)"
+msgstr ""
+
+#: blueman/Sdp.py:154
+msgid "Common ISDN Access (CIP)"
+msgstr ""
+
+#: blueman/Sdp.py:155
+msgid "VideoConferencingGW (VCP)"
+msgstr ""
+
+#: blueman/Sdp.py:156
+msgid "UDI-MT"
+msgstr ""
+
+#: blueman/Sdp.py:157
+msgid "UDI-TA"
+msgstr ""
+
+#: blueman/Sdp.py:158
+msgid "Audio/Video"
+msgstr ""
+
+#: blueman/Sdp.py:159
+msgid "SIM Access (SAP)"
+msgstr ""
+
+#: blueman/Sdp.py:160
+msgid "Phonebook Access (PBAP) - PCE"
+msgstr ""
+
+#: blueman/Sdp.py:161
+msgid "Phonebook Access (PBAP) - PSE"
+msgstr ""
+
+#: blueman/Sdp.py:162
+msgid "Phonebook Access (PBAP)"
+msgstr ""
+
+#: blueman/Sdp.py:164
+msgid "Message Access Server"
+msgstr ""
+
+#: blueman/Sdp.py:165
+msgid "Message Notification Server"
+msgstr ""
+
+#: blueman/Sdp.py:166
+msgid "Message Access Profile (MAP)"
+msgstr ""
+
+#: blueman/Sdp.py:167
+msgid "GNSS"
+msgstr ""
+
+#: blueman/Sdp.py:168
+msgid "GNSS Server"
+msgstr ""
+
+#: blueman/Sdp.py:169
+msgid "3D Display"
+msgstr ""
+
+#: blueman/Sdp.py:170
+msgid "3D Glasses"
+msgstr ""
+
+#: blueman/Sdp.py:171
+msgid "3D Synchronization (3DSP)"
+msgstr ""
+
+#: blueman/Sdp.py:172
+msgid "Multi-Profile Specification (MPS) Profile"
+msgstr ""
+
+#: blueman/Sdp.py:173
+msgid "Multi-Profile Specification (MPS) Service"
+msgstr ""
+
+#: blueman/Sdp.py:174
+msgid "Calendar, Task, and Notes (CTN) Access Service"
+msgstr ""
+
+#: blueman/Sdp.py:175
+msgid "Calendar, Task, and Notes (CTN) Notification Service"
+msgstr ""
+
+#: blueman/Sdp.py:176
+msgid "Calendar, Task, and Notes (CTN) Profile"
+msgstr ""
+
+#: blueman/Sdp.py:177
+msgid "PnP Information"
+msgstr ""
+
+#: blueman/Sdp.py:178
+msgid "Generic Networking"
+msgstr ""
+
+#: blueman/Sdp.py:179
+msgid "Generic FileTransfer"
+msgstr ""
+
+#: blueman/Sdp.py:180
+msgid "Generic Audio"
+msgstr ""
+
+#: blueman/Sdp.py:181
+msgid "Generic Telephony"
+msgstr ""
+
+#: blueman/Sdp.py:182
+msgid "Video Source"
+msgstr ""
+
+#: blueman/Sdp.py:183
+msgid "Video Sink"
+msgstr ""
+
+#: blueman/Sdp.py:184
+msgid "Video Distribution"
+msgstr ""
+
+#: blueman/Sdp.py:185
+msgid "HDP"
+msgstr ""
+
+#: blueman/Sdp.py:186
+msgid "HDP Source"
+msgstr ""
+
+#: blueman/Sdp.py:187
+msgid "HDP Sink"
+msgstr ""
+
+#: blueman/Sdp.py:188
+msgid "Generic Access"
+msgstr ""
+
+#: blueman/Sdp.py:189
+msgid "Generic Attribute"
+msgstr ""
+
+#: blueman/Sdp.py:190
+msgid "Immediate Alert"
+msgstr ""
+
+#: blueman/Sdp.py:191
+msgid "Link Loss"
+msgstr ""
+
+#: blueman/Sdp.py:192
+msgid "Tx Power"
+msgstr ""
+
+#: blueman/Sdp.py:193
+msgid "Current Time Service"
+msgstr ""
+
+#: blueman/Sdp.py:194
+msgid "Reference Time Update Service"
+msgstr ""
+
+#: blueman/Sdp.py:195
+msgid "Next DST Change Service"
+msgstr ""
+
+#: blueman/Sdp.py:196
+msgid "Glucose"
+msgstr ""
+
+#: blueman/Sdp.py:197
+msgid "Health Thermometer"
+msgstr ""
+
+#: blueman/Sdp.py:198
+msgid "Device Information"
+msgstr ""
+
+#: blueman/Sdp.py:199
+msgid "Heart Rate"
+msgstr ""
+
+#: blueman/Sdp.py:200
+msgid "Phone Alert Status Service"
+msgstr ""
+
+#: blueman/Sdp.py:201
+msgid "Battery Service"
+msgstr ""
+
+#: blueman/Sdp.py:202
+msgid "Blood Pressure"
+msgstr ""
+
+#: blueman/Sdp.py:203
+msgid "Alert Notification Service"
+msgstr ""
+
+#: blueman/Sdp.py:204
+msgid "Human Interface Device"
+msgstr ""
+
+#: blueman/Sdp.py:205
+msgid "Scan Parameters"
+msgstr ""
+
+#: blueman/Sdp.py:206
+msgid "Running Speed and Cadence"
+msgstr ""
+
+#: blueman/Sdp.py:207
+msgid "Automation IO"
+msgstr ""
+
+#: blueman/Sdp.py:208
+msgid "Cycling Speed and Cadence"
+msgstr ""
+
+#: blueman/Sdp.py:209
+msgid "Cycling Power"
+msgstr ""
+
+#: blueman/Sdp.py:210
+msgid "Location and Navigation"
+msgstr ""
+
+#: blueman/Sdp.py:211
+msgid "Environmental Sensing"
+msgstr ""
+
+#: blueman/Sdp.py:212
+msgid "Body Composition"
+msgstr ""
+
+#: blueman/Sdp.py:213
+msgid "User Data"
+msgstr ""
+
+#: blueman/Sdp.py:214
+msgid "Weight Scale"
+msgstr ""
+
+#: blueman/Sdp.py:215
+msgid "Bond Management"
+msgstr ""
+
+#: blueman/Sdp.py:216
+msgid "Continuous Glucose Monitoring"
+msgstr ""
+
+#: blueman/Sdp.py:217
+msgid "Internet Protocol Support"
+msgstr ""
+
+#: blueman/Sdp.py:218
+msgid "Indoor Positioning"
+msgstr ""
+
+#: blueman/Sdp.py:219
+msgid "Pulse Oximeter"
+msgstr ""
+
+#: blueman/Sdp.py:220
+msgid "HTTP Proxy"
+msgstr ""
+
+#: blueman/Sdp.py:221
+msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+msgid "Object Transfer"
+msgstr ""
+
+#: blueman/Sdp.py:223
+msgid "AppleAgent"
+msgstr ""
+
+#: blueman/Sdp.py:224
+msgid "Primary Service"
+msgstr ""
+
+#: blueman/Sdp.py:225
+msgid "Secondary Service"
+msgstr ""
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
+msgstr ""
+
+#: blueman/Sdp.py:228
+msgid "Device Name"
+msgstr ""
+
+#: blueman/Sdp.py:229
+msgid "Appearance"
+msgstr ""
+
+#: blueman/Sdp.py:230
+msgid "Peripheral Privacy Flag"
+msgstr ""
+
+#: blueman/Sdp.py:231
+msgid "Reconnection Address"
+msgstr ""
+
+#: blueman/Sdp.py:232
+msgid "Peripheral Preferred Connection Parameters"
+msgstr ""
+
+#: blueman/Sdp.py:233
+msgid "Service Changed"
+msgstr ""
+
+#: blueman/Sdp.py:234
+msgid "System ID"
+msgstr ""
+
+#: blueman/Sdp.py:235
+msgid "Model Number String"
+msgstr ""
+
+#: blueman/Sdp.py:236
+msgid "Serial Number String"
+msgstr ""
+
+#: blueman/Sdp.py:237
+msgid "Firmware Revision String"
+msgstr ""
+
+#: blueman/Sdp.py:238
+msgid "Hardware Revision String"
+msgstr ""
+
+#: blueman/Sdp.py:239
+msgid "Software Revision String"
+msgstr ""
+
+#: blueman/Sdp.py:240
+msgid "Manufacturer Name String"
+msgstr ""
+
+#: blueman/Sdp.py:241
+msgid "PnP ID"
+msgstr ""
+
+#: blueman/Sdp.py:242
+msgid "Characteristic Extended Properties"
+msgstr ""
+
+#: blueman/Sdp.py:243
+msgid "Characteristic User Description"
+msgstr ""
+
+#: blueman/Sdp.py:244
+msgid "Client Characteristic Configuration"
+msgstr ""
+
+#: blueman/Sdp.py:245
+msgid "Server Characteristic Configuration"
+msgstr ""
+
+#: blueman/Sdp.py:246
+msgid "Characteristic Presentation Format"
+msgstr ""
+
+#: blueman/Sdp.py:247
+msgid "Characteristic Aggregate Format"
+msgstr ""
+
+#: blueman/Sdp.py:248
+msgid "Valid Range"
+msgstr ""
+
+#: blueman/Sdp.py:249
+msgid "External Report Reference"
+msgstr ""
+
+#: blueman/Sdp.py:250
+msgid "Report Reference"
+msgstr ""
+
+#: blueman/Sdp.py:377
+msgid "Auto connect profiles"
+msgstr ""
+
+#: blueman/Sdp.py:379
+msgid "Proprietary"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:21
+msgid "yes"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:21
+msgid "no"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
+msgid "_Info"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:119
+msgid "Show device information"
+msgstr ""
+
+#: blueman/plugins/manager/Notes.py:52
+msgid "Send _note"
+msgstr ""
+
+#: blueman/plugins/manager/Notes.py:53
+msgid "Send a text note"
+msgstr ""
+
+#: blueman/plugins/manager/PulseAudioProfile.py:87
 #, python-format
 msgid "Failed to change profile to %s"
 msgstr ""
 
-#: ../blueman/plugins/manager/PulseAudioProfile.py:155
+#: blueman/plugins/manager/PulseAudioProfile.py:128
 msgid "Audio Profile"
 msgstr ""
 
-#: ../blueman/plugins/manager/PulseAudioProfile.py:156
+#: blueman/plugins/manager/PulseAudioProfile.py:129
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: ../blueman/plugins/manager/Services.py:122
-msgid "Dialup Service"
-msgstr ""
-
-#: ../blueman/plugins/manager/Services.py:135
-msgid "Serial Service"
-msgstr ""
-
-#: ../blueman/plugins/manager/Services.py:150
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: ../blueman/plugins/manager/Services.py:173
-msgid "Dialup Settings"
-msgstr ""
-
-#: ../blueman/plugins/manager/Services.py:186
-msgid "Serial Ports"
-msgstr ""
-
-#: ../blueman/plugins/manager/Services.py:235
-#: ../blueman/plugins/services/Network.py:34
-#: ../blueman/plugins/services/Network.py:59
-msgid "Network"
-msgstr ""
-
-#: ../blueman/plugins/manager/Services.py:247
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: ../blueman/plugins/manager/Services.py:259
-#: ../blueman/plugins/manager/Services.py:268 ../apps/blueman-assistant:328
-msgid "Input Service"
+#: blueman/plugins/manager/Services.py:108
+msgid "Dialup Settings"
 msgstr ""
 
-#: ../blueman/plugins/manager/Services.py:283
-#: ../blueman/plugins/manager/Services.py:291 ../apps/blueman-assistant:356
-msgid "Headset Service"
+#: blueman/plugins/manager/Services.py:117
+msgid "Serial Ports"
 msgstr ""
 
-#: ../blueman/plugins/manager/Services.py:317
-msgid "Allows to send audio to remote device"
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
+msgid "Unspecified"
 msgstr ""
 
-#: ../blueman/plugins/manager/Services.py:342
-msgid "Allows to receive audio from remote device"
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
+msgid "Connected"
 msgstr ""
 
-#: ../blueman/plugins/applet/NetUsage.py:196
-#: ../blueman/plugins/applet/NetUsage.py:298
-#: ../blueman/plugins/applet/NetUsage.py:301
+#: blueman/plugins/applet/AutoConnect.py:42
+#, python-format
+msgid "Automatically connected to %(service)s on %(device)s"
+msgstr ""
+
+#: blueman/plugins/applet/NetUsage.py:156
+#: blueman/plugins/applet/NetUsage.py:265
+#: blueman/plugins/applet/NetUsage.py:270
 msgid "Connected:"
 msgstr ""
 
-#: ../blueman/plugins/applet/NetUsage.py:212
-#: ../blueman/plugins/applet/NetUsage.py:309
+#: blueman/plugins/applet/NetUsage.py:170
+#: blueman/plugins/applet/NetUsage.py:280
 msgid "Not Connected"
 msgstr ""
 
-#: ../blueman/plugins/applet/NetUsage.py:218
+#: blueman/plugins/applet/NetUsage.py:176
 msgid ""
 "No usage statistics are available yet. Try establishing a connection first "
 "and then check this page."
 msgstr ""
 
-#: ../blueman/plugins/applet/NetUsage.py:241
+#: blueman/plugins/applet/NetUsage.py:204
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../blueman/plugins/applet/NetUsage.py:242
+#: blueman/plugins/applet/NetUsage.py:205
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../blueman/plugins/applet/NetUsage.py:243
+#: blueman/plugins/applet/NetUsage.py:206
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../blueman/plugins/applet/NetUsage.py:245
+#: blueman/plugins/applet/NetUsage.py:208
 #, python-format
 msgid "%d %s %d %s and %d %s"
 msgstr ""
 
-#: ../blueman/plugins/applet/NetUsage.py:276
+#: blueman/plugins/applet/NetUsage.py:242
 msgid "Are you sure you want to reset the counter?"
 msgstr ""
 
-#: ../blueman/plugins/applet/NetUsage.py:315
+#: blueman/plugins/applet/NetUsage.py:287
 msgid ""
 "Allows you to monitor your (mobile broadband) network traffic usage. Useful "
 "for limited data access plans. This plugin tracks every device seperately."
 msgstr ""
 
-#: ../blueman/plugins/applet/NetUsage.py:333
-msgid "Network Usage"
+#: blueman/plugins/applet/NetUsage.py:307
+msgid "Network _Usage"
 msgstr ""
 
-#: ../blueman/plugins/applet/NetUsage.py:334
+#: blueman/plugins/applet/NetUsage.py:308
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: ../blueman/plugins/applet/StatusIcon.py:72
-msgid "Icon Name"
-msgstr ""
-
-#: ../blueman/plugins/applet/StatusIcon.py:73
-msgid "Custom icon to use for the notification area"
-msgstr ""
-
-#: ../blueman/plugins/applet/StatusIcon.py:90
-#: ../blueman/plugins/applet/StatusIcon.py:103
-#: ../blueman/plugins/applet/Indicator.py:106
-#: ../blueman/plugins/applet/Indicator.py:111
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: ../blueman/plugins/applet/StatusIcon.py:105
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: ../blueman/plugins/applet/Networking.py:31
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: ../blueman/plugins/applet/Networking.py:54
-#: ../blueman/plugins/services/Network.py:129
-msgid "Failed to apply network settings"
-msgstr ""
-
-#: ../blueman/plugins/applet/Networking.py:55
-msgid ""
-"You might not be able to connect to the Bluetooth network via this machine"
-msgstr ""
-
-#: ../blueman/plugins/applet/NMDUNSupport.py:85
-msgid "Bluetooth Dialup"
-msgstr ""
-
-#: ../blueman/plugins/applet/NMDUNSupport.py:86
-#, python-format
-msgid "DUN connection on %s will now be available in Network Manager"
-msgstr ""
-
-#: ../blueman/plugins/applet/NMDUNSupport.py:96
-msgid "Modem Manager did not support the connection"
-msgstr ""
-
-#: ../blueman/plugins/applet/NMDUNSupport.py:104
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
-"NetworkManager 0.8"
+"NetworkManager"
 msgstr ""
 
-#: ../blueman/plugins/applet/RecentConns.py:57
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: ../blueman/plugins/applet/RecentConns.py:64
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: ../blueman/plugins/applet/RecentConns.py:65
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: ../blueman/plugins/applet/RecentConns.py:83
-msgid "Recent Connections"
+#: blueman/plugins/applet/RecentConns.py:64
+msgid "Recent _Connections"
 msgstr ""
 
-#: ../blueman/plugins/applet/RecentConns.py:296
-#, python-format
-msgid "Connecting to %s"
-msgstr ""
-
-#: ../blueman/plugins/applet/RecentConns.py:302
-#: ../blueman/plugins/applet/PPPSupport.py:68
-msgid "Connected"
-msgstr ""
-
-#: ../blueman/plugins/applet/RecentConns.py:302
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: ../blueman/plugins/applet/RecentConns.py:308
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: ../blueman/plugins/applet/RecentConns.py:326
-#, python-format
-msgid "Network Access (%s)"
-msgstr ""
-
-#: ../blueman/plugins/applet/RecentConns.py:331
-msgid "Service"
-msgstr ""
-
-#: ../blueman/plugins/applet/RecentConns.py:343
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: ../blueman/plugins/applet/RecentConns.py:362
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: ../blueman/plugins/applet/NMPANSupport.py:182
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: ../blueman/plugins/applet/NMPANSupport.py:335
-msgid "Already connected"
-msgstr ""
-
-#: ../blueman/plugins/applet/DBusService.py:39
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: ../blueman/plugins/applet/NMMonitor.py:106
-msgid ""
-"Monitors NetworkManager's modem connections and automatically disconnects "
-"Bluetooth link after the network connection is closed"
+#: blueman/plugins/applet/TransferService.py:127
+msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: ../blueman/plugins/applet/TransferService.py:29
+#: blueman/plugins/applet/TransferService.py:128
+#, python-format
+msgid "Incoming file %(0)s from %(1)s"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:130
+msgid "Reject"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:137
+msgid "Receiving file"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:138
+#, python-format
+msgid "Receiving file %(0)s from %(1)s"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: ../blueman/plugins/applet/KillSwitch.py:33
-msgid ""
-"Toggles a platform Bluetooth killswitch when Bluetooth power state changes. "
-"Useless with USB dongles."
+#: blueman/plugins/applet/TransferService.py:180
+msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: ../blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/TransferService.py:181
+#, python-format
+msgid ""
+"Please make sure that directory \"<b>%s</b>\" exists or configure it with "
+"blueman-services. Until then the default \"%s\" will be used"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:303
+msgid "File received"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:304
+#, python-format
+msgid "File %(0)s from %(1)s successfully received"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:312
+msgid "Transfer failed"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:313
+#, python-format
+msgid "Transfer of file %(0)s failed"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
+msgid "Files received"
+msgstr ""
+
+#: blueman/plugins/applet/TransferService.py:334
+#, python-format
+msgid "Received %(files)d file in the background"
+msgid_plural "Received %(files)d files in the background"
+msgstr[0] ""
+msgstr[1] ""
+
+#: blueman/plugins/applet/TransferService.py:343
+#, python-format
+msgid "Received %(files)d more file in the background"
+msgid_plural "Received %(files)d more files in the background"
+msgstr[0] ""
+msgstr[1] ""
+
+#: blueman/plugins/applet/KillSwitch.py:37
+msgid ""
+"Switches Bluetooth killswitch status to match Bluetooth power state.Allows "
+"turning Bluetooth back on from an icon that shows its status; provided it "
+"isn't unplugged by the system, or physically."
+msgstr ""
+
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: ../blueman/plugins/applet/StandardItems.py:38
-msgid "_Setup New Device"
+#: blueman/plugins/applet/StandardItems.py:30
+msgid "_Set Up New Device"
 msgstr ""
 
-#: ../blueman/plugins/applet/StandardItems.py:45
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: ../blueman/plugins/applet/StandardItems.py:50
-msgid "_Browse Files on Device"
-msgstr ""
-
-#: ../blueman/plugins/applet/StandardItems.py:58
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: ../blueman/plugins/applet/StandardItems.py:63
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: ../blueman/plugins/applet/StandardItems.py:68
-msgid "_Local Services"
-msgstr ""
-
-#: ../blueman/plugins/applet/StandardItems.py:78
-msgid "_Plugins"
-msgstr ""
-
-#: ../blueman/plugins/applet/StandardItems.py:113 ../apps/blueman-manager:237
-msgid "Starting Bluetooth Assistant"
-msgstr ""
-
-#: ../blueman/plugins/applet/StandardItems.py:117 ../apps/blueman-manager:278
-msgid "Starting File Sender"
-msgstr ""
-
-#: ../blueman/plugins/applet/StandardItems.py:121
-msgid "Starting File Browser"
-msgstr ""
-
-#: ../blueman/plugins/applet/StandardItems.py:125
-msgid "Starting Device Manager"
-msgstr ""
-
-#: ../blueman/plugins/applet/StandardItems.py:129 ../apps/blueman-manager:269
-msgid "Starting Adapter Preferences"
-msgstr ""
-
-#: ../blueman/plugins/applet/StandardItems.py:133
-msgid "Starting Service Preferences"
-msgstr ""
-
-#: ../blueman/plugins/applet/StandardItems.py:137
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
-#: ../blueman/plugins/applet/AuthAgent.py:28
+#: blueman/plugins/applet/AuthAgent.py:8
 msgid "Provides passkey, authentication services for BlueZ daemon"
 msgstr ""
 
-#: ../blueman/plugins/applet/PulseAudio.py:139
-msgid ""
-"Automatically manages Pulseaudio Bluetooth sinks/sources.\n"
-"<b>Note:</b> Requires pulseaudio 0.9.15 or higher"
-msgstr ""
-
-#: ../blueman/plugins/applet/PulseAudio.py:146
-msgid "Make default sink"
-msgstr ""
-
-#: ../blueman/plugins/applet/PulseAudio.py:147
-msgid "Make the a2dp audio sink the default after connection"
-msgstr ""
-
-#: ../blueman/plugins/applet/PulseAudio.py:150
-msgid "Move streams"
-msgstr ""
-
-#: ../blueman/plugins/applet/PulseAudio.py:151
-msgid "Move existing audio streams to bluetooth device"
-msgstr ""
-
-#: ../blueman/plugins/applet/PulseAudio.py:312
-#: ../blueman/plugins/applet/PulseAudio.py:317
-msgid "Bluetooth Audio"
-msgstr ""
-
-#: ../blueman/plugins/applet/PulseAudio.py:313
-msgid ""
-"Failed to initialize PulseAudio Bluetooth module. Bluetooth audio over "
-"PulseAudio will not work."
-msgstr ""
-
-#: ../blueman/plugins/applet/PulseAudio.py:318
-msgid ""
-"Successfully connected to a Bluetooth audio device. This device will now be "
-"available in the PulseAudio mixer"
-msgstr ""
-
-#: ../blueman/plugins/applet/ExitItem.py:24
+#: blueman/plugins/applet/ExitItem.py:7
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: ../blueman/plugins/applet/DhcpClient.py:26
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: ../blueman/plugins/applet/DhcpClient.py:63
-#: ../blueman/plugins/applet/DhcpClient.py:71
-#: ../blueman/plugins/applet/DhcpClient.py:77
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: ../blueman/plugins/applet/DhcpClient.py:63
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: ../blueman/plugins/applet/DhcpClient.py:71
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: ../blueman/plugins/applet/DhcpClient.py:77
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
-"Please wait..."
+"Please wait…"
 msgstr ""
 
-#: ../blueman/plugins/applet/NMIntegration.py:39
-msgid ""
-"<b>Deprecated</b>\n"
-"Makes DUN/PAN connections available for NetworkManager 0.7"
-msgstr ""
-
-#: ../blueman/plugins/applet/NMIntegration.py:79
-msgid "CDMA or GSM not supported"
-msgstr ""
-
-#: ../blueman/plugins/applet/NMIntegration.py:80
-#, python-format
-msgid ""
-"The device %s does not appear to support GSM/CDMA.\n"
-"This connection will not work."
-msgstr ""
-
-#: ../blueman/plugins/applet/Indicator.py:31
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: ../blueman/plugins/applet/Indicator.py:35
-msgid "Show overlay icon"
-msgstr ""
-
-#: ../blueman/plugins/applet/Indicator.py:36
-msgid "Whether to show a composition over the status icon when connected"
-msgstr ""
-
-#: ../blueman/plugins/applet/Indicator.py:96
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: ../blueman/plugins/applet/Indicator.py:98
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
-msgid "<b>%d Active Connection</b>"
-msgid_plural "<b>%d Active Connections</b>"
+msgid "<b>%(connections)d Active Connection</b>"
+msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../blueman/plugins/applet/Headset.py:26
-msgid "Runs a command when answer button is pressed on a headset"
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
 msgstr ""
 
-#: ../blueman/plugins/applet/Headset.py:32
-msgid "Command"
+#: blueman/plugins/applet/AppIndicator.py:17
+msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: ../blueman/plugins/applet/Headset.py:33
-msgid "Command to execute when answer button is pressed:"
-msgstr ""
-
-#: ../blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: ../blueman/plugins/applet/DiscvManager.py:37
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: ../blueman/plugins/applet/DiscvManager.py:38
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: ../blueman/plugins/applet/DiscvManager.py:46
-#: ../blueman/plugins/applet/DiscvManager.py:142
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: ../blueman/plugins/applet/DiscvManager.py:54
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: ../blueman/plugins/applet/DiscvManager.py:80
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
-msgid "Discoverable... %ss"
+msgid "Discoverable… %ss"
 msgstr ""
 
-#: ../blueman/plugins/applet/Menu.py:27
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: ../blueman/plugins/applet/PPPSupport.py:68
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: ../blueman/plugins/applet/PPPSupport.py:75
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: ../blueman/plugins/applet/SerialManager.py:39
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: ../blueman/plugins/applet/SerialManager.py:43
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: ../blueman/plugins/applet/SerialManager.py:44
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -1464,311 +2419,145 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: ../blueman/plugins/applet/SerialManager.py:77
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: ../blueman/plugins/applet/SerialManager.py:78
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: ../blueman/plugins/applet/SerialManager.py:123
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: ../blueman/plugins/applet/SerialManager.py:124
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: ../blueman/plugins/applet/PowerManager.py:30
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: ../blueman/plugins/applet/PowerManager.py:53
-msgid "<b>Bluetooth Off</b>"
+#: blueman/plugins/applet/PowerManager.py:44
+msgid "Auto power-on"
 msgstr ""
 
-#: ../blueman/plugins/applet/PowerManager.py:54
-#: ../blueman/plugins/applet/PowerManager.py:196
-msgid "<b>Turn Bluetooth Off</b>"
+#: blueman/plugins/applet/PowerManager.py:45
+msgid "Automatically power on adapters"
 msgstr ""
 
-#: ../blueman/plugins/applet/PowerManager.py:56
-#: ../blueman/plugins/applet/PowerManager.py:197
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
+msgid "<b>Turn Bluetooth _Off</b>"
+msgstr ""
+
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: ../blueman/plugins/applet/PowerManager.py:184
-msgid "<b>Turn Bluetooth On</b>"
+#: blueman/plugins/applet/PowerManager.py:162
+msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: ../blueman/plugins/applet/PowerManager.py:185
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: ../blueman/plugins/services/Network.py:152
+#: blueman/plugins/applet/GameControllerWakelock.py:19
+msgid ""
+"Temporarily suspends the screensaver when a bluetooth game controller is "
+"connected."
+msgstr ""
+
+#: blueman/plugins/services/Network.py:25
+msgid "Network"
+msgstr ""
+
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: ../blueman/plugins/services/Network.py:164
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: ../blueman/plugins/services/Network.py:169
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
-"configuration %s/%s\n"
+"configuration  %s/%s\n"
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: ../blueman/plugins/services/Network.py:314
-#: ../blueman/plugins/services/Network.py:317
-#: ../blueman/plugins/services/Network.py:323
-#: ../blueman/plugins/services/Network.py:329
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
-#: ../blueman/plugins/services/Audio.py:33
-msgid "Audio"
-msgstr ""
-
-#: ../blueman/plugins/services/Transfer.py:30
+#: blueman/plugins/services/Transfer.py:15
 msgid "Transfer"
 msgstr ""
 
-#: ../blueman/plugins/services/Transfer.py:46
+#: blueman/plugins/services/Transfer.py:30
 msgid "Applet's transfer service plugin is disabled"
 msgstr ""
 
-#: ../blueman/plugins/services/Transfer.py:135 ../apps/blueman-sendto:110
-msgid "obex-data-server not available"
+#: data/blueman-adapters.desktop.in:4
+msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: ../data/blueman.desktop.in.h:1
+#: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
 
-#: ../data/blueman.desktop.in.h:2 ../data/blueman-manager.desktop.in.h:1
+#: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr ""
 
-#: ../data/blueman-manager.desktop.in.h:2
+#: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
 msgstr ""
 
-#: ../data/configs/org.blueman.policy.in.h:1
-msgid "Bluetooth Configuration"
+#: data/thunar-sendto-blueman.desktop.in:5
+msgid "Bluetooth Device"
 msgstr ""
 
-#: ../data/configs/org.blueman.policy.in.h:2
-msgid "Changing Bluetooth system settings requires privileges"
-msgstr ""
-
-#: ../data/configs/org.blueman.policy.in.h:3
-msgid "Configure Bluetooth Modems"
-msgstr ""
-
-#: ../data/configs/org.blueman.policy.in.h:4
+#: data/configs/org.blueman.policy.in:10
 msgid "Configure Bluetooth Network"
 msgstr ""
 
-#: ../data/configs/org.blueman.policy.in.h:5
+#: data/configs/org.blueman.policy.in:11
 msgid "Configuring networking requires privileges"
 msgstr ""
 
-#: ../data/configs/org.blueman.policy.in.h:6
+#: data/configs/org.blueman.policy.in:19
 msgid "Launch DHCP client"
 msgstr ""
 
-#: ../data/configs/org.blueman.policy.in.h:7
+#: data/configs/org.blueman.policy.in:20
 msgid "Launching DHCP client requires privileges"
 msgstr ""
 
-#: ../data/configs/org.blueman.policy.in.h:8
-msgid "System policy prevents modifying the configuration"
+#: data/configs/org.blueman.policy.in:28
+msgid "Launch PPP daemon"
 msgstr ""
 
-#: ../data/configs/org.blueman.policy.in.h:9
-msgid "The Blueman Project"
+#: data/configs/org.blueman.policy.in:29
+msgid "Launching PPP daemon requires privileges"
 msgstr ""
 
-#: ../apps/blueman-manager:106
-msgid "Bluetooth needs to be turned on for the device manager to function"
+#: data/configs/org.blueman.policy.in:37
+msgid "Set RfKill State"
 msgstr ""
 
-#: ../apps/blueman-manager:116
-msgid "Connection to BlueZ failed"
-msgstr ""
-
-#: ../apps/blueman-manager:118
-msgid ""
-"Bluez daemon is not running, blueman-manager cannot continue.\n"
-"This probably means that there were no Bluetooth adapters detected or "
-"Bluetooth daemon was not started."
-msgstr ""
-
-#: ../apps/blueman-manager:205 ../apps/blueman-assistant:276
-msgid "Adding"
-msgstr ""
-
-#: ../apps/blueman-manager:225
-msgid "Searching"
-msgstr ""
-
-#: ../apps/blueman-manager:244
-msgid "Success"
-msgstr ""
-
-#: ../apps/blueman-manager:249
-msgid "Failure"
-msgstr ""
-
-#: ../apps/blueman-manager:257
-msgid "Pairing"
-msgstr ""
-
-#: ../apps/blueman-adapters:55
-msgid "Bluetooth needs to be turned on for the adapter manager to work"
-msgstr ""
-
-#: ../apps/blueman-adapters:143
-msgid "Always"
-msgstr ""
-
-#: ../apps/blueman-adapters:147
-#, c-format
-msgid "%d Minute"
-msgid_plural "%d Minutes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../apps/blueman-sendto:111
-msgid "obex-data-server is probably not installed"
-msgstr ""
-
-#: ../apps/blueman-sendto:139
-msgid "Error occurred"
-msgstr ""
-
-#: ../apps/blueman-sendto:155
-msgid "Cancelling"
-msgstr ""
-
-#: ../apps/blueman-sendto:175 ../apps/blueman-sendto:209
-msgid "Sending File"
-msgstr ""
-
-#: ../apps/blueman-sendto:175 ../apps/blueman-sendto:209
-msgid "ETA:"
-msgstr ""
-
-#: ../apps/blueman-sendto:203
-#, c-format
-msgid "%.0f Minute"
-msgid_plural "%.0f Minutes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../apps/blueman-sendto:205
-#, c-format
-msgid "%.0f Second"
-msgid_plural "%.0f Seconds"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../apps/blueman-sendto:261
-#, c-format
-msgid "Error occurred while sending file %s"
-msgstr ""
-
-#: ../apps/blueman-sendto:265
-msgid "Skip"
-msgstr ""
-
-#: ../apps/blueman-sendto:266
-msgid "Retry"
-msgstr ""
-
-#: ../apps/blueman-sendto:316
-msgid "Send files to this device"
-msgstr ""
-
-#: ../apps/blueman-sendto:323
-msgid "Bluetooth needs to be turned on for file sending to work"
-msgstr ""
-
-#: ../apps/blueman-sendto:377
-msgid "Select files to send"
-msgstr ""
-
-#: ../apps/blueman-assistant:61
-msgid "Start configuration assistant for this device"
-msgstr ""
-
-#: ../apps/blueman-assistant:65
-msgid "Bluetooth needs to be turned on for the Bluetooth assistant to work"
-msgstr ""
-
-#: ../apps/blueman-assistant:79
-msgid "Bluetooth Assistant"
-msgstr ""
-
-#: ../apps/blueman-assistant:131
-msgid "No adapters found"
-msgstr ""
-
-#: ../apps/blueman-assistant:275
-msgid "<b>Adding Device...</b>"
-msgstr ""
-
-#: ../apps/blueman-assistant:281
-#, c-format
-msgid ""
-"<b>Pairing in progress...</b>\n"
-"\n"
-"Enter passkey <b>%s</b> on the device."
-msgstr ""
-
-#: ../apps/blueman-assistant:293
-msgid "<b>Failed to add device</b>"
-msgstr ""
-
-#: ../apps/blueman-assistant:346
-msgid "A2DP Sink (Send Audio)"
-msgstr ""
-
-#: ../apps/blueman-assistant:351
-msgid "A2DP Source (Receive Audio)"
-msgstr ""
-
-#: ../apps/blueman-assistant:360
-msgid "Don't connect"
-msgstr ""
-
-#: ../apps/blueman-assistant:375
-msgid "<b>Device added and connected successfuly</b>"
-msgstr ""
-
-#: ../apps/blueman-assistant:381
-msgid "<b>Device added successfuly, but failed to connect</b>"
-msgstr ""
-
-#: ../apps/blueman-browse:47
-msgid "Browse this device"
-msgstr ""
-
-#: ../apps/blueman-browse:74
-#, c-format
-msgid "Failed to launch \"%s\""
-msgstr ""
-
-#: ../apps/blueman-browse:75
-msgid "You can enter an alternate browser in service settings"
+#: data/configs/org.blueman.policy.in:38
+msgid "Setting RfKill State requires privileges"
 msgstr ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Bosnian (http://www.transifex.com/mate/MATE/language/bs/)\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr ""
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Sakriven"
 
@@ -67,8 +67,8 @@ msgstr "_Uređaj"
 msgid "_View"
 msgstr "_Pogled"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Pomoć"
 
@@ -81,7 +81,7 @@ msgstr "Traži za uređaje u blizini"
 msgid "Search"
 msgstr "Pretraga"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -90,17 +90,17 @@ msgstr ""
 msgid "Pair"
 msgstr "Par"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Povjerenje"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr ""
 
@@ -109,7 +109,7 @@ msgstr ""
 msgid "Setup..."
 msgstr "Podešavanje..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Ukloni ovaj uređaj sa liste poznatih uređaja"
 
@@ -284,7 +284,12 @@ msgstr "Nije specificirano"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -346,7 +351,7 @@ msgstr "_Resetuj"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -354,33 +359,31 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth Adapteri"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Uvijek"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minuta"
 msgstr[1] "%d Minute"
 msgstr[2] "%d Minuta"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Neuspjela konekcija na BlueZ"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -391,48 +394,48 @@ msgstr ""
 msgid "Searching"
 msgstr "Traženje"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transfer Bluetooth Daoteke"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Povezivanje"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Otpremanje Datoteke"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -440,94 +443,86 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Preskoči"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Pokušaj ponovo"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Došlo je do greške"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokalne Usluge"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Unesite PIN kod"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Potvrdi"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Zabrani"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Usluga:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Uvijek prihvati"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Prihvati"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -558,239 +553,238 @@ msgstr "Da"
 msgid "No"
 msgstr "Ne"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Prijavi problem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Upravitelj uređajima"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Prikaži _Alatnu traku"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Priključci"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokalne Usluge"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Traži"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "nekategorizovano"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Slab"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimalno"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Puno"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Previše"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Nisko"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Visoko"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Veoma visoko"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Uspjeh!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Neuspješno"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Neuspjela Veza: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Povezivanje"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Connecting"
 msgid "Disconnecting…"
 msgstr "Povezivanje"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Spoji Na:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Odpoji:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Pošalji _Fajl..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Preimenuj uređaj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Ukloni"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Poništi operaciju"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Odaberi Uređaj"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Još"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -798,7 +792,7 @@ msgstr ""
 "  Sanel https://launchpad.net/~sanel-bih\n"
 "  kenan3008 https://launchpad.net/~kenan3008"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -806,17 +800,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr "GSM Postavke"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Priključci"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -824,7 +818,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -832,870 +826,1247 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Selekcija adaptera"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "nekategorizovano"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Prihvati"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "radna površina"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "ručni"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobilni"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "bežični"
 
 #. translators: device class
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
+msgstr "mikrofon"
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
+msgstr "modem"
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
+msgid "50-67 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
-msgstr "modem"
+msgid "67-83 percent"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+msgid "83-99 percent"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "slušalice"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "nepoznato"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Izvor Zvuka"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Izvor Zvuka"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Izvor Zvuka"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tastatura"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "Povezivanje"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tastatura"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Grupna Mreža"
+
+#: blueman/DeviceClass.py:170
+msgid "Generic Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:171
+msgid "Generic Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Grupna Mreža"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Transfer Bluetooth Daoteke"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Grupna Mreža"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Transfer Bluetooth Daoteke"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Transfer Bluetooth Daoteke"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Grupna Mreža"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transfer Bluetooth Daoteke"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Transfer Bluetooth Daoteke"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Transfer Bluetooth Daoteke"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transfer Bluetooth Daoteke"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+msgid "Generic Glucose Meter"
+msgstr ""
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Grupna Mreža"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Transfer Bluetooth Daoteke"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "slušalice"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Izvor Zvuka"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Grupna Mreža"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Grupna Mreža"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Transfer Bluetooth Daoteke"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Izvor Zvuka"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Izvor Zvuka"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Preimenuj uređaj"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Lokalne Usluge"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Transfer"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "aplet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Lokalne Usluge"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Traži za uređaje u blizini"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Transfer"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "aplet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Local Services"
-msgid "Primary Service"
-msgstr "Lokalne Usluge"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Traži za uređaje u blizini"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Upravitelj uređajima"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Renew IP Address"
 msgid "Reconnection Address"
 msgstr "Obnovi IP Adresu"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Upravitelj uređajima"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "da"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "ne"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1720,34 +2091,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Obnovi IP Adresu"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nespecificirano"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Povezan"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1813,134 +2185,129 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Osposobljen"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "BLuetooth Onesposobljen"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Povezan s %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Neuspjelo povezivanje"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Odbaci"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Prijem datoteke"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Datoteka primljena"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Datoteka %(0)s od %(1)s uspješno primljena"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Transfer nije uspio"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Neuspio transfer datoteke %(0)s"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Primljene datoteke"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
@@ -1948,7 +2315,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1963,27 +2330,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Uređaj"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_teri"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "aplet"
 
@@ -1995,44 +2362,44 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth Mreža"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth je Aktivan"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
@@ -2040,63 +2407,69 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "BLuetooth Onesposobljen"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2107,78 +2480,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Isključi sve adaptere"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Uključi sve adaptere"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Mreža"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2186,8 +2558,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2201,40 +2573,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Adapteri"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "aplet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth Osposobljen"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Osposobljen"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth Uređaji"
 
@@ -2269,6 +2627,21 @@ msgstr ""
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr ""
+
+#~ msgid "Enter PIN code"
+#~ msgstr "Unesite PIN kod"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "slušalice"
+
+#~ msgid "unknown"
+#~ msgstr "nepoznato"
 
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth Uređaji"

--- a/po/ca.po
+++ b/po/ca.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-12 09:11+0000\n"
 "Last-Translator: Sergi Almacellas Abellana <sergi@koolpi.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Ajusts de visibilitat</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Ocult"
 
@@ -70,8 +70,8 @@ msgstr "_Dispositiu"
 msgid "_View"
 msgstr "_Vista"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Ajuda"
 
@@ -84,7 +84,7 @@ msgstr "Cerca els dispositius que estiguin a prop"
 msgid "Search"
 msgstr "Cerca"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Crea l'aparellament amb el dispositiu"
 
@@ -93,17 +93,17 @@ msgstr "Crea l'aparellament amb el dispositiu"
 msgid "Pair"
 msgstr "Aparella"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Marca o desmarca aquest dispositiu com de confiança"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Confia"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Executa l'assistent de configuració per a aquest dispositiu"
 
@@ -112,7 +112,7 @@ msgstr "Executa l'assistent de configuració per a aquest dispositiu"
 msgid "Setup..."
 msgstr "Configura..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Suprimeix aquest dispositiu dels dispositius coneguts"
 
@@ -294,7 +294,12 @@ msgstr "no especificat"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -356,7 +361,7 @@ msgstr "_Restableix"
 msgid "Send note"
 msgstr "Envia una nota"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth ha d'estar encès perquè funcioni el gestor d'adaptadors"
 
@@ -364,32 +369,30 @@ msgstr "Bluetooth ha d'estar encès perquè funcioni el gestor d'adaptadors"
 msgid "Bluetooth Adapters"
 msgstr "Adaptadors Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Sempre"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minut"
 msgstr[1] "%d minuts"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptador"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth ha d'estar encès perquè funcioni el gestor de dispositius"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Ha fallat la connexió a BlueZ "
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -403,144 +406,136 @@ msgstr ""
 msgid "Searching"
 msgstr "S'està cercant"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Assistent de Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Preferències de l'adaptador"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Eina d'enviament de fitxers"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transferència de fitxers Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "S'està connectant"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd no està disponible"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Ha fallat el inici automàtic del serveix obex. Asegureu-vos que el servei "
 "s'està executant"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "S'està cancel·lant"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "S'està enviant el fitxer"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Aprox.:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "S'ha produït un error mentre s'enviava el fitxer %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Omet"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Torna-ho a intentar"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "S'ha produït un error"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Serveis locals"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Sol·licitud d'aparellament per %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autenticació Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Introdueix el codi PIN per a l'autenticació:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Introdueix el codi PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Introdueix la contrasenya per a l'autenticació:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Introdueix la contrasenya"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Contrasenya per aparellar"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Codi PIN per aparellar"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Sol·licitud d'aparellament per:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirma el valor per a l'autenticació:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirma"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Denega"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Sol·licitud d'autenticació per:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Servei:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Accepta sempre"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Accepta"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -574,251 +569,248 @@ msgstr "Sí"
 msgid "No"
 msgstr "No"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "Informa d'un p_roblema"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Gestor de dispositius"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Mos_tra la barra d'eines"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Mo_stra la barra d'estat"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_Ordena per"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nom"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Afegit"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Descendent"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Connectors"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Serveis _locals"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferències del servei"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Cerca"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Preferències de l'adaptador"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Surt"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "Sense classificar"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Confiat i emparellat</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Emparellat</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Confiança</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Pobra"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Per sota d'òptima"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Òptima"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Molta"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Massa"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Baixa"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Alta"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Molt alta"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Èxit!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Port sèrie connectat a %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Ha fallat"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "No s'ha pogut connectar:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "S'està connectant"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "No s'ha pogut desconnectar:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "S'està desconnectant..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Connecta als orígens A2DP dels perfils de connexió automàtica, enfonsament "
 "A2DP, i HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Desconnecta forçadament el dispositiu"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Connecta a:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Desconnecta:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Envia un _fitxer..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "Em_parella"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "C_onfia"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "De_sconfia"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Reanomena el dispositiu"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Suprimeix"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Cancel·la l'operació"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indicador d'activitat de dades"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "El nombre total de dades rebudes i la relació de transmissió"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "El nombre total de dades enviades i la relació de transmissió"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Desconfia"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Selecciona el dispositiu"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Més"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Francesc Famadas <kiski97@gmail.com>\n"
 "Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman és un gestor de Bluetooth GTK+"
 
@@ -826,17 +818,17 @@ msgstr "Blueman és un gestor de Bluetooth GTK+"
 msgid "GSM Settings"
 msgstr "Ajusts GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Connectors"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Qüestió de dependència"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -847,7 +839,7 @@ msgstr ""
 "<b>%(1)s</b> també descarregarà <b>\"%(0)s\"</b>.\n"
 "Voleu procedir?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -857,886 +849,1259 @@ msgstr ""
 "El connector <b>%(0)s</b> entra en conflicte amb <b>%(1)s</b>. El fet de "
 "carregar <b>%(1)s</b> descarregarà <b>\"%(0)s\"</b>. Voleu procedir?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Selecció de l'adaptador"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Mode de detecció… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "Sense classificar"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Punt d'accés de xarxa"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "escriptori"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "servidor"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "ordinador portàtil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "de mà"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "telèfon mòbil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "sense fil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "telèfon intel·ligent"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "mòdem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "XDSI"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd no està disponible"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "auricular"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "mans lliures"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "Desconegut"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "micròfon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Origen d'àudio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Origen d'àudio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Origen d'àudio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "teclat"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "punter"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "teclat"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "punter"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Connecta"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Connecta"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Connecta"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Connecta"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Transferència de fitxers Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Connecta"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Transferència de fitxers Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Transferència de fitxers Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Grup xarxa"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transferència de fitxers Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Connecta"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Connecta"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transferència de fitxers Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Connecta"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Grup xarxa"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Ports sèries"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Accés a xarxes a través de línia telefònica (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Transferència de fitxers Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "auricular"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Origen d'àudio"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Conducte de l'àudio"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Punt d'accés de xarxa"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Grup xarxa"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "mans lliures"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "NAP (Network Access Point)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "NAP (Network Access Point)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Grup xarxa"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Transferència de fitxers Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Origen d'àudio"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Conducte de l'àudio"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Origen d'àudio"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Reanomena el dispositiu"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Mostra la informació del dispositiu"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Serveis locals"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Transfereix"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "miniaplicació"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Aparella el dispositiu"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Cerca els dispositius que estiguin a prop"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Transfereix"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "miniaplicació"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Aparella el dispositiu"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Cerca els dispositius que estiguin a prop"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Gestor de dispositius"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "_Connexions recents"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Gestor de dispositius"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Preferències de l'adaptador"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Perfils de connexió automàtica"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Propietari"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "sí"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "no"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Informació"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Mostra la informació del dispositiu"
 
@@ -1761,34 +2126,35 @@ msgstr "Perfil d'àudio"
 msgid "Select audio profile for PulseAudio"
 msgstr "Selecciona el perfil d'àudio per a PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Port sèrie %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Renova l'adreça IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Ajusts de l'accés a través de línia telefònica"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Ports sèries"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Sense especificar"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Connectat"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Connectat automàticament a %(service)s a %(device)s"
@@ -1856,22 +2222,17 @@ msgstr "Ús de la _xarxa"
 msgid "Shows network traffic usage"
 msgstr "Mostra l'ús del trànsit de xarxa"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth habilitat"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth inhabilitat"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Gestiona els serveis de la xarxa local, com ara els ponts NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1879,7 +2240,7 @@ msgstr ""
 "Proporciona compatibilitat DUN (Dial Up Networking) amb ModemManager i "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1887,38 +2248,38 @@ msgstr ""
 "per a un ràpid accés"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Nombre màxim d'elements"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "El nombre màxim d'opcions al menú de connexions recents que es mostrarà."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Connexions recents"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "S'ha connectat a %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "No s'ha pogut connectar"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s a %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "L'adaptador per a aquesta connexió no està disponible"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1926,41 +2287,41 @@ msgstr ""
 "Proporciona compatibilitat per a PAN (Personal Area Networking) que es va "
 "presentar amb NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Proporciona l'API de DBus per als altres components de Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Fitxer entrant a través de Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Fitxer entrant %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Refusa"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "S'està rebent el fitxer"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "S'està rebent el fitxer %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Proporciona les capacitats de transferència de fitxers OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "El directori configurat per als fitxers entrants no existeix"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1970,42 +2331,38 @@ msgstr ""
 "blueman-services. Fins que no ho feu s'utilitzara la carpeta per defecte \"%s"
 "\""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "S'ha rebut el fitxer"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "El fitxer %(0)s de %(1)s s'ha rebut correctament"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Ha fallat la transferència"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Ha fallat la transferència del fitxer %(0)s"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "S'han rebut els fitxers"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "S'ha rebut %d fitxer en segon pla"
 msgstr[1] "S'han rebut %d fitxers en segon pla"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "S'ha rebut %d fitxer més en segon pla"
@@ -2018,27 +2375,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Afegeix les opcions de menú estàndards al menú de la icona d'estat"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "Configura un dispo_sitiu nou"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Envia _fitxers al dispositiu"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Dispositius"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_tadors"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "miniaplicació"
 
@@ -2051,28 +2408,28 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Afegeix una opció al menú per sortir de la miniaplicació"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 "Proporciona un client bàsic de dhcp per a les connexions PAN de Bluetooth."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Xarxa Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "La interfície %(0)s es vincula a l'adreça IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "No s'ha pogut obtenir l'adreça IP a %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2081,7 +2438,7 @@ msgstr ""
 "S'està intentant d'obtenir una adreça IP a %s\n"
 "Espereu…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2089,24 +2446,27 @@ msgstr ""
 "Afegeix una indicació a la icona d'estat quan Bluetooth està actiu i mostra "
 "el nombre de connexions a la informació emergent."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth actiu"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d connexió activa</b>"
 msgstr[1] "<b>%d connexions actives</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth inhabilitat"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Utilitza libappindicator per mostrar una icona d'estat"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2114,35 +2474,36 @@ msgstr ""
 "Proporciona una opció al menú per fer visible temporalment l'adaptador per "
 "defecte quan s'estableix a ocult per defecte"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Temps d'expiració del mode de detecció"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Quantitat de temps en segons que durarà el mode de detecció"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Habilita el _mode de detecció"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Fes temporalment visible l'adaptador predeterminat"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Mode de detecció… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Proporciona un menú per a la miniaplicació i una API perquè els altres "
 "connectors ho puguin manipular"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2151,24 +2512,24 @@ msgstr ""
 "S'ha connectat correctament al servei <b>DUN</b> a <b>%(0)s.</b>\n"
 "La xarxa està disponible ara a través de <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Proporciona compatibilitat bàsica per a la connexió a Internet a través del "
 "perfil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "El gestor de connexions de perfils estàndards SPP, permet executar accions "
 "personalitzades"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script a executar en connectar"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2187,11 +2548,11 @@ msgstr ""
 "Després de la desconnexió del dispositiu, l'script enviarà un senyal HUP</"
 "span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Port sèrie connectat"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2199,11 +2560,11 @@ msgstr ""
 "El servei de port sèrie al dispositiu <b>%s</b> ara estarà disponible a "
 "través de <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Ha fallat l'script de connexió del port sèrie"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2212,37 +2573,37 @@ msgstr ""
 "S'ha produït un error en llançar l'script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Controla els estats d'alimentació de l'adaptador Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Engega automàticament"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Engega automàticament els adaptadors"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Apaga el Bluet_ooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Apaga tots els adaptadors"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Engega el Bluet_ooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Engega tots els adaptadors"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2250,22 +2611,21 @@ msgstr ""
 "Suspèn temporalment l'estalvi de pantalla quan es connecta un dispositiu de "
 "joc Bluetooth."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Xarxa"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Adreça IP no vàlida"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "L'adreça IP entra en conflicte amb la interfície %s, que té la mateixa adreça"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2276,8 +2636,8 @@ msgstr ""
 "següent configuració  %s/%s\n"
 "Aixo pot causar un comportament incorrecte de la xarxa"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Actualment no és compatible amb aquesta configuració"
 
@@ -2291,40 +2651,26 @@ msgstr "El connector de transferència de la miniaplicació està inhabilitat"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptadors Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "miniaplicació"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman és un gestor de Bluetooth GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth habilitat"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Dispositius Bluetooth"
 
@@ -2360,6 +2706,31 @@ msgstr "Estableix l'estat RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "El fet d'establir l'estat RfKill requereix privilegis"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Introdueix el codi PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Introdueix la contrasenya"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Port sèrie connectat a %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "XDSI"
+
+#~ msgid "headset"
+#~ msgstr "auricular"
+
+#~ msgid "handsfree"
+#~ msgstr "mans lliures"
+
+#~ msgid "unknown"
+#~ msgstr "Desconegut"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Dispositius Bluetooth"
 
@@ -2380,11 +2751,6 @@ msgstr "El fet d'establir l'estat RfKill requereix privilegis"
 
 #~ msgid "_Remove..."
 #~ msgstr "Sup_rimeix..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Connecta"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/cs.po
+++ b/po/cs.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Czech (http://www.transifex.com/mate/MATE/language/cs/)\n"
@@ -36,7 +36,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Nastavení viditelnosti</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Skryté"
 
@@ -80,8 +80,8 @@ msgstr "_Zařízení"
 msgid "_View"
 msgstr "_Zobrazit"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Nápověda"
 
@@ -94,7 +94,7 @@ msgstr "Hledat zařízení v dosahu"
 msgid "Search"
 msgstr "Vyhledávání"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Vytvořit párování se zařízením"
 
@@ -103,17 +103,17 @@ msgstr "Vytvořit párování se zařízením"
 msgid "Pair"
 msgstr "Pár"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Označit/Odznačit toto zařízení jako důvěryhodné"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Důvěřovat"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Spustit instalačního pomocníka pro toto zařízení"
 
@@ -122,7 +122,7 @@ msgstr "Spustit instalačního pomocníka pro toto zařízení"
 msgid "Setup..."
 msgstr "Nastavení..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Odebrat toto zařízení ze seznamu důvěryhodných zařízení"
 
@@ -302,7 +302,12 @@ msgstr "Neurčeno"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -364,7 +369,7 @@ msgstr "Reset"
 msgid "Send note"
 msgstr "Odeslat poznámku"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Je potřeba zapnout bluetooth, aby správce adaptéru fungoval"
 
@@ -372,14 +377,12 @@ msgstr "Je potřeba zapnout bluetooth, aby správce adaptéru fungoval"
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth adaptéry"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Vždy"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minuta"
@@ -387,19 +390,19 @@ msgstr[1] "%d Minuty"
 msgstr[2] "%d Minuty"
 msgstr[3] "%d Minuty"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptér"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth musí být zapnuto, aby správce zařízení fungoval"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Připojení k BlueZ selhalo"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -413,50 +416,50 @@ msgstr ""
 msgid "Searching"
 msgstr "Probíhá hledání"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Asistent Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Předvolby adaptéru"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Odesílatel souborů"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Přenos souboru pomocí Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Připojování"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd je nedostupný"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Nepodařilo se automaticky spustit obex službu. Ujistěte se, že je spuštěn "
 "démon služby obex"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Ruší se"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Odesílání souboru"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Zbývající čas:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -465,94 +468,86 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Odesílání souboru %s selhalo"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Přeskočit"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Opakovat"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Došlo k chybě"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokální služby"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Požadavek na spárování s %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth ověřování"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Zadejte PIN kód pro ověření:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Zadejte PIN kód"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Zadejte ověřovací klíč:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Zadejte klíč"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Párovací řetězec pro"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Párovací PIN kód pro"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Požadavek na spárování pro:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Potvrďte hodnotu pro ověření:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Potvrdit"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Zamítnout"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Požadavek na pověření pro:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Služba:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Vždy přijmout"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Přijmout"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -587,243 +582,240 @@ msgstr "Ano"
 msgid "No"
 msgstr "Ne"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "Nahlásit p_roblém"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Správce zařízení"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Zobrazit panel nástrojů"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Zobrazit stavový panel"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Seřadit p_odle"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Názvu"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Přidání"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Sestupně"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Zásuvné moduly"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokální služby"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Předvolby služby"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Hledat"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Předvolby adaptéru"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Ukončit"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "nekategorizováno"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Důvěryhodné a spárované</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Spárováno</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Důvěryhodný</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Mizerný"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Neoptimální"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimální"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Mnoho"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Příliš"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Nízké"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Vysoké"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Velmi vysoké"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Úspěch!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Sériový port připojen k %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Nepodařilo se"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Spojení se nezdařilo: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Připojování"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Odpojení se nezdařilo: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Odpojování…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Připojuje profily automatického připojení A2DP source, A2DP sink a HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Vynutit odpojení zařízení"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Připojit k:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Odpojit:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Odeslat _soubor…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Párovat"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Důvěřovat"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Nedůvěřovat"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Přejmenovat zařízení"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Odstranit"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Zrušit operaci"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indikace datové aktivity"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Celkem přijatých dat a poměr přenosu"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Celkem odeslaných dat a poměr přenosu"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Nedůvěřovat"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Vybrat zařízení"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Více"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -844,7 +836,7 @@ msgstr ""
 "  schunka https://launchpad.net/~schunka\n"
 "  xills pills https://launchpad.net/~adamturan"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman je správce Bluetooth založený na GTK+"
 
@@ -852,17 +844,17 @@ msgstr "Blueman je správce Bluetooth založený na GTK+"
 msgid "GSM Settings"
 msgstr "Nastavení GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Zásuvné moduly"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problém se součástmi, na kterých závisí"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -873,7 +865,7 @@ msgstr ""
 "také zruší <b>„%(0)s“</b>.\n"
 "Pokračovat?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -884,886 +876,1259 @@ msgstr ""
 "deaktivován <b>%(0)s</b>.\n"
 "Provést?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Výběr adaptéru"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Viditelné… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "nekategorizováno"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Přístupový bod sítě"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "desktop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "kapesní"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobilní"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "bezdrátový"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smartphone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd je nedostupný"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "headset"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "neznámé"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Zdroj zvuku"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Zdroj zvuku"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Zdroj zvuku"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "klávesnice"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "bodování"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "klávesnice"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "bodování"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Připojení"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Připojení"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Připojení"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Připojení"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Přenos souboru pomocí Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Připojení"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Přenos souboru pomocí Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Přenos souboru pomocí Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Síťová skupina"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Přenos souboru pomocí Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Připojení"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Připojení"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Přenos souboru pomocí Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Připojení"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Síťová skupina"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Sériové porty"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Vytáčené připojení (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Přenos souboru pomocí Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "headset"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Zdroj zvuku"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Přenášení zvuku"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Přístupový bod sítě"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Síťová skupina"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Síťový přístupový bod (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Síťový přístupový bod (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Síťová skupina"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Přenos souboru pomocí Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Zdroj zvuku"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Přenášení zvuku"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Zdroj zvuku"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Přejmenovat zařízení"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Zobrazit informace o zařízení"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Lokální služby"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Přenos"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "applet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Spárovat zařízení"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Hledat zařízení v dosahu"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Přenos"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "applet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Spárovat zařízení"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Hledat zařízení v dosahu"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Správce zařízení"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Poslední _spojení"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Správce zařízení"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Předvolby adaptéru"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Automatické propojení profilů"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietární"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ano"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "ne"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Zobrazit informace o zařízení"
 
@@ -1788,34 +2153,35 @@ msgstr "Profil zvuku"
 msgid "Select audio profile for PulseAudio"
 msgstr "Vyberte zvukový profil pro PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Sériový port %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Obnovit IP adresu"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Nastavení vytáčeného připojení"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Sériové porty"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Neurčeno"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Připojeno"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1888,22 +2254,17 @@ msgstr "Využití sítě"
 msgid "Shows network traffic usage"
 msgstr "Ukázat využití sítě"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth povoleno"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth zakázáno"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Spravovat místní síťové služby, např. NAP bridges"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1911,7 +2272,7 @@ msgstr ""
 "Poskytuje podporu pro Telefonické připojení sítě (Dial Up Networking) s "
 "ModemManager a NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1919,37 +2280,37 @@ msgstr ""
 "přístup."
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maximum položek"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Maximální počet položek nedávných spojení, které se zobrazí v menu."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Poslední _spojení"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Připojeno k %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Připojení selhalo"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s na %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adaptér pro toto spojení není přístupný"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1957,41 +2318,41 @@ msgstr ""
 "Poskytuje podporu pro Personal Area Networking (PAN) představeném v "
 "NetworkManageru 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Poskytuje DBus API pro další součásti Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Příchozí soubor přes bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Příchozí soubor %(0)s ze %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Odmítnout"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Přijímání souboru"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Přijímání souboru %(0)s z %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Umožnuje přenos souborů pomocí OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Cílová složka pro příchozí soubory neexistuje"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -2000,33 +2361,31 @@ msgstr ""
 "Zkontrolujte, zda existuje adresář \"<b>%s</b>\" nebo jej nakonfigurujte "
 "pomocí služeb blueman-services. Do té doby bude použito výchozí \"%s\""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Soubor přijat"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Soubor %(0)s z %(1)s úspěšně přijat"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Přenos se nezdařil"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Přenos souboru %(0)s se nezdařil"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Soubory přijaty"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Přijat %d soubor na pozadí"
@@ -2034,10 +2393,8 @@ msgstr[1] "Přijaty %d soubory na pozadí"
 msgstr[2] "Přijato %d souborů na pozadí"
 msgstr[3] "Přijaty %d soubory na pozadí"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Přijat %d soubor na pozadí"
@@ -2052,27 +2409,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Přidá standardní položky nabídky do nabídky stavové ikony"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Nastavit nové zařízení"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Odeslat _soubory do zařízení"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Zařízení"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_téry"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2084,27 +2441,27 @@ msgstr "Poskytuje passkey pro autentizační služby BlueZ démonu"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Přidává položku ukončovacího menu k ukončení apletu"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Poskytuje základního klienta DHCP pro Bluetooth PAN připojení."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Síť Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Zařízení %(0)s připojeno k IP adrese %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Neúspěšné získání IP adresy na %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2113,7 +2470,7 @@ msgstr ""
 "Zkouším získat  IP adresu na %s\n"
 "Prosím čekejte…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2121,14 +2478,12 @@ msgstr ""
 "Přidá údaj na stavovou ikonu, pokud je Bluetooth aktivní a zobrazuje počet "
 "připojení v popisu."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth aktivní"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Aktivní spojení</b>"
@@ -2136,11 +2491,16 @@ msgstr[1] "<b>%d Aktivní spojení</b>"
 msgstr[2] "<b>%d Aktivních spojení</b>"
 msgstr[3] "<b>%d Aktivních spojení</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth zakázáno"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Používá libappindicator k zobrazení stavové ikony"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2148,33 +2508,34 @@ msgstr ""
 "Poskytuje položku nabídky pro dočasné zviditelnění výchozího adaptéru, jehož "
 "výchozí stav je skrytý"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Čas viditelnosti"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Počet sekund, po které zařízení setrvá ve viditelném režimu"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Zneviditelnit"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Dočasně zviditelnit výchozí adaptér"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Viditelné… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "Poskytuje nabídku pro applet a API pro další pluginy k jeho ovládání"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2183,24 +2544,24 @@ msgstr ""
 "Úspěšně připojeno k <b>DUN</b> službe na <b>%(0)s.</b>\n"
 "Síť je nyní dostupná skrz <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Poskytuje základní podporu připojení k internetu přes profil vytáčeného "
 "spojení."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Ovladač připojení standardního SPP profilu, umožňuje spuštění vlastních "
 "činností"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skript ke spuštění připojení"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2218,21 +2579,21 @@ msgstr ""
 "\n"
 "Skript odešle HUP signál po odpojení zařízení</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Seriový port připojen"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr "Sériový port na zařízení <b>%s</b> teď bude dostupný skrz <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Skript připojení seriového portu selhal"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2241,58 +2602,57 @@ msgstr ""
 "Vyskytl se problém se spouštěním skriptu %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Ovládání stavu napájení adaptéru Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatické zapínání"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automaticky zapnout adaptéry"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Vypnout Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Vypnout všechny adaptéry"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Zapnout Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Zapne všchny adaptéry"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "Při připojení Bluetooth herního ovladače, dočasně vypne spořič obrazovky."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Síť"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Neplatná IP adresa"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP adresa je již použita na rozhraní %s"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2303,8 +2663,8 @@ msgstr ""
 "konfiguraci  %s/%s\n"
 "To může způsobit nesprávné chování sítě"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Není podporováno s tímto nastavením"
 
@@ -2318,40 +2678,26 @@ msgstr "Applet má zakázaný plugin pro přenos souborů"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth adaptéry"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman je správce Bluetooth založený na GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth povoleno"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Zařízení bluetooth"
 
@@ -2387,6 +2733,31 @@ msgstr "Nastavení stavu RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Nastavení stavu RfKill vyžaduje oprávnění"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Zadejte PIN kód"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Zadejte klíč"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Sériový port připojen k %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "headset"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "neznámé"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Zařízení bluetooth"
 
@@ -2411,11 +2782,6 @@ msgstr "Nastavení stavu RfKill vyžaduje oprávnění"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Odstranit…"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Připojení"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Danish (http://www.transifex.com/mate/MATE/language/da/)\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Synlighedsindstilling</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Skjult"
 
@@ -67,8 +67,8 @@ msgstr "_Enhed"
 msgid "_View"
 msgstr "_Vis"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Hjælp"
 
@@ -81,7 +81,7 @@ msgstr "Søg efter enheder i nærheden"
 msgid "Search"
 msgstr "Søg"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Opret sammenføjning med enheden"
 
@@ -90,17 +90,17 @@ msgstr "Opret sammenføjning med enheden"
 msgid "Pair"
 msgstr "Sammenføj"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Marker/fjern markering af denne enhed som betroet"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Tillid"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Start opsætningsassistenten for denne enhed"
 
@@ -109,7 +109,7 @@ msgstr "Start opsætningsassistenten for denne enhed"
 msgid "Setup..."
 msgstr "Opsætning …"
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Fjern denne enhed fra listen over kendte enheder"
 
@@ -289,7 +289,12 @@ msgstr "Ikke specificeret"
 msgid "<b>Author:</b>"
 msgstr "<b>Forfatter:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -351,7 +356,7 @@ msgstr "_Nulstil"
 msgid "Send note"
 msgstr "Send note"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth skal være aktiveret for at adapterhåndteringen virker"
 
@@ -359,32 +364,30 @@ msgstr "Bluetooth skal være aktiveret for at adapterhåndteringen virker"
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth-adaptere"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Altid"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minut"
 msgstr[1] "%d Minutter"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth skal være tændt for at enhedshåndteringen kan fungere"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Forbindelse til BlueZ mislykkedes"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -398,143 +401,135 @@ msgstr ""
 msgid "Searching"
 msgstr "Søger"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth-assistent"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adapterpræferencer"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Filafsender"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth-filoverførsel"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Forbinder"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd er ikke tilgængelig"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Kunne ikke starte tjenesten obex automatisk. Sikr at dæmonen obex kører"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Afbryder"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Sender fil"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "EA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Der opstod en fejl under afsendelse af filen %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Spring over"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Forsøg igen"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Der opstod en fejl"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokale tjenester"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Sammensætningsforespørgsel for %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth-godkendelse"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Indtast PIN-kode for godkendelse:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Indtast PIN-kode"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Indtast adgangsnøgle for godkendelse:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Indtast adgangsnøgle"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Parrer adgangsnøgle for"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Parrer PIN-kode for"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Sammensætningsforespørgsel for:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Bekræft værdi for godkendelse:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Bekræft"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Afvis"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Godkendelsesforespørgsel for:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Tjeneste:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Accepter altid"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Accepter"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -568,243 +563,240 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nej"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Rapporter et problem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Enhedshåndtering"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Vis _værktøjslinje"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Vis _statuslinje"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "S_orter efter"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Navn"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Tilføjet"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Faldende"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Udvidelsesmoduler"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokale tjenester"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Tjenestepræferencer"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Søg"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Adapterpræferencer"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Afslut"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "ikke kategoriseret"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Betroet og parret</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Parret</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Betroet</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Dårlig"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Næsten optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Meget"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "For meget"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Lav"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Højt"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Meget højt"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Succes!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Serielport forbundet til %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Mislykkedes"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Forbindelse mislykkedes: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Forbinder"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Afkobl mislykkedes:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Afbryder …"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Forbinder lydforbindelsesprofilerne A2DP-kilde, A2DP-datakanal og HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Afbryd med tvang enheden"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Forbind til:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Afbryd:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Send en _fil …"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Sammenføj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Betro"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Mistro"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Omdøb enhed"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Fjern"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Annuller handlingen"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Identifikation af dataaktivitet"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Data modtaget i alt samt overførselshastighed"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Data sendt i alt samt overførselshastighed"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Mistro"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Vælg enhed"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mere"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Joe Hansen, 2014.\n"
@@ -812,7 +804,7 @@ msgstr ""
 "Dansk-gruppen <dansk@dansk-gruppen.dk>\n"
 "Mere info: http://www.dansk-gruppen.dk"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman er en GTK+ Bluetooth-håndtering"
 
@@ -820,17 +812,17 @@ msgstr "Blueman er en GTK+ Bluetooth-håndtering"
 msgid "GSM Settings"
 msgstr "GSM-indstillinger"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Udvidelsesmoduler"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Afhængighedsproblem"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -841,7 +833,7 @@ msgstr ""
 "%(1)s</b> vil også blive deaktivere <b>»%(0)s«</b>.\n"
 "Fortsæt?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -852,886 +844,1259 @@ msgstr ""
 "<b>%(1)s</b> vil fjerne <b>%(0)s</b>.\n"
 "Fortsæt?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Adaptervalg"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Synlig … %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "ikke kategoriseret"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Netværksadgangspunkt"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "skrivebord"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "bærbar"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "håndholdt"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobiltelefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "trådløs"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smarttelefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd er ikke tilgængelig"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "hovedtelefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "håndfri"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "ukendt"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Lydkilde"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Lydkilde"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Lydkilde"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tastatur"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "pegeredskab"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tastatur"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "pegeredskab"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Kobl på"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Kobl på"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Kobl på"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Kobl på"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth-filoverførsel"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Kobl på"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth-filoverførsel"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth-filoverførsel"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Gruppenetværk"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth-filoverførsel"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Kobl på"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Kobl på"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth-filoverførsel"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Kobl på"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Gruppenetværk"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Serielporte"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Opkaldsnetværk (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth-filoverførsel"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "hovedtelefon"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Lydkilde"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Datakanal for lyd"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Netværksadgangspunkt"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Gruppenetværk"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "håndfri"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Gruppenetværk"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth-filoverførsel"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Lydkilde"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Datakanal for lyd"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Lydkilde"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Omdøb enhed"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Vis enhedsinformation"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Lokale tjenester"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Overfør"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "panelprogram"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Par enhed"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Søg efter enheder i nærheden"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Overfør"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "panelprogram"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Par enhed"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Søg efter enheder i nærheden"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Enhedshåndtering"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Seneste _forbindelser"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Enhedshåndtering"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Adapterpræferencer"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Forbind automatisk profiler"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietær"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ja"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nej"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Vis enhedsinformation"
 
@@ -1756,34 +2121,35 @@ msgstr "Lydprofil"
 msgid "Select audio profile for PulseAudio"
 msgstr "Vælg lydprofil for PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Serielport %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Forny IP-adresse"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Opkaldsindstillinger"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Serielporte"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Uspecificeret"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Forbundet"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Altid forbundet til %(service)s på %(device)s"
@@ -1851,22 +2217,17 @@ msgstr "_Netværksbrug"
 msgid "Shows network traffic usage"
 msgstr "Viser forbrug af netværkstrafik"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth er aktiveret"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth er deaktiveret"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Håndterer lokale netværkstjenester, såsom NAP-broer"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1874,7 +2235,7 @@ msgstr ""
 "Tilbyder understøttelse for Dial Up Networking (DUN) med ModemManager og "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1882,37 +2243,37 @@ msgstr ""
 "give hurtig adgang"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maks. antal punkter"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Det maksimale antal punkter menuen for seneste forbindelser vil vise."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Seneste _forbindelser"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Forbundet til %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Kunne ikke forbinde"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s på %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "En adapter for denne forbindelse er ikke tilgængelig"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1920,41 +2281,41 @@ msgstr ""
 "Tilbyder understøttelse for Personal Area Networking (PAN) introduceret i "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Muligører DBus API for andre Blueman-komponenter"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Indkommende fil over Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Indkommende fil %(0)s fra %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Afvis"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Modtager fil"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Modtager fil %(0)s fra %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Tilbyder OBEX-filoverførselsfunktioner"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Den konfigurerede mappe for indgående filer findes ikke"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1963,42 +2324,38 @@ msgstr ""
 "Sikr dig venligst at mappen »<b>%s</b>« findes eller konfigurer den med "
 "blueman-services. Indtil da vil standarden »%s« blive anvendt"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Fil modtaget"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Fil %(0)s fra %(1)s blev modtaget"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Overførselsfejl"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Overførsel af filen %(0)s fejlede"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Filer modtaget"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Modtog %d fil i baggrunden"
 msgstr[1] "Modtog %d filer i baggrunden"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Modtog %d fil mere i baggrunden"
@@ -2011,27 +2368,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Tilføj menupunkter til statusikonmenuen"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Opsæt ny enhed"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Send _filer til enhed"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Enheder"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "_Adaptere"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "panelprogram"
 
@@ -2043,27 +2400,27 @@ msgstr "Tilbyder adgangsnøgle, godkendelsestjenester for BlueZ-dæmon"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Tilføjer et punkt i menuen til at afslutte panelprogrammet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Tilbyder en grundlæggende dhcp-klient for Bluetooth PAN-forbindelser."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth-netværk"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Grænseflade %(0)s bundet til IP-adresse %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Kunne ikke indhente en IP-adresse på %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2072,7 +2429,7 @@ msgstr ""
 "Forsøger at indhente en IP-adresse på %s\n"
 "Vent venligst …"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2080,24 +2437,27 @@ msgstr ""
 "Tilføjer en indikation på statusikonet når Bluetooth er aktiv og viser "
 "antallet af forbindelser i værktøjsfiffet."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth er aktiv"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d aktiv forbindelse</b>"
 msgstr[1] "<b>%d aktive forbindelser</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth er deaktiveret"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Bruger libappindicator til at vise et statusikon"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2105,35 +2465,36 @@ msgstr ""
 "Tilbyder et menupunkt der gør standardadapteren midlertidig synlig, når den "
 "som standard er sat til at være usynlig"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Tidsudløb for synlighed"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Tid i sekunder som tilstanden synlighed skal være aktiveret"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Gør synlig"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Gør standardadapteren midlertidig synlig"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Synlig … %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Tilbyder en menu for panelprogrammet og en API så andre udvidelsesmoduler "
 "kan manipulere den"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2142,24 +2503,24 @@ msgstr ""
 "Forbundet til <b>DUN</b>-tjeneste på <b>%(0)s.</b>\n"
 "Netværk er nu tilgængelig via <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Tilbyder grundlæggende understøttelse for forbindelse til internettet via "
 "DUN-profil."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standardhåndtering for SPP-profilforbindelse, giver mulighed for at køre "
 "tilpassede handlinger"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skript der skal køres ved forbindelse"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2177,22 +2538,22 @@ msgstr ""
 "\n"
 "Ved frakobling af enhed vil skriptet få sendt et HUP-signal</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Serielport tilsluttet"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "Serielporttjeneste på enhed <b>%s</b> vil nu være tilgængelig via <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Forbindelsesskriptet for serielporten mislykkedes"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2201,37 +2562,37 @@ msgstr ""
 "Der opstod et problem med at starte skript %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Kontrollerer strømtilstande for Bluetoothadaptere"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatisk tænd"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automatisk tænding af adaptere"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Deaktiver Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Afbryd alle adaptere"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Aktiver Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Tænd alle adaptere"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2239,22 +2600,21 @@ msgstr ""
 "Suspender midlertidigt pauseskærmen når en Bluetooth-spilcontroller er "
 "forbundet."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Netværk"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Ugyldig IP-adresse"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "IP-adressen er i konflikt med grænseflade %s, som har den samme adresse"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2265,8 +2625,8 @@ msgstr ""
 "følgende konfiguration %s/%s\n"
 "Dette kan medføre ugyldig netværksopførsel"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "I øjeblikket ikke understøttet med denne opsætning"
 
@@ -2280,40 +2640,26 @@ msgstr "Panelprogrammets udvidelsesmodul for overførseltjeneste er deaktiveret"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth-adaptere"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "panelprogram"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman er en GTK+ Bluetooth-håndtering"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth er aktiveret"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth-enheder"
 
@@ -2349,6 +2695,31 @@ msgstr "Angiv RfKill-tilstand"
 msgid "Setting RfKill State requires privileges"
 msgstr "Angivelse af RfKill-tilstand kræver privilegier"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Indtast PIN-kode"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Indtast adgangsnøgle"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Serielport forbundet til %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "hovedtelefon"
+
+#~ msgid "handsfree"
+#~ msgstr "håndfri"
+
+#~ msgid "unknown"
+#~ msgstr "ukendt"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth-enheder"
 
@@ -2369,11 +2740,6 @@ msgstr "Angivelse af RfKill-tilstand kræver privilegier"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Fjern …"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Kobl på"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/de.po
+++ b/po/de.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-31 21:43+0000\n"
 "Last-Translator: Christopher Schramm <github@cschramm.eu>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Sichtbarkeitseinstellung</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Versteckt"
 
@@ -78,8 +78,8 @@ msgstr "_Gerät"
 msgid "_View"
 msgstr "_Ansicht"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Hilfe"
 
@@ -92,7 +92,7 @@ msgstr "Nach Geräten in der Nähe suchen"
 msgid "Search"
 msgstr "Suche"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Kopplung mit dem Gerät herstellen"
 
@@ -101,17 +101,17 @@ msgstr "Kopplung mit dem Gerät herstellen"
 msgid "Pair"
 msgstr "Kopplung"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Diesem Gerät vertrauen/nicht vertrauen"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Vertrauen"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Den Einrichtungsassistenten für dieses Gerät aufrufen"
 
@@ -120,7 +120,7 @@ msgstr "Den Einrichtungsassistenten für dieses Gerät aufrufen"
 msgid "Setup..."
 msgstr "Einrichten …"
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Dieses Gerät von der Liste der bekannten Geräte entfernen"
 
@@ -301,7 +301,12 @@ msgstr "Nicht angegeben"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -363,7 +368,7 @@ msgstr "_Zurücksetzen"
 msgid "Send note"
 msgstr "Notiz senden"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "Bluetooth muss eingeschaltet sein, damit die Adapterverwaltung funktioniert"
@@ -372,31 +377,31 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth-Adapter"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Immer"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%(minutes)d Minute"
 msgstr[1] "%(minutes)d Minuten"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "Bluetooth muss eingeschaltet sein, damit die Geräteverwaltung funktioniert"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Verbindung mit BlueZ fehlgeschlagen"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -411,144 +416,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Suche"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth-Assistent"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adaptereinstellungen"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Dateisender"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth-Dateitransfer"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Verbinde"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd ist nicht verfügbar"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Automatischer Start des OBEX-Dienstes fehlgeschlagen. Stellen Sie sicher, "
 "dass der OBEX-Daemon läuft"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Abbruch"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Sende Datei"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] "%(seconds)d Sekunde"
 msgstr[1] "%(seconds)d Sekunden"
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Fehler beim Senden der Datei %s aufgetreten"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Überspringen"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Erneut versuchen"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Fehler aufgetreten"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokale Dienste"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Kopplungsanfrage von %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth-Legitimation"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "PIN-Code zur Legitimation eingeben:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "PIN Code eingeben"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Passwort zur Legitimation eingeben:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Passwort eingeben"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Kopplungspasswort für"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Kopplungs-PIN-Code für"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Kopplungsanfrage für:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Wert zur Legitimation bestätigen:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Verweigern"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Legitimierungsanfrage für:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Dienst:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Immer annehmen"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Annehmen"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -582,230 +579,234 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nein"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Ein Problem melden"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Geräteverwaltung"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "_Werkzeugleiste anzeigen"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "_Statusleiste anzeigen"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "S_ortieren nach"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Name"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Hinzugefügt"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Absteigend"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Erweiterungen"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokale Dienste"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Diensteinstellungen"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Suchen"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "Ada_ptereinstellungen"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "B_eenden"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "Sonstige"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Vertrauenswürdig und gekoppelt</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Gekoppelt</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Vertrauenswürdig</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Schwach"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Nicht optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Viel"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Zu viel"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Niedrig"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Hoch"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Sehr hoch"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Erfolgreich!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Serieller Anschluss verbunden mit %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Verbindung fehlgeschlagen: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 msgid "Connecting…"
 msgstr "Verbinde…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Trennung fehlgeschlagen: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 msgid "Disconnecting…"
 msgstr "Verbindung wird getrennt…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "<b>Verbinden</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Verbindet automatische Verbindungsprofile A2DP-Quelle, A2DP-Senken und HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "<b>Trennen</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Trennung des Gerätes erzwingen"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Verbinden mit:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Trennen:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 msgid "Send a _File…"
 msgstr "_Datei senden…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Kopplung"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Vertrauenswürdigkeit"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Keine Vertrauenswürdigkeit"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "Einrichten…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr "G_erät umbenennen…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 msgid "_Remove…"
 msgstr "Entfe_rnen…"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Vorgang abbrechen"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Anzeige von Datenaktivität"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Gesamte empfangene Daten und Übertragungsrate"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Gesamte versendete Daten und Übertragungsrate"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Nicht vertrauenswürdig"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Gerät auswählen"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mehr"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -843,7 +844,7 @@ msgstr ""
 "  tim♡mint https://launchpad.net/~tim.h.s\n"
 "  tofro https://launchpad.net/~tobias-froeschle"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman ist eine GTK+-basierte Bluetooth-Verwaltung"
 
@@ -851,17 +852,17 @@ msgstr "Blueman ist eine GTK+-basierte Bluetooth-Verwaltung"
 msgid "GSM Settings"
 msgstr "GSM-Einstellungen"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Erweiterungen"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Abhängigkeitsproblem"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -873,7 +874,7 @@ msgstr ""
 "deaktivieren.\n"
 "Fortfahren?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -884,840 +885,1247 @@ msgstr ""
 "%(1)s</b> wird <b>%(0)s</b> deaktivieren.\n"
 "Fortfahren?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Adapterauswahl"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr "Suche…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "Sonstige"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Network Access Point (NAP)"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "desktop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "Server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "Laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "Handheld"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "Palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "Mobiltelefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "Drahtlosgerät"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "Smartphone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "Modem"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "ISDN-Gerät"
-
-#. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "Headset"
-
-#. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "Freisprecheinrichtung"
-
-#. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "Unbekannt"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
-msgstr "Mikrofon"
-
-#. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
-msgstr "Lautsprecher"
-
-#. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
-msgstr "Kopfhörer"
-
-#. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
-msgstr "Tragbares Audiogerät"
-
-#. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr "Autoradio"
-
-#. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
-msgstr "Set-Top-Box"
-
-#. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
-msgstr "HiFi-Gerät"
-
-#. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
-msgstr "Videorekorder"
-
-#. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
-msgstr "Videokamera"
-
-#. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
-msgstr "Camcorder"
-
-#. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr "Monitor"
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr "Monitor mit Lautsprecher"
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
-msgstr "Videokonferenzeinrichtung"
-
-#. translators: device class
-#: blueman/DeviceClass.py:145
-msgid "gaming/toy"
-msgstr "Spielzeug"
-
-#. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "Tastatur"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "Zeigegerät"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
-msgstr "Kombination"
-
-#: blueman/Sdp.py:93
-msgid "SDP"
-msgstr "SDP"
-
-#: blueman/Sdp.py:94
-msgid "UDP"
-msgstr "UDP"
-
-#: blueman/Sdp.py:95
-msgid "RFCOMM"
-msgstr "RFCOMM"
-
-#: blueman/Sdp.py:96
-msgid "TCP"
-msgstr "TCP"
-
-#: blueman/Sdp.py:97
-msgid "TCS-BIN"
-msgstr "TCS-BIN"
-
-#: blueman/Sdp.py:98
-msgid "TCS-AT"
-msgstr "TCS-AT"
-
-#: blueman/Sdp.py:99
-msgid "ATT"
-msgstr "ATT"
-
-#: blueman/Sdp.py:100
-msgid "OBEX"
-msgstr "OBEX"
-
-#: blueman/Sdp.py:101
-msgid "IP"
-msgstr "IP"
-
-#: blueman/Sdp.py:102
-msgid "FTP"
-msgstr "FTP"
-
-#: blueman/Sdp.py:103
-msgid "HTTP"
-msgstr "HTTP"
-
-#: blueman/Sdp.py:104
-msgid "WSP"
-msgstr "WSP"
-
-#: blueman/Sdp.py:105
-msgid "BNEP"
-msgstr "BNEP"
-
-#: blueman/Sdp.py:106
-msgid "UPnP/ESDP"
-msgstr "UPnP/ESDP"
-
-#: blueman/Sdp.py:107
-msgid "HIDP"
-msgstr "HIDP"
-
-#: blueman/Sdp.py:108
-msgid "Hardcopy Control Channel"
-msgstr "Druck-Steuerkanal"
-
-#: blueman/Sdp.py:109
-msgid "Hardcopy Data Channel"
-msgstr "Druck-Datenkanal"
-
-#: blueman/Sdp.py:110
-msgid "Hardcopy Notification"
-msgstr "Druck-Benachrichtigung"
-
-#: blueman/Sdp.py:111
-msgid "AVCTP"
-msgstr "AVCTP"
-
-#: blueman/Sdp.py:112
-msgid "AVDTP"
-msgstr "AVDTP"
-
-#: blueman/Sdp.py:113
-msgid "CMTP"
-msgstr "CMTP"
-
-#: blueman/Sdp.py:114
-msgid "UDI_C-Plane"
-msgstr "UDI_C-Plane"
-
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
-msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgid "83-99 percent"
 msgstr ""
 
-#: blueman/Sdp.py:117
-msgid "L2CAP"
-msgstr "L2CAP"
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd ist nicht verfügbar"
 
-#: blueman/Sdp.py:118
-msgid "ServiceDiscoveryServerServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:119
-msgid "BrowseGroupDescriptorServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:120
-msgid "Public Browse Group"
-msgstr ""
-
-#: blueman/Sdp.py:121
-msgid "Serial Port"
-msgstr "Serielle Anschlüsse"
-
-#: blueman/Sdp.py:122
-msgid "LAN Access Using PPP"
-msgstr "PPP-LAN-Zugang"
-
-#: blueman/Sdp.py:123
-msgid "Dialup Networking (DUN)"
-msgstr "Einwahl-Netzwerk (DUN)"
-
-#: blueman/Sdp.py:124
-msgid "IrMC Sync"
-msgstr "IrMC-Synchronisierung"
-
-#: blueman/Sdp.py:125
-msgid "OBEX Object Push"
-msgstr "OBEX-Objekt-Transfer"
-
-#: blueman/Sdp.py:126
-msgid "OBEX File Transfer"
-msgstr "OBEX-Dateitransfer"
-
-#: blueman/Sdp.py:127
-msgid "IrMC Sync Command"
-msgstr "IrMC-Synchronisierungs-Steuerung"
-
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
 msgid "Headset"
 msgstr "Headset"
 
-#: blueman/Sdp.py:129
-msgid "Cordless Telephony"
-msgstr "Schnurlostelefon"
-
-#: blueman/Sdp.py:130
-msgid "Audio Source"
-msgstr "Audio-Quelle"
-
-#: blueman/Sdp.py:131
-msgid "Audio Sink"
-msgstr "Audio-Ausgabe"
-
-#: blueman/Sdp.py:132
-msgid "Remote Control Target"
-msgstr "Fernsteuerungsziel"
-
-#: blueman/Sdp.py:133
-msgid "Advanced Audio"
-msgstr "Verbessertes Audio-Profil (A2DP)"
-
-#: blueman/Sdp.py:134
-msgid "Remote Control"
-msgstr "Fernsteuerung"
-
-#: blueman/Sdp.py:135
-msgid "Video Conferencing"
-msgstr "Videokonferenz"
-
-#: blueman/Sdp.py:136
-msgid "Intercom"
-msgstr ""
-
-#: blueman/Sdp.py:137
-msgid "Fax"
-msgstr "Fax"
-
-#: blueman/Sdp.py:138
-msgid "Headset Audio Gateway"
-msgstr "Headset Audio Gateway"
-
-#: blueman/Sdp.py:139
-msgid "WAP"
-msgstr ""
-
-#: blueman/Sdp.py:140
-msgid "WAP Client"
-msgstr ""
-
-#: blueman/Sdp.py:141
-msgid "PANU"
-msgstr ""
-
-#: blueman/Sdp.py:142
-msgid "Network Access Point"
-msgstr "Network Access Point (NAP)"
-
-#: blueman/Sdp.py:143
-msgid "Group Network"
-msgstr "Gruppennetzwerk"
-
-#: blueman/Sdp.py:144
-msgid "DirectPrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:145
-msgid "ReferencePrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:146
-msgid "Imaging (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:147
-msgid "ImagingResponder (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:148
-msgid "ImagingAutomaticArchive (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:149
-msgid "ImagingReferencedObjects (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:150
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
 msgid "Handsfree"
 msgstr "Freisprecheinrichtung"
 
-#: blueman/Sdp.py:151
+#. translators: device class
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#. translators: device class
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
+msgstr "Lautsprecher"
+
+#. translators: device class
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
+msgstr "Kopfhörer"
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
+msgstr "Tragbares Audiogerät"
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
+msgstr "Autoradio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
+msgstr "Set-Top-Box"
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
+msgstr "HiFi-Gerät"
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
+msgstr "Videorekorder"
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Videokamera"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
+msgstr "Camcorder"
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Monitor"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
+msgstr "Monitor mit Lautsprecher"
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Videokonferenzeinrichtung"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+#, fuzzy
+msgid "Gaming/Toy"
+msgstr "Spielzeug"
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "Tastatur"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "Zeigegerät"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+#, fuzzy
+msgid "Combo"
+msgstr "Kombination"
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+msgid "Display"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Dateitransfer"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Fernsteuerung"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Dateitransfer"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Dateitransfer"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Netzwerk"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Dateitransfer"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Dateitransfer"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Netzwerk"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
+msgid "SDP"
+msgstr "SDP"
+
+#: blueman/Sdp.py:88
+msgid "UDP"
+msgstr "UDP"
+
+#: blueman/Sdp.py:89
+msgid "RFCOMM"
+msgstr "RFCOMM"
+
+#: blueman/Sdp.py:90
+msgid "TCP"
+msgstr "TCP"
+
+#: blueman/Sdp.py:91
+msgid "TCS-BIN"
+msgstr "TCS-BIN"
+
+#: blueman/Sdp.py:92
+msgid "TCS-AT"
+msgstr "TCS-AT"
+
+#: blueman/Sdp.py:93
+msgid "ATT"
+msgstr "ATT"
+
+#: blueman/Sdp.py:94
+msgid "OBEX"
+msgstr "OBEX"
+
+#: blueman/Sdp.py:95
+msgid "IP"
+msgstr "IP"
+
+#: blueman/Sdp.py:96
+msgid "FTP"
+msgstr "FTP"
+
+#: blueman/Sdp.py:97
+msgid "HTTP"
+msgstr "HTTP"
+
+#: blueman/Sdp.py:98
+msgid "WSP"
+msgstr "WSP"
+
+#: blueman/Sdp.py:99
+msgid "BNEP"
+msgstr "BNEP"
+
+#: blueman/Sdp.py:100
+msgid "UPnP/ESDP"
+msgstr "UPnP/ESDP"
+
+#: blueman/Sdp.py:101
+msgid "HIDP"
+msgstr "HIDP"
+
+#: blueman/Sdp.py:102
+msgid "Hardcopy Control Channel"
+msgstr "Druck-Steuerkanal"
+
+#: blueman/Sdp.py:103
+msgid "Hardcopy Data Channel"
+msgstr "Druck-Datenkanal"
+
+#: blueman/Sdp.py:104
+msgid "Hardcopy Notification"
+msgstr "Druck-Benachrichtigung"
+
+#: blueman/Sdp.py:105
+msgid "AVCTP"
+msgstr "AVCTP"
+
+#: blueman/Sdp.py:106
+msgid "AVDTP"
+msgstr "AVDTP"
+
+#: blueman/Sdp.py:107
+msgid "CMTP"
+msgstr "CMTP"
+
+#: blueman/Sdp.py:108
+msgid "UDI_C-Plane"
+msgstr "UDI_C-Plane"
+
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
+msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgstr ""
+
+#: blueman/Sdp.py:111
+msgid "L2CAP"
+msgstr "L2CAP"
+
+#: blueman/Sdp.py:112
+msgid "ServiceDiscoveryServerServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:113
+msgid "BrowseGroupDescriptorServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:114
+msgid "Public Browse Group"
+msgstr ""
+
+#: blueman/Sdp.py:115
+msgid "Serial Port"
+msgstr "Serielle Anschlüsse"
+
+#: blueman/Sdp.py:116
+msgid "LAN Access Using PPP"
+msgstr "PPP-LAN-Zugang"
+
+#: blueman/Sdp.py:117
+msgid "Dialup Networking (DUN)"
+msgstr "Einwahl-Netzwerk (DUN)"
+
+#: blueman/Sdp.py:118
+msgid "IrMC Sync"
+msgstr "IrMC-Synchronisierung"
+
+#: blueman/Sdp.py:119
+msgid "OBEX Object Push"
+msgstr "OBEX-Objekt-Transfer"
+
+#: blueman/Sdp.py:120
+msgid "OBEX File Transfer"
+msgstr "OBEX-Dateitransfer"
+
+#: blueman/Sdp.py:121
+msgid "IrMC Sync Command"
+msgstr "IrMC-Synchronisierungs-Steuerung"
+
+#: blueman/Sdp.py:123
+msgid "Cordless Telephony"
+msgstr "Schnurlostelefon"
+
+#: blueman/Sdp.py:124
+msgid "Audio Source"
+msgstr "Audio-Quelle"
+
+#: blueman/Sdp.py:125
+msgid "Audio Sink"
+msgstr "Audio-Ausgabe"
+
+#: blueman/Sdp.py:126
+msgid "Remote Control Target"
+msgstr "Fernsteuerungsziel"
+
+#: blueman/Sdp.py:127
+msgid "Advanced Audio"
+msgstr "Verbessertes Audio-Profil (A2DP)"
+
+#: blueman/Sdp.py:128
+msgid "Remote Control"
+msgstr "Fernsteuerung"
+
+#: blueman/Sdp.py:129
+msgid "Video Conferencing"
+msgstr "Videokonferenz"
+
+#: blueman/Sdp.py:130
+msgid "Intercom"
+msgstr ""
+
+#: blueman/Sdp.py:131
+msgid "Fax"
+msgstr "Fax"
+
+#: blueman/Sdp.py:132
+msgid "Headset Audio Gateway"
+msgstr "Headset Audio Gateway"
+
+#: blueman/Sdp.py:133
+msgid "WAP"
+msgstr ""
+
+#: blueman/Sdp.py:134
+msgid "WAP Client"
+msgstr ""
+
+#: blueman/Sdp.py:135
+msgid "PANU"
+msgstr ""
+
+#: blueman/Sdp.py:136
+msgid "Network Access Point"
+msgstr "Network Access Point (NAP)"
+
+#: blueman/Sdp.py:137
+msgid "Group Network"
+msgstr "Gruppennetzwerk"
+
+#: blueman/Sdp.py:138
+msgid "DirectPrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:139
+msgid "ReferencePrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:140
+msgid "Imaging (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:141
+msgid "ImagingResponder (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:142
+msgid "ImagingAutomaticArchive (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:143
+msgid "ImagingReferencedObjects (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr "Telefonbuchzugriff (PBAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr "Nachrichtenzugriff (MAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr "Netzwerk"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr "Dateitransfer"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr "Video-Quelle"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr "Video-Ausgabe"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr "Gesundheitsgeräte-Quelle (HDP)"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr "Zeitdienst"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr "Geräteinformationen"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr "Batterie-Dienst"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr "Objekt-Übertragung"
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr "AppleAgent"
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr ""
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr ""
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 msgid "Device Name"
 msgstr "Gerätename"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr ""
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "automatische Verbindungsprofile"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietär"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ja"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nein"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Geräteinformationen anzeigen"
 
@@ -1742,34 +2150,35 @@ msgstr "Audio-Profil"
 msgid "Select audio profile for PulseAudio"
 msgstr "Audioprofil für PulseAudio auswählen"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Serielle Schnittstelle %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "IP-Adresse erneuern"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Einwahleinstellungen"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Serielle Anschlüsse"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nicht festgelegt"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Verbunden"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Automatisch mit %(service)s auf %(device)s verbunden"
@@ -1837,22 +2246,17 @@ msgstr "_Netzwerknutzung"
 msgid "Shows network traffic usage"
 msgstr "Zeigt Netzwerk-Chronik"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth aktiviert"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth deaktiviert"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Verwaltet das lokale Netzwerk, wie z.B. NAP-Brücken"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1860,7 +2264,7 @@ msgstr ""
 "Stellt Unterstützung für Wählverbindungen mit ModemManager und "
 "NetworkManager zur Verfügung"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1868,37 +2272,37 @@ msgstr ""
 "Schnellzugriff bereithält"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maximalanzahl"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Die maximale Anzahl der letzten Verbindungen wird angezeigt."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Zuletzt benutzte _Verbindungen"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Verbunden mit %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Verbindung gescheitert"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s auf %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adapter für diese Verbindung ist nicht verfügbar"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1906,41 +2310,41 @@ msgstr ""
 "Stellt Unterstützung für Personal-Area-Networking (PAN), welches in der "
 "Netzwerkverwaltung 0.8 integriert ist, zur Verfügung"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Stellt eine DBus-API für andere Blueman-Komponenten bereit"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Dateiempfang über Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Ankommende Datei %(0)s von %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Ablehnen"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "empfange Datei"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Empfange Datei %(0)s von %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Stellt OBEX-Dateiübertragungs-Funktionen bereit"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Konfiguriertes Verzeichnis für eingehende Dateien existiert nicht"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1949,37 +2353,37 @@ msgstr ""
 "Bitte stellen Sie sicher, dass das Verzeichnis „<b>%s</b>“ vorhanden ist "
 "oder konfigurieren Sie es mit blueman-services. Bis dahin wird „%s“ verwendet"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Datei empfangen"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Datei %(0)s von %(1)s erfolgreich empfangen"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Übertragung fehlgeschlagen"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Transfer der Datei %(0)s fehlgeschlagen"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Dateien empfangen"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "%(files)d Datei im Hintergrund empfangen"
 msgstr[1] "%(files)d Dateien im Hintergrund empfangen"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1993,27 +2397,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Blendet Standardmenüelemente im Statussymbolmenü ein"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Neues Gerät einrichten"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "_Dateien an Gerät senden"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Geräte"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_ter"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "Applet"
 
@@ -2025,28 +2429,28 @@ msgstr "Stellt den Passwortlegitimierungssdienst für den BlueZ-Dienst bereit"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Blendet ein Menüelement ein, mit dem das Applet beendet werden kann"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 "Stellt einen einfachen DHCP-Client für Bluetooth-PAN-Verbindungen bereit."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth-Netzwerk"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Schnittstelle %(0)s gebunden an IP-Adresse %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Konnte keine IP-Adresse von %s erhalten"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2055,7 +2459,7 @@ msgstr ""
 "Es wird versucht, eine IP-Adresse auf %s zu erhalten\n"
 "Bitte warten …"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2063,22 +2467,27 @@ msgstr ""
 "Blendet auf dem Statussymbol eine Anzeige ein, wenn Bluetooth aktiv ist, und "
 "zeigt beim Überfahren die Anzahl der aktiven Verbindungen an."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth aktiv"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%(connections)d aktive Verbindung</b>"
 msgstr[1] "<b>%(connections)d aktive Verbindungen</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth deaktiviert"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Benutzt libappindicator, um ein Statussymbol anzuzeigen"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2086,35 +2495,36 @@ msgstr ""
 "Schafft einen Menüpunkt, der den Standard-Adapter temporär anzeigt, falls er "
 "auf „Versteckt“ geschaltet ist"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Feststellbarer Timeout"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Zeitspanne (in Sekunden), die der Adapter sichtbar sein wird"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Erkennbar machen"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Den Standard-Adapter vorübergehend sichtbar machen"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Sichtbar … %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Stellt ein Menü für das Hilfsprogramm und eine API für andere Erweiterungen "
 "zum Verändern desselben zur Verfügung"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2123,24 +2533,24 @@ msgstr ""
 "Verbindung zum <b>DUN</b>-Dienst auf <b>%(0)s</b> hergestellt.\n"
 "Netzwerk ist nun erreichbar durch <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Stellt eine einfache Unterstützung für Verbindungen ins Internet über ein "
 "DUN-Profil bereit."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standard-SPP-Profil-Verbindungssteuerungsprogramm. Ermöglicht es, "
 "benutzerdefinierte Aktionen auszuführen"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Bei Verbindung auszuführendes Skript"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2159,22 +2569,22 @@ msgstr ""
 "Wenn das Gerät getrennt wird, wird ein HUP-Signal an das Skript gesendet.</"
 "span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Serielle Schnittstelle verbunden"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "Serielle Schnittstelle auf Gerät <b>%s</b> ist nun verfügbar durch <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Verbindungsskript für serielle Schnittstelle ist fehlgeschlagen"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2183,37 +2593,37 @@ msgstr ""
 "Beim Ausführen des Skriptes %s ist ein Problem aufgetreten:\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Steuert den Energiestatus des Bluetoothadapters"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatisches einschalten"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Adapter automatisch einschalten"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Bluetooth _ausschalten</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Alle Adapter ausschalten"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Bluetooth _einschalten</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Alle Adapter einschalten"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2221,23 +2631,22 @@ msgstr ""
 "Unterbricht vorübergehend den Bildschirmschoner, wenn eine Bluetooth-"
 "Gamecontroller angeschlossen wird."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Netzwerk"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Ungültige IP-Adresse"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "IP-Adresse ist im Konflikt mit der Schnittstelle %s, welche die gleiche "
 "Adresse hat"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2248,8 +2657,8 @@ msgstr ""
 "die folgende Konfiguration hat: %s/%s\n"
 "Dies könnte zu fehlerhaftem Verhalten führen"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Diese Konfiguration wird derzeit nicht unterstützt"
 
@@ -2265,10 +2674,6 @@ msgstr "Die Erweiterung für den Datentransferservice ist deaktiviert"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth-Adapter-Einstellungen"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman Applet"
@@ -2276,11 +2681,6 @@ msgstr "Blueman Applet"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Bluetooth Manager"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2323,6 +2723,31 @@ msgid "Setting RfKill State requires privileges"
 msgstr ""
 "Um den RfKill-Status festlegen zu können sind Zugriffsrechte erforderlich"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "PIN Code eingeben"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Passwort eingeben"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Serieller Anschluss verbunden mit %s"
+
+#~ msgid "palm"
+#~ msgstr "Palm"
+
+#~ msgid "isdn"
+#~ msgstr "ISDN-Gerät"
+
+#~ msgid "headset"
+#~ msgstr "Headset"
+
+#~ msgid "handsfree"
+#~ msgstr "Freisprecheinrichtung"
+
+#~ msgid "unknown"
+#~ msgstr "Unbekannt"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth-Geräte"
 
@@ -2341,11 +2766,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Entfernen …"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Verbinden"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/el.po
+++ b/po/el.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: george k <norhorn@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/blueman/blueman/el/"
@@ -32,7 +32,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Ρύθμιση Ορατότητας</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Σε απόκρυψη"
 
@@ -76,8 +76,8 @@ msgstr "_Συσκευή"
 msgid "_View"
 msgstr "_Προβολή"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Βοήθεια"
 
@@ -90,7 +90,7 @@ msgstr "Αναζήτηση συσκευών που βρίσκονται κοντ
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Δημιουργία ζεύξης με τη συσκευή"
 
@@ -99,17 +99,17 @@ msgstr "Δημιουργία ζεύξης με τη συσκευή"
 msgid "Pair"
 msgstr "Ζεύξη"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Σημείωση αυτής της συσκευής ως έμπιστης/μη έμπιστης"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Έμπιστο"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Εκτέλεση βοηθού εγκατάστασης για αυτή την συσκευή"
 
@@ -118,7 +118,7 @@ msgstr "Εκτέλεση βοηθού εγκατάστασης για αυτή �
 msgid "Setup..."
 msgstr "Ρύθμιση..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Αφαίρεση αυτής της συσκευής από τη λίστα γνωστών συσκευών"
 
@@ -299,7 +299,12 @@ msgstr "Ακαθόριστο"
 msgid "<b>Author:</b>"
 msgstr "<b>Συγγραφέας:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -361,7 +366,7 @@ msgstr "Επαναφο_ρά"
 msgid "Send note"
 msgstr "Αποστολή σημείωσης"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "Πρέπει να ενεργοποιηθεί το Bluetooth για να μπορεί να λειτουργήσει ο "
@@ -371,34 +376,32 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Προσαρμογείς Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Πάντα"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Λεπτό"
 msgstr[1] "%d Λεπτά"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Προσαρμογέας"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "Πρέπει να είναι ενεργοποιημένο το Bluetooth για να μπορέσει να λειτουργήσει "
 "ο διαχειριστής συσκευών"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Απέτυχε η σύνδεση με το BlueZ"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -413,143 +416,135 @@ msgstr ""
 msgid "Searching"
 msgstr "Αναζήτηση"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Βοηθός Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Προτιμήσεις προσαρμογέα"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Αποστολέας αρχείων"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Μεταφορά αρχείων μέσω Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Γίνεται σύνδεση"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "Το obexd δεν είναι διαθέσιμο"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Η αυτόματη εκκίνηση της υπηρεσίας obex απέτυχε. Βεβαιωθείτε ότι εκτελείται"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Ακύρωση"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Αποστολή Αρχείου"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Χρόνος Που Απομένει:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Παρουσιάστηκε σφάλμα κατα την αποστολή του αρχείου %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Παράλεψη"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Επανάληψη"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Παρουσιάστηκε σφάλμα"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Τοπικές υπηρεσίες"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Αίτηση ζεύξης για %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Αυθεντικοποίηση Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Εισάγετε τον κωδικό PIN για αυθεντικοπίηση:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Εισάγετε τον κωδικό PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Εισάγετε φράση-κλειδιού πρόσβασης για την αυθεντικοποίηση:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Εισάγετε τη φράση-κλειδί"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Φράση-κλειδί ζεύξης για"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Κωδικός ΡΙΝ ζεύξης για"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Αίτημα ζεύξης για:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Επιβεβαίωση τιμής για αυθεντικοποίηση:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Επιβεβαίωση"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Άρνηση"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Αίτημα εξουσιοδότησης απο:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Υπηρεσία:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Πάντα αποδοχή"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Αποδοχή"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -584,243 +579,240 @@ msgstr "Ναι"
 msgid "No"
 msgstr "Όχι"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Αναφορά Προβλήματος"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Διαχειριστής Συσκευών"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Εμφάνιση ερ_γαλειοθήκης"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Εμφάνιση γραμμής_Κατάστασης"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Τα_ξινόμηση ανά"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Όνομα"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_ Προστέθηκε"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Μείωση"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Πρόσθετα"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Τοπικές Υπηρεσίες"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Προτιμήσεις Υπηρεσίας"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Αναζήτηση"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Προτιμήσεις προσαρμογέα"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Έξοδος"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "ακατηγοριοποίητο"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Έμπιστος και Συνδυαζμένος</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Συνδυασμένος</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Έμπιστες</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Κακή"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Ημί-βέλτιστη"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Βέλτιστη"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Ικανοποιητική"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Ιδιαίτερα ικανοποιητική"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Υψηλή"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Πολύ Υψηλή"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Επιτυχία!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Η σειριακή θύρα συνδέθηκε σε %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Αποτυχία"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Η σύνδεση απέτυχε: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Γίνεται σύνδεση"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Αποτυχία αποσύνδεσης: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Γίνεται αποσύνδεση..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Σύνδεση</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Συνδέει τα προφίλ αυτόματης σύνδεσης A2DP source, A2DP sink, και HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Αποσύνδεση</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Εξαναγκαστική αποσύνδεση συσκευής"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Σύνδεση σε:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Αποσύνδεση:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Αποστολή _Αρχείου..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Ζευξη"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Έμπιστο"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Μη έμπιστη"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Ρύθμιση…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Μετονομασία συσκευής"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Αφαίρεση"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Ακύρωση λειτουργίας"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Ένδειξη δραστηριότητας δεδομένων"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Σύνολο ληφθέντων δεδομένων και ρυθμός μετάδοσης"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Σύνολο απεσταλμένων δεδομένων και ρυθμός μετάδοσης"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Μη Έμπιστη"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Επιλογή συσκευής"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Περισσότερα"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -836,7 +828,7 @@ msgstr ""
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  Τάσος Παπανικολάου https://launchpad.net/~taspap"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Το Blueman είναι ένα διαχειριστής Bluetooth στο GTK+"
 
@@ -844,17 +836,17 @@ msgstr "Το Blueman είναι ένα διαχειριστής Bluetooth στο
 msgid "GSM Settings"
 msgstr "Ρυθμίσεις GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Πρόσθετα"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Πρόβλημα εξάρτησης"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -865,7 +857,7 @@ msgstr ""
 "<b>%(1)s</b> θα έχει ως αποτέλεσμα την αποφόρτωση και του <b>\"%(0)s\"</b>.\n"
 "Θέλετε να συνεχίσετε;"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -876,886 +868,1259 @@ msgstr ""
 "Όταν φορτώσετε το <b>%(1)s</b> θα αποφορτώσετε το <b>%(0)s</b>.\n"
 "Θέλετε να συνεχίσετε;"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Επιλογή προσαρμογέα"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Ανιχνεύσιμο... %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "ακατηγοριοποίητο"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Σημείο πρόσβασης δικτύου"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "επιφάνεια εργασίας"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "διακομιστής"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "φορητός υπολογιστής"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "υπολογιστής παλάμης"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "μέγεθος παλάμης"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "κινητό"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "ασύρματο"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "έξυπνο τηλέφωνο"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "μόντεμ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "Το obexd δεν είναι διαθέσιμο"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "σετ ακουστικών"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "ακουστικά"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "άγνωστο"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "μικρόφωνο"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Πηγή ήχου"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Πηγή ήχου"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Πηγή ήχου"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "πληκτρολόγιο"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "συσκευή επίδειξης"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "πληκτρολόγιο"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "συσκευή επίδειξης"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Σύνδεση"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Σύνδεση"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Σύνδεση"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Σύνδεση"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Μεταφορά αρχείων μέσω Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Σύνδεση"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Μεταφορά αρχείων μέσω Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Μεταφορά αρχείων μέσω Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Ομάδα δικτύου"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Μεταφορά αρχείων μέσω Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Σύνδεση"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Σύνδεση"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Μεταφορά αρχείων μέσω Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Σύνδεση"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Ομάδα δικτύου"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Σειριακές Θύρες"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Σύνδεση μέσω τηλεφώνου (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Μεταφορά αρχείων μέσω Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "σετ ακουστικών"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Πηγή ήχου"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Προορισμός Ήχου"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Σημείο πρόσβασης δικτύου"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Ομάδα δικτύου"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "ακουστικά"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Σημείο Πρόσβασης Δικτύου (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Σημείο Πρόσβασης Δικτύου (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Ομάδα δικτύου"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Μεταφορά αρχείων μέσω Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Πηγή ήχου"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Προορισμός Ήχου"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Πηγή ήχου"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Μετονομασία συσκευής"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Εμφάνιση πληροφορίες συσκευής"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Τοπικές υπηρεσίες"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Μεταφορά"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "Μικροεφαρμογή"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Ταίριασμα συσκευής"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Αναζήτηση συσκευών που βρίσκονται κοντά"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Μεταφορά"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "Μικροεφαρμογή"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Ταίριασμα συσκευής"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Αναζήτηση συσκευών που βρίσκονται κοντά"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Διαχειριστής Συσκευών"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Πρόσφατες _Συνδέσεις"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Διαχειριστής Συσκευών"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Προτιμήσεις προσαρμογέα"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Αυτόματη σύνδεση προφίλ"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Ιδιόκτητο"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ναι"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "όχι"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Πληροφορίες"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Εμφάνιση πληροφορίες συσκευής"
 
@@ -1780,34 +2145,35 @@ msgstr "Προφίλ Ήχου"
 msgid "Select audio profile for PulseAudio"
 msgstr "Επιλογή προφίλ ήχου για το PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Σειριακή Θύρα %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Ανανέωση Διεύθυνσης IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Ρυθμίσεις Dialup"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Σειριακές Θύρες"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Ακαθόριστο"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Συνδεδεμένο"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Αυτόματη σύνδεση στο %(service)s του %(device)s"
@@ -1875,22 +2241,17 @@ msgstr "_Χρήση δικτύου"
 msgid "Shows network traffic usage"
 msgstr "Εμφανίζει τη χρήση κίνησης δικτύου"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Το Bluetooth Ενεργοποιήθηκε"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Το Bluetooth Απενεργοποιήθηκε"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Διαχειρίζεται υπηρεσίες τοπικού δικτύου, όπως γέφυρες NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1898,7 +2259,7 @@ msgstr ""
 "Παρέχει υποστήριξη για συνδέσεις μέσω τηλεφώνου (DUN) με τη βοήθεια του "
 "Διαχειριστή Modem και του Διαχειριστή Δικτύου"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1906,38 +2267,38 @@ msgstr ""
 "πρόσβαση"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Μέγιστος αριθμός αντικειμένων"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Ο κατάλογος για το μέγιστο αριθμό των πρόσφατων συνδέσεων θα εμφανιστεί."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Πρόσφατες _Συνδέσεις"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Συνδέθηκε στο %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Αποτυχία σύνδεσης"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s στο %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Ο προσαρμογέας για αυτή τη σύνδεση δεν είναι διαθέσιμος"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1945,41 +2306,41 @@ msgstr ""
 "Παρέχει υποστήριξη για Personal Area Networking (PAN) το οποίο "
 "πρωτοεμφανίστηκε στον NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Παρέχει DBus API για άλλα στοιχεία του Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Εισερχόμενο αρχείο μέσω Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Εισερχόμενο αρχείο %(0)s από %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Απόρριψη"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Λήψη αρχείου"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Λήψη αρχείου %(0)s από %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Παρέχει δυνατότητες μεταφοράς αρχείων OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Ο ρυθμισμένος ως κατάλογος εισερχομένων αρχείων, δεν υπάρχει"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1988,42 +2349,38 @@ msgstr ""
 "Βεβαιωθείτε ότι ο κατάλογος \"<b>%s</b>\" υπάρχει ή ρυθμίστε τον με τις "
 "υπηρεσίες του blueman. Μέχρι τότε θα χρησιμοποιηθεί η προεπιλογή \"%s\""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Ελήφθη αρχείο"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Το αρχείο %(0)s ελήφθη επιτυχώς από το %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Η μεταφορά απέτυχε"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Η μεταφορά του αρχείου %(0)s απέτυχε"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Ελήφθησαν αρχεία"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Ελήφθη %d αρχείο στο παρασκήνιο"
 msgstr[1] "Ελήφθησαν %d αρχεία στο παρασκήνιο"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Ελήφθη άλλο %d αρχείο στο παρασκήνιο"
@@ -2036,27 +2393,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Προσθέτει τυπικά στοιχεία μενού στο μενού εικονιδίων κατάστασης"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Εγκατάσταση Νέας Συσκευής"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Αποστολή _Αρχείου σε Συσκευή"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Συσκευές"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Προσαρμο_γείς"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "Μικροεφαρμογή"
 
@@ -2071,27 +2428,27 @@ msgstr ""
 "Προσθέτει ένα αντικείμενο μενού εξόδου στον κατάλογο για τερματισμό της "
 "μικροεφαρμογής"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Παρέχει ένα βασικό πελάτη dhcp για συνδέσεις Bluetooth PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Δίκτυο Βluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Η διεπαφή %(0)s έχει αντιστοιχιστεί με την διεύθυνση IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Αποτυχία κατά την απόκτηση διεύθυνσης IP από το %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2100,7 +2457,7 @@ msgstr ""
 "Προσπάθεια λήψης μιας διεύθυνσης IP%s\n"
 "Παρακαλώ περιμένετε…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2110,26 +2467,29 @@ msgstr ""
 "εμφανίζεται όταν ο δρομέας του ποντικιού βρίσκεται πάνω στο εικονίδιο "
 "κατάστασης."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth Ενεργό"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Ενεργή Σύνδεση</b>"
 msgstr[1] "<b>%d Ενεργές Συνδέσεις</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Το Bluetooth Απενεργοποιήθηκε"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 "Χρησιμοποιεί τη βιβλιοθήκη libappindicator για να εμφανίσει ένα εικονίδιο "
 "κατάστασης"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2137,37 +2497,38 @@ msgstr ""
 "Παρέχει ένα στοιχείο μενού για προσωρινή ενεργοποίηση της ορατότητας του "
 "προεπιλεγμένου προσαρμογέα, όταν αυτός κανονικά είναι ρυθμισμένος σε απόκρυψη"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Χρονικό όριο λειτουργίας ορατότητας"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 "Χρονικό διάστημα (σε δευτερόλεπτα) για το οποίο θα είναι ενεργή η λειτουργία "
 "ορατότητας"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Ορισμός ως Ανι_χνεύσιμο"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Προσωρινή ενεργοποίηση ορατότητας προεπιλεγμένου προσαρμογέα"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Ανιχνεύσιμο... %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Παρέχει ένα μενού για την μικροεφαρμογή και ένα API για χειρισμό της από "
 "άλλα πρόσθετα"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2176,23 +2537,23 @@ msgstr ""
 "Επιτυχής σύνδεση στην υπηρεσία <b>DUN</b> στο <b>%(0)s.</b>\n"
 "Το δίκτυο είναι τώρα διαθέσιμο μέσω <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Παρέχει βασική υποστήριξη για σύνδεση στο διαδίκτυο μέσω ενός προφίλ DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Πρότυπο προφίλ SPP διαχείρισης συνδέσεων, επιτρέπει την εκτέλεση "
 "προσαρμοσμένων ενεργειών"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Δέσμη εντολών προς εκτέλεση κατά τη σύνδεση"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2211,11 +2572,11 @@ msgstr ""
 "Με την αποσύνδεση της συσκευής θα αποσταλεί ένα σήμα HUP στη δέσμη εντολών</"
 "span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Η σειριακή θύρα συνδέθηκε"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2223,11 +2584,11 @@ msgstr ""
 "Η υπηρεσία σειριακής θύρα της συσκευής <b>%s</b> θα είναι διαθέσιμη μέσω <b>"
 "%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Η δέσμη εντολών για τη σύνδεση σειριακής θύρας απέτυχε"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2236,37 +2597,37 @@ msgstr ""
 "Υπήρξε ένα πρόβλημα κατά την εκτέλεση της δέσμης εντολών %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Ελέγχει την κατάσταση ενέργειας του προσαρμογέα Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Αυτόματη ενεργοποίηση"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Αυτόματη ενεργοποίηση προσαρμογέων"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Απενεργοποίηση Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Απενεργοποίηση όλων των προσαρμογέων"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Ενεργοποίηση Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Ενεργοποίηση όλων των προσαρμογέων"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2274,22 +2635,21 @@ msgstr ""
 "Διακόπτει προσωρινά την προφύλαξη οθόνης όταν ένα χειριστήριο παιχνιδιού "
 "συνδεθεί."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Δίκτυο"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Μη έγκυρη διεύθυνση IP"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "Η διεύθυνση IP συγκρούεται με τη διεπαφή %s η οποία έχει την ίδια διεύθυνση"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2300,8 +2660,8 @@ msgstr ""
 "παράμετρους %s/%s\n"
 "Αυτό μπορεί να προκαλέσει εσφαλμένη συμπεριφορά δικτύου"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Δεν υποστηρίζονται αυτή τη στιγμή με αυτή τη ρύθμιση"
 
@@ -2318,10 +2678,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Ρύθμιση προσαρμογέα Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "συσκευή-blueman"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Εφαρμογή blueman"
@@ -2329,11 +2685,6 @@ msgstr "Εφαρμογή blueman"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Διαχειριστής bluetooth του blueman"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2375,6 +2726,37 @@ msgstr "Ορισμός κατάστασης RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Η ρύθμιση κατάστασης RfKill απαιτεί δικαιώματα"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Εισάγετε τον κωδικό PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Εισάγετε τη φράση-κλειδί"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Η σειριακή θύρα συνδέθηκε σε %s"
+
+#~ msgid "palm"
+#~ msgstr "μέγεθος παλάμης"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "σετ ακουστικών"
+
+#~ msgid "handsfree"
+#~ msgstr "ακουστικά"
+
+#~ msgid "unknown"
+#~ msgstr "άγνωστο"
+
+#~ msgid "blueman-device"
+#~ msgstr "συσκευή-blueman"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Συσκευές Bluetooth"
 
@@ -2395,11 +2777,6 @@ msgstr "Η ρύθμιση κατάστασης RfKill απαιτεί δικαι�
 
 #~ msgid "_Remove..."
 #~ msgstr "_Αφαίρεση..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Σύνδεση"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-03-28 10:09+0000\n"
 "Last-Translator: Jeannette L <j.lavoie@net-c.ca>\n"
 "Language-Team: English (Australia) <https://hosted.weblate.org/projects/"
@@ -24,7 +24,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Visibility Setting</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Hidden"
 
@@ -68,8 +68,8 @@ msgstr "_Device"
 msgid "_View"
 msgstr "_View"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Help"
 
@@ -82,7 +82,7 @@ msgstr "Search for nearby devices"
 msgid "Search"
 msgstr "Search"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Create pairing with the device"
 
@@ -91,17 +91,17 @@ msgstr "Create pairing with the device"
 msgid "Pair"
 msgstr "Pair"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Mark/Unmark this device as trusted"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Trust"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Run the setup assistant for this device"
 
@@ -110,7 +110,7 @@ msgstr "Run the setup assistant for this device"
 msgid "Setup..."
 msgstr "Setup..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Remove this device from the known devices list"
 
@@ -291,7 +291,12 @@ msgstr "Not specified"
 msgid "<b>Author:</b>"
 msgstr "<b>Author:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -353,7 +358,7 @@ msgstr "_Reset"
 msgid "Send note"
 msgstr "Send note"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth needs to be turned on for the adaptor manager to work"
 
@@ -361,32 +366,30 @@ msgstr "Bluetooth needs to be turned on for the adaptor manager to work"
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth Adaptors"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Always"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minute"
 msgstr[1] "%d Minutes"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth needs to be turned on for the device manager to function"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Connection to BlueZ failed"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -400,142 +403,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Searching"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth Assistant"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adapter Preferences"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "File Sender"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth File Transfer"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Connecting"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd not available"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr "Failed to autostart obex service. Make sure the obex daemon is running"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Cancelling"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Sending File"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Error occurred while sending file %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Skip"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Retry"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Error occurred"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Local Services"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Pairing request for %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth Authentication"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Enter PIN code for authentication:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Enter PIN code"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Enter passkey for authentication:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Enter passkey"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Pairing passkey for"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Pairing PIN code for"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Pairing request for:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirm value for authentication:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirm"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Deny"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Authorisation request for:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Service:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Always accept"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Accept"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -569,245 +564,243 @@ msgstr "Yes"
 msgid "No"
 msgstr "No"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Report a Problem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Device Manager"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Show _Toolbar"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Show _Statusbar"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "S_ort By"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Name"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Added"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Descending"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Plugins"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Local Services"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Service Preferences"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Search"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Adapter Preferences"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "uncategorised"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Trusted and paired</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Paired</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Trusted</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Poor"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Sub-optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Much"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Too much"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Low"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "High"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Very High"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Success!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Serial port connected to %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Failed"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Connection Failed: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Connecting"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Disconnection Failed: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Disconnecting..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Forcefully disconnect the device"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Connect To:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Disconnect:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Send a _File..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Pair"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Trust"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Untrust"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Rename device"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Remove"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Cancel Operation"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Data activity indication"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Total data received and rate of transmission"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Total data sent and rate of transmission"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Untrust"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Select Device"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "More"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr "translator-credits"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman is a GTK+ Bluetooth manager"
 
@@ -815,17 +808,17 @@ msgstr "Blueman is a GTK+ Bluetooth manager"
 msgid "GSM Settings"
 msgstr "GSM Settings"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Plugins"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Dependency issue"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -836,7 +829,7 @@ msgstr ""
 "also unload <b>\"%(0)s\"</b>.\n"
 "Proceed?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -847,886 +840,1259 @@ msgstr ""
 "unload <b>%(0)s</b>.\n"
 "Proceed?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Adaptor selection"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Discoverable… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "uncategorised"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Network Access Point"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "desktop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "handheld"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobile"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "cordless"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smart phone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd not available"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "headset"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "unknown"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "microphone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Audio Source"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Audio Source"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Audio Source"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "keyboard"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "pointing"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "keyboard"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "pointing"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Group Network"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Group Network"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Serial Ports"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Dialup Networking (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth File Transfer"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "headset"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Audio Source"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Audio Sink"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Network Access Point"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Group Network"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Group Network"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth File Transfer"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Audio Source"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Audio Sink"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Audio Source"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Rename device"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Show device information"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Local Services"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Transfer"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "applet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Pair Device"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Search for nearby devices"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Transfer"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "applet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Pair Device"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Search for nearby devices"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Device Manager"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Recent _Connections"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Device Manager"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Adapter Preferences"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Auto connect profiles"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietary"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "yes"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "no"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Show device information"
 
@@ -1751,34 +2117,35 @@ msgstr "Audio Profile"
 msgid "Select audio profile for PulseAudio"
 msgstr "Select audio profile for PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Serial Port %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Renew IP Address"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Dialup Settings"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Serial Ports"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Unspecified"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Connected"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1845,22 +2212,17 @@ msgstr "Network _Usage"
 msgid "Shows network traffic usage"
 msgstr "Shows network traffic usage"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Enabled"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth Disabled"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Manages local network services, like NAP bridges"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1868,44 +2230,44 @@ msgstr ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 "Provides a menu item that contains last used connections for quick access"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maximum items"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "The maximum number of items recent connections menu will display."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Recent _Connections"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Connected to %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Failed to connect"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s on %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adaptor for this connection is not available"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1913,41 +2275,41 @@ msgstr ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Provides DBus API for other Blueman components"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Incoming file over Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Incoming file %(0)s from %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Reject"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Receiving file"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Receiving file %(0)s from %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Provides OBEX file transfer capabilities"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Configured directory for incoming files does not exist"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1956,42 +2318,38 @@ msgstr ""
 "Please make sure that directory ‘<b>%s</b>’ exists or configure it with "
 "blueman-services. Until then the default ‘%s’ will be used"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "File received"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "File %(0)s from %(1)s successfully received"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Transfer failed"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Transfer of file %(0)s failed"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Files received"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Received %d file in the background"
 msgstr[1] "Received %d files in the background"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Received %d more file in the background"
@@ -2004,27 +2362,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Adds standard menu items to the status icon menu"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Set Up New Device"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Send _Files to Device"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Devices"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_tors"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2036,27 +2394,27 @@ msgstr "Provides passkey, authentication services for BlueZ daemon"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Adds an exit menu item to quit the applet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Provides a basic dhcp client for Bluetooth PAN connections."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth Network"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interface %(0)s bound to IP address %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Failed to obtain an IP address on %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2065,7 +2423,7 @@ msgstr ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2073,24 +2431,27 @@ msgstr ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth Active"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Active Connection</b>"
 msgstr[1] "<b>%d Active Connections</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth Disabled"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Uses libappindicator to show a statusicon"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2098,34 +2459,35 @@ msgstr ""
 "Provides a menu item for making the default adaptor temporarily visible when "
 "it is set to hidden by default"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Discoverable timeout"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Amount of time in seconds discoverable mode will last"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Make Discoverable"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Make the default adaptor temporarily visible"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Discoverable… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2134,21 +2496,21 @@ msgstr ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "Provides basic support for connecting to the internet via DUN profile."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standard SPP profile connection handler, allows executing custom actions"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script to execute on connection"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2166,22 +2528,22 @@ msgstr ""
 "\n"
 "Upon device disconnection the script will be sent a HUP signal</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Serial port connected"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Serial port connection script failed"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2190,37 +2552,37 @@ msgstr ""
 "There was a problem launching script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Controls Bluetooth adaptor power states"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Auto power-on"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automatically power on adapters"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Turn Bluetooth _Off</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Turn off all adaptors"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Turn Bluetooth _On</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Turn on all adaptors"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2228,21 +2590,20 @@ msgstr ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Network"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Invalid IP address"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP address conflicts with interface %s which has the same address"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2253,8 +2614,8 @@ msgstr ""
 "configuration  %s/%s\n"
 "This may cause incorrect network behaviour"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Not currently supported with this setup"
 
@@ -2268,40 +2629,26 @@ msgstr "Applet's transfer service plugin is disabled"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Adaptors"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman is a GTK+ Bluetooth manager"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Enabled"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth Devices"
 
@@ -2337,6 +2684,31 @@ msgstr "Set RfKill State"
 msgid "Setting RfKill State requires privileges"
 msgstr "Setting RfKill State requires privileges"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Enter PIN code"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Enter passkey"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Serial port connected to %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "headset"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "unknown"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth Devices"
 
@@ -2357,11 +2729,6 @@ msgstr "Setting RfKill State requires privileges"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Remove..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Connect"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-03-28 10:09+0000\n"
 "Last-Translator: Jeannette L <j.lavoie@net-c.ca>\n"
 "Language-Team: English (United Kingdom) <https://hosted.weblate.org/projects/"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Visibility Setting</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Hidden"
 
@@ -70,8 +70,8 @@ msgstr "_Device"
 msgid "_View"
 msgstr "_View"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Help"
 
@@ -84,7 +84,7 @@ msgstr "Search for nearby devices"
 msgid "Search"
 msgstr "Search"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Create pairing with the device"
 
@@ -93,17 +93,17 @@ msgstr "Create pairing with the device"
 msgid "Pair"
 msgstr "Pair"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Mark/Unmark this device as trusted"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Trust"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Run the setup assistant for this device"
 
@@ -112,7 +112,7 @@ msgstr "Run the setup assistant for this device"
 msgid "Setup..."
 msgstr "Setup..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Remove this device from the known devices list"
 
@@ -293,7 +293,12 @@ msgstr "Not specified"
 msgid "<b>Author:</b>"
 msgstr "<b>Author:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -355,7 +360,7 @@ msgstr "_Reset"
 msgid "Send note"
 msgstr "Send note"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth needs to be turned on for the adaptor manager to work"
 
@@ -363,32 +368,30 @@ msgstr "Bluetooth needs to be turned on for the adaptor manager to work"
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth Adaptors"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Always"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minute"
 msgstr[1] "%d Minutes"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth needs to be turned on for the device manager to function"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Connection to BlueZ failed"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -402,142 +405,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Searching"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth Assistant"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adapter Preferences"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "File Sender"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth File Transfer"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Connecting"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd not available"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr "Failed to autostart obex service. Make sure the obex daemon is running"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Cancelling"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Sending File"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Error occurred while sending file %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Skip"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Retry"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Error occurred"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Local Services"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Pairing request for %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth Authentication"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Enter PIN code for authentication:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Enter PIN code"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Enter passkey for authentication:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Enter passkey"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Pairing passkey for"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Pairing PIN code for"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Pairing request for:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirm value for authentication:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirm"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Deny"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Authorisation request for:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Service:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Always accept"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Accept"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -571,243 +566,240 @@ msgstr "Yes"
 msgid "No"
 msgstr "No"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Report a Problem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Device Manager"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Show _Toolbar"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Show _Statusbar"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "S_ort by"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Name"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Added"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Descending"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Plug-ins"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Local Services"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Service Preferences"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Search"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Adapter Preferences"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "uncategorised"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Trusted and paired</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Paired</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Trusted</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Poor"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Sub-optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Much"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Too much"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Low"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "High"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Very High"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Success!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Serial port connected to %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Failed"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Connection Failed: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Connecting"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Disconnection failed: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Disconnecting..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 #, fuzzy
-#| msgid "<b>Disconnect:</b>"
 msgid "_<b>Disconnect</b>"
 msgstr "<b>Disconnect:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Forcefully disconnect the device"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Connect To:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Disconnect:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Send a _File..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Pair"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Trust"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Untrust"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Rename device"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Remove"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Cancel Operation"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Data activity indication"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Total data received and rate of transmission"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Total data sent and rate of transmission"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Untrust"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Select Device"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "More"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -819,7 +811,7 @@ msgstr ""
 "  Tristan Brindle https://launchpad.net/~tristan-brindle\n"
 "  Valmantas Palikša https://launchpad.net/~walmis"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman is a GTK+ Bluetooth manager"
 
@@ -827,17 +819,17 @@ msgstr "Blueman is a GTK+ Bluetooth manager"
 msgid "GSM Settings"
 msgstr "GSM Settings"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Dependency issue"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -848,7 +840,7 @@ msgstr ""
 "will also unload <b>\"%(0)s\"</b>.\n"
 "Proceed?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -859,886 +851,1259 @@ msgstr ""
 "unload <b>%(0)s</b>.\n"
 "Proceed?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Adaptor selection"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Discoverable… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "uncategorised"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Network Access Point"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "desktop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "handheld"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobile"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "cordless"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smart phone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd not available"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "headset"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "unknown"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "microphone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Audio Source"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Audio Source"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Audio Source"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "keyboard"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "pointing"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "keyboard"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "pointing"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Group Network"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth File Transfer"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Connect"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Group Network"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Serial Ports"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Dialup Networking (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth File Transfer"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "headset"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Audio Source"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Audio Sink"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Network Access Point"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Group Network"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Group Network"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth File Transfer"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Audio Source"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Audio Sink"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Audio Source"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Rename device"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Show device information"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Local Services"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Transfer"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "applet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Pair device"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Search for nearby devices"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Transfer"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "applet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Pair device"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Search for nearby devices"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Device Manager"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Recent _Connections"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Device Manager"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Adapter Preferences"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Auto connect profiles"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietary"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "yes"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "no"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Show device information"
 
@@ -1763,34 +2128,35 @@ msgstr "Audio Profile"
 msgid "Select audio profile for PulseAudio"
 msgstr "Select audio profile for PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Serial Port %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Renew IP Address"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Dialup Settings"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Serial Ports"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Unspecified"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Connected"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1857,22 +2223,17 @@ msgstr "Network _Usage"
 msgid "Shows network traffic usage"
 msgstr "Shows network traffic usage"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Enabled"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth Disabled"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Manages local network services, like NAP bridges"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1880,44 +2241,44 @@ msgstr ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 "Provides a menu item that contains last used connections for quick access"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maximum items"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "The maximum number of items recent connections menu will display."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Recent _Connections"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Connected to %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Failed to connect"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s on %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adaptor for this connection is not available"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1925,41 +2286,41 @@ msgstr ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Provides DBus API for other Blueman components"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Incoming file over Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Incoming file %(0)s from %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Reject"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Receiving file"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Receiving file %(0)s from %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Provides OBEX file transfer capabilities"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Configured directory for incoming files does not exist"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1968,42 +2329,38 @@ msgstr ""
 "Please make sure that directory ‘<b>%s</b>’ exists or configure it with "
 "blueman-services. Until then the default ‘%s’ will be used"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "File received"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "File %(0)s from %(1)s successfully received"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Transfer failed"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Transfer of file %(0)s failed"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Files received"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Received %d file in the background"
 msgstr[1] "Received %d files in the background"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Received %d more file in the background"
@@ -2016,27 +2373,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Adds standard menu items to the status icon menu"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Set Up New Device"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Send _Files to Device"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Devices"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_tors"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2048,27 +2405,27 @@ msgstr "Provides passkey, authentication services for BlueZ daemon"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Adds an exit menu item to quit the applet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Provides a basic dhcp client for Bluetooth PAN connections."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth Network"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interface %(0)s bound to IP address %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Failed to obtain an IP address on %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2077,7 +2434,7 @@ msgstr ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2085,24 +2442,27 @@ msgstr ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth Active"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Active Connection</b>"
 msgstr[1] "<b>%d Active Connections</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth Disabled"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Uses libappindicator to show a status icon"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2110,34 +2470,35 @@ msgstr ""
 "Provides a menu item for making the default adaptor temporarily visible when "
 "it is set to hidden by default"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Discoverable timeout"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Amount of time in seconds discoverable mode will last"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Make Discoverable"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Make the default adaptor temporarily visible"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Discoverable… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Provides a menu for the applet and an API for other plug-ins to manipulate it"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2146,21 +2507,21 @@ msgstr ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "Provides basic support for connecting to the internet via DUN profile."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standard SPP profile connection handler, allows executing custom actions"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script to execute on connection"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2178,22 +2539,22 @@ msgstr ""
 "\n"
 "Upon device disconnection the script will be sent a HUP signal</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Serial port connected"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Serial port connection script failed"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2202,37 +2563,37 @@ msgstr ""
 "There was a problem launching script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Controls Bluetooth adapter power states"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Auto power-on"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automatically power on adapters"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Turn Bluetooth _Off</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Turn off all adaptors"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Turn Bluetooth _On</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Turn on all adaptors"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2240,21 +2601,20 @@ msgstr ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Network"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Invalid IP address"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP address conflicts with interface %s which has the same address"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2265,8 +2625,8 @@ msgstr ""
 "configuration  %s/%s\n"
 "This may cause incorrect network behaviour"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Not currently supported with this set-up"
 
@@ -2280,40 +2640,26 @@ msgstr "Applet's transfer service plug-in is disabled"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Adaptors"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman is a GTK+ Bluetooth manager"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Enabled"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth Devices"
 
@@ -2349,6 +2695,31 @@ msgstr "Set RfKill State"
 msgid "Setting RfKill State requires privileges"
 msgstr "Setting RfKill State requires privileges"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Enter PIN code"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Enter passkey"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Serial port connected to %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "headset"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "unknown"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth Devices"
 
@@ -2369,11 +2740,6 @@ msgstr "Setting RfKill State requires privileges"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Remove..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Connect"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/es.po
+++ b/po/es.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-21 05:24+0000\n"
 "Last-Translator: Amaro Martínez <xoas@airmail.cc>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -32,7 +32,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Ajustes de visibilidad</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Oculto"
 
@@ -76,8 +76,8 @@ msgstr "_Dispositivo"
 msgid "_View"
 msgstr "_Ver"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "Ay_uda"
 
@@ -90,7 +90,7 @@ msgstr "Buscar dispositivos cercanos"
 msgid "Search"
 msgstr "Buscar"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Crear un vínculo con el dispositivo"
 
@@ -99,17 +99,17 @@ msgstr "Crear un vínculo con el dispositivo"
 msgid "Pair"
 msgstr "Emparejar"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Marcar o desmarcar este dispositivo como de confianza"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Confianza"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Ejecutar el asistente de configuración para este dispositivo"
 
@@ -118,7 +118,7 @@ msgstr "Ejecutar el asistente de configuración para este dispositivo"
 msgid "Setup..."
 msgstr "Configurar..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Eliminar este dispositivo de la lista de dispositivos conocidos"
 
@@ -299,7 +299,12 @@ msgstr "Sin especificar"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -361,7 +366,7 @@ msgstr "_Restablecer"
 msgid "Send note"
 msgstr "Enviar una nota"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "Es necesario encender el adaptador Bluetooth para que funcione el gestor de "
@@ -371,34 +376,32 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Adaptadores Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Siempre"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minuto"
 msgstr[1] "%d minutos"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptador"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "Es necesario encender el adaptador Bluetooth para que funcione el gestor de "
 "dispositivos"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Ha fallado la conexión a BlueZ"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -413,144 +416,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Buscando"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Asistente de Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Preferencias del adaptador"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Envío de archivos"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transferencia de archivos por Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Conectando"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd no disponible"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Ha fallado el inicio automático del servicio obex. Asegúrese de que el "
 "servicio obex esté ejecutándose"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Cancelando"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Enviando archivo"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Tiempo estimado:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Se ha producido un error al enviar el archivo %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Omitir"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Reintentar"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Se ha producido un error"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Servicios locales"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Solicitud de emparejamiento para %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autenticación Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Escriba el código PIN para la autenticación:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Escriba el código PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Escriba la clave de paso para la autenticación:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Escriba la clave de paso"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Clave de paso de emparejamiento para"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Código PIN de emparejamiento para"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Solicitud de emparejamiento para:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirmar el valor para la autenticación:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Rechazar"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Solicitud de autorización para:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Servicio:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Aceptar siempre"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Aceptar"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -584,246 +579,245 @@ msgstr "Sí"
 msgid "No"
 msgstr "No"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Informar de un problema"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Gestor de dispositivos"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Mostrar barra de _herramientas"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Mostrar barra de _estado"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_Ordenar por"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nombre"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Añadido"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Descendente"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Complementos"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Servicios locales"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferencias del servicio"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Buscar"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "_Preferencias"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "_Salir"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "sin categorizar"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Emparejados y de confianza</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Emparejados</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>De confianza</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Insuficiente"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Casi óptima"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Óptima"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Mucha"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Demasiada"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Baja"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Alta"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Muy alta"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "¡Correcto!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Puerto en serie conectado con %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Ha fallado"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Ha fallado la conexión: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Conectando"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Ha fallado la desconexión:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Desconectando..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Conectar</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Conecta perfiles de auto-conexión fuente A2DP,  receptor A2DP y HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Desconectar</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Forzar la desconexión del dispositivo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Conectarse a:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Desconectar:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Enviar un _archivo…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Emparejar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Confiar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Desconfiar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Configurar…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Cambiar nombre de dispositivo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Eliminar"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Cancelar operación"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indicador de actividad de datos"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Total de datos recibidos y tasa de transmisión"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Total de datos enviados y tasa de transmisión"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Eliminar confianza"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Seleccionar dispositivo"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Más"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Amaro Martínez <xoas@airmail.cc>, 2020\n"
 "Toni Estevez <toni.estevez@gmail.com>, 2019\n"
 "Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2014-2015, 2019"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman es un gestor de conexiones Bluetooth basado en GTK"
 
@@ -831,17 +825,17 @@ msgstr "Blueman es un gestor de conexiones Bluetooth basado en GTK"
 msgid "GSM Settings"
 msgstr "Ajustes de GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Complementos"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problema de dependencias"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -852,7 +846,7 @@ msgstr ""
 "%(1)s</b> también se descargará «<b>%(0)s</b>».\n"
 "¿Quiere continuar?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -863,840 +857,1230 @@ msgstr ""
 "hará qué <b>%(0)s</b> se descargue.\n"
 "¿Quiere continuar?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Selección del adaptador"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr "Detectando…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "sin categorizar"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Punto de acceso a la red"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "equipo de escritorio"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "servidor"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "portátil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "PDA"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "Palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "móvil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "dispositivo inalámbrico"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "teléfono inteligente"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "módem"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
-
-#. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "auriculares"
-
-#. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "manos libres"
-
-#. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "desconocido"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
-msgstr "micrófono"
-
-#. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
-msgstr "altavoz"
-
-#. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
-msgstr "auriculares"
-
-#. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
-msgstr "audio portátil"
-
-#. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr "audio para coche"
-
-#. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
-msgstr "decodificador de televisión"
-
-#. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
-msgstr "audio de alta fidelidad"
-
-#. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
-msgstr "vcr"
-
-#. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
-msgstr "cámara de vídeo"
-
-#. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
-msgstr "camcorder"
-
-#. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr "monitor de vídeo"
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr "pantalla de vídeo y altavoz"
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
-msgstr "dispositivo de videoconferencia"
-
-#. translators: device class
-#: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "teclado"
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd no disponible"
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "dispositivo señalador"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
-msgstr ""
-
-#: blueman/Sdp.py:93
-msgid "SDP"
-msgstr ""
-
-#: blueman/Sdp.py:94
-msgid "UDP"
-msgstr ""
-
-#: blueman/Sdp.py:95
-msgid "RFCOMM"
-msgstr ""
-
-#: blueman/Sdp.py:96
-msgid "TCP"
-msgstr "TCP"
-
-#: blueman/Sdp.py:97
-msgid "TCS-BIN"
-msgstr "TCS-BIN"
-
-#: blueman/Sdp.py:98
-msgid "TCS-AT"
-msgstr ""
-
-#: blueman/Sdp.py:99
-msgid "ATT"
-msgstr ""
-
-#: blueman/Sdp.py:100
-msgid "OBEX"
-msgstr ""
-
-#: blueman/Sdp.py:101
-msgid "IP"
-msgstr ""
-
-#: blueman/Sdp.py:102
-msgid "FTP"
-msgstr ""
-
-#: blueman/Sdp.py:103
-msgid "HTTP"
-msgstr ""
-
-#: blueman/Sdp.py:104
-msgid "WSP"
-msgstr ""
-
-#: blueman/Sdp.py:105
-msgid "BNEP"
-msgstr ""
-
-#: blueman/Sdp.py:106
-msgid "UPnP/ESDP"
-msgstr ""
-
-#: blueman/Sdp.py:107
-msgid "HIDP"
-msgstr ""
-
-#: blueman/Sdp.py:108
-msgid "Hardcopy Control Channel"
-msgstr ""
-
-#: blueman/Sdp.py:109
-msgid "Hardcopy Data Channel"
-msgstr ""
-
-#: blueman/Sdp.py:110
-msgid "Hardcopy Notification"
-msgstr ""
-
-#: blueman/Sdp.py:111
-msgid "AVCTP"
-msgstr ""
-
-#: blueman/Sdp.py:112
-msgid "AVDTP"
-msgstr ""
-
-#: blueman/Sdp.py:113
-msgid "CMTP"
-msgstr ""
-
-#: blueman/Sdp.py:114
-msgid "UDI_C-Plane"
-msgstr ""
-
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
-msgid "Multi-Channel Adaptation Protocol (MCAP)"
-msgstr ""
-
-#: blueman/Sdp.py:117
-msgid "L2CAP"
-msgstr ""
-
-#: blueman/Sdp.py:118
-msgid "ServiceDiscoveryServerServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:119
-msgid "BrowseGroupDescriptorServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:120
-msgid "Public Browse Group"
-msgstr ""
-
-#: blueman/Sdp.py:121
-msgid "Serial Port"
-msgstr "Puerto serie"
-
-#: blueman/Sdp.py:122
-msgid "LAN Access Using PPP"
-msgstr ""
-
-#: blueman/Sdp.py:123
-msgid "Dialup Networking (DUN)"
-msgstr "Red de acceso telefónico (DUN)"
-
-#: blueman/Sdp.py:124
-msgid "IrMC Sync"
-msgstr ""
-
-#: blueman/Sdp.py:125
-msgid "OBEX Object Push"
-msgstr ""
-
-#: blueman/Sdp.py:126
-msgid "OBEX File Transfer"
-msgstr "Transferencia de archivos por OBEX"
-
-#: blueman/Sdp.py:127
-msgid "IrMC Sync Command"
-msgstr ""
-
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
 msgid "Headset"
 msgstr "Auriculares"
 
-#: blueman/Sdp.py:129
-msgid "Cordless Telephony"
-msgstr ""
-
-#: blueman/Sdp.py:130
-msgid "Audio Source"
-msgstr "Fuente de audio"
-
-#: blueman/Sdp.py:131
-msgid "Audio Sink"
-msgstr "Salida de audio"
-
-#: blueman/Sdp.py:132
-msgid "Remote Control Target"
-msgstr ""
-
-#: blueman/Sdp.py:133
-msgid "Advanced Audio"
-msgstr ""
-
-#: blueman/Sdp.py:134
-msgid "Remote Control"
-msgstr ""
-
-#: blueman/Sdp.py:135
-msgid "Video Conferencing"
-msgstr ""
-
-#: blueman/Sdp.py:136
-msgid "Intercom"
-msgstr ""
-
-#: blueman/Sdp.py:137
-msgid "Fax"
-msgstr ""
-
-#: blueman/Sdp.py:138
-msgid "Headset Audio Gateway"
-msgstr ""
-
-#: blueman/Sdp.py:139
-msgid "WAP"
-msgstr ""
-
-#: blueman/Sdp.py:140
-msgid "WAP Client"
-msgstr ""
-
-#: blueman/Sdp.py:141
-msgid "PANU"
-msgstr ""
-
-#: blueman/Sdp.py:142
-msgid "Network Access Point"
-msgstr "Punto de acceso a la red"
-
-#: blueman/Sdp.py:143
-msgid "Group Network"
-msgstr "Red de grupo"
-
-#: blueman/Sdp.py:144
-msgid "DirectPrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:145
-msgid "ReferencePrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:146
-msgid "Imaging (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:147
-msgid "ImagingResponder (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:148
-msgid "ImagingAutomaticArchive (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:149
-msgid "ImagingReferencedObjects (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:150
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
 msgid "Handsfree"
 msgstr "Manos libres"
 
-#: blueman/Sdp.py:151
+#. translators: device class
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
+msgstr "micrófono"
+
+#. translators: device class
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
+msgstr "altavoz"
+
+#. translators: device class
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
+msgstr "auriculares"
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
+msgstr "audio portátil"
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
+msgstr "audio para coche"
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
+msgstr "decodificador de televisión"
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
+msgstr "audio de alta fidelidad"
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
+msgstr "vcr"
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "cámara de vídeo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
+msgstr "camcorder"
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "monitor de vídeo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
+msgstr "pantalla de vídeo y altavoz"
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "dispositivo de videoconferencia"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "teclado"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "dispositivo señalador"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+msgid "Combo"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+msgid "Display"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+msgid "Generic Phone"
+msgstr ""
+
+#: blueman/DeviceClass.py:170
+msgid "Generic Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:171
+msgid "Generic Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+msgid "Generic Clock"
+msgstr ""
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+msgid "Generic Remote Control"
+msgstr ""
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+msgid "Generic Tag"
+msgstr ""
+
+#: blueman/DeviceClass.py:178
+msgid "Generic Keyring"
+msgstr ""
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+msgid "Generic Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:181
+msgid "Generic Thermometer"
+msgstr ""
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+msgid "Generic Glucose Meter"
+msgstr ""
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+msgid "Generic: Cycling"
+msgstr ""
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
+msgid "SDP"
+msgstr ""
+
+#: blueman/Sdp.py:88
+msgid "UDP"
+msgstr ""
+
+#: blueman/Sdp.py:89
+msgid "RFCOMM"
+msgstr ""
+
+#: blueman/Sdp.py:90
+msgid "TCP"
+msgstr "TCP"
+
+#: blueman/Sdp.py:91
+msgid "TCS-BIN"
+msgstr "TCS-BIN"
+
+#: blueman/Sdp.py:92
+msgid "TCS-AT"
+msgstr ""
+
+#: blueman/Sdp.py:93
+msgid "ATT"
+msgstr ""
+
+#: blueman/Sdp.py:94
+msgid "OBEX"
+msgstr ""
+
+#: blueman/Sdp.py:95
+msgid "IP"
+msgstr ""
+
+#: blueman/Sdp.py:96
+msgid "FTP"
+msgstr ""
+
+#: blueman/Sdp.py:97
+msgid "HTTP"
+msgstr ""
+
+#: blueman/Sdp.py:98
+msgid "WSP"
+msgstr ""
+
+#: blueman/Sdp.py:99
+msgid "BNEP"
+msgstr ""
+
+#: blueman/Sdp.py:100
+msgid "UPnP/ESDP"
+msgstr ""
+
+#: blueman/Sdp.py:101
+msgid "HIDP"
+msgstr ""
+
+#: blueman/Sdp.py:102
+msgid "Hardcopy Control Channel"
+msgstr ""
+
+#: blueman/Sdp.py:103
+msgid "Hardcopy Data Channel"
+msgstr ""
+
+#: blueman/Sdp.py:104
+msgid "Hardcopy Notification"
+msgstr ""
+
+#: blueman/Sdp.py:105
+msgid "AVCTP"
+msgstr ""
+
+#: blueman/Sdp.py:106
+msgid "AVDTP"
+msgstr ""
+
+#: blueman/Sdp.py:107
+msgid "CMTP"
+msgstr ""
+
+#: blueman/Sdp.py:108
+msgid "UDI_C-Plane"
+msgstr ""
+
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
+msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgstr ""
+
+#: blueman/Sdp.py:111
+msgid "L2CAP"
+msgstr ""
+
+#: blueman/Sdp.py:112
+msgid "ServiceDiscoveryServerServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:113
+msgid "BrowseGroupDescriptorServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:114
+msgid "Public Browse Group"
+msgstr ""
+
+#: blueman/Sdp.py:115
+msgid "Serial Port"
+msgstr "Puerto serie"
+
+#: blueman/Sdp.py:116
+msgid "LAN Access Using PPP"
+msgstr ""
+
+#: blueman/Sdp.py:117
+msgid "Dialup Networking (DUN)"
+msgstr "Red de acceso telefónico (DUN)"
+
+#: blueman/Sdp.py:118
+msgid "IrMC Sync"
+msgstr ""
+
+#: blueman/Sdp.py:119
+msgid "OBEX Object Push"
+msgstr ""
+
+#: blueman/Sdp.py:120
+msgid "OBEX File Transfer"
+msgstr "Transferencia de archivos por OBEX"
+
+#: blueman/Sdp.py:121
+msgid "IrMC Sync Command"
+msgstr ""
+
+#: blueman/Sdp.py:123
+msgid "Cordless Telephony"
+msgstr ""
+
+#: blueman/Sdp.py:124
+msgid "Audio Source"
+msgstr "Fuente de audio"
+
+#: blueman/Sdp.py:125
+msgid "Audio Sink"
+msgstr "Salida de audio"
+
+#: blueman/Sdp.py:126
+msgid "Remote Control Target"
+msgstr ""
+
+#: blueman/Sdp.py:127
+msgid "Advanced Audio"
+msgstr ""
+
+#: blueman/Sdp.py:128
+msgid "Remote Control"
+msgstr ""
+
+#: blueman/Sdp.py:129
+msgid "Video Conferencing"
+msgstr ""
+
+#: blueman/Sdp.py:130
+msgid "Intercom"
+msgstr ""
+
+#: blueman/Sdp.py:131
+msgid "Fax"
+msgstr ""
+
+#: blueman/Sdp.py:132
+msgid "Headset Audio Gateway"
+msgstr ""
+
+#: blueman/Sdp.py:133
+msgid "WAP"
+msgstr ""
+
+#: blueman/Sdp.py:134
+msgid "WAP Client"
+msgstr ""
+
+#: blueman/Sdp.py:135
+msgid "PANU"
+msgstr ""
+
+#: blueman/Sdp.py:136
+msgid "Network Access Point"
+msgstr "Punto de acceso a la red"
+
+#: blueman/Sdp.py:137
+msgid "Group Network"
+msgstr "Red de grupo"
+
+#: blueman/Sdp.py:138
+msgid "DirectPrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:139
+msgid "ReferencePrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:140
+msgid "Imaging (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:141
+msgid "ImagingResponder (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:142
+msgid "ImagingAutomaticArchive (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:143
+msgid "ImagingReferencedObjects (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr ""
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr ""
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr "Fuente de vídeo"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr ""
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr ""
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr ""
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr ""
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr ""
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 msgid "Device Name"
 msgstr "Nombre del dispositivo"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr ""
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Conexión automática de perfiles"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Privativo"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "sí"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "no"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Información"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Mostrar información del dispositivo"
 
@@ -1721,34 +2105,35 @@ msgstr "Perfil de audio"
 msgid "Select audio profile for PulseAudio"
 msgstr "Seleccione el perfil de audio de PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Puerto en serie %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Renovar dirección IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Ajustes de acceso telefónico"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Puertos seriales"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Sin especificar"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Conectado"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Conectado automáticamente a %(service)s en %(device)s"
@@ -1816,22 +2201,17 @@ msgstr "_Uso de red"
 msgid "Shows network traffic usage"
 msgstr "Muestra el uso del tráfico de red"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth activado"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth desactivado"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Gestiona servicios locales de red como puentes NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1839,7 +2219,7 @@ msgstr ""
 "Proporciona compatibilidad para conexión por marcación (DUN) con "
 "ModemManager y con NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1847,39 +2227,39 @@ msgstr ""
 "para un acceso rápido"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "N.º máximo de elementos"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "El número máximo de elementos que aparecerán en el menú de conexiones "
 "recientes."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Conexiones recientes"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Conectado a %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "No se ha podido conectar"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s en %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "El adaptador para esta conexión no esta disponible"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1887,41 +2267,41 @@ msgstr ""
 "Proporciona compatibilidad para Personal Area Networking (PAN) introducido "
 "en NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Proporciona la API de DBus para otros componentes de Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Recepción de archivo mediante Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Archivo entrante %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Rechazar"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Recepción de archivo"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Recibiendo el archivo%(0)s de%(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Proporciona capacidades de transferencia de archivos OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "La carpeta configurada para los archivos entrantes no existe"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1930,42 +2310,38 @@ msgstr ""
 "Asegúrese de que la carpeta «<b>%s</b>» exista o configúrela con blueman-"
 "services. Hasta ese momento, se usará la carpeta predeterminada «%s»"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Archivo recibido"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Archivo %(0)s de %(1)s recibido correctamente"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Ha fallado la transferencia"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Ha fallado la transferencia del archivo %(0)s"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Archivos recibidos"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Se ha recibido %d archivo en segundo plano"
 msgstr[1] "Se han recibido %d archivos en segundo plano"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Se ha recibido %d archivo más en segundo plano"
@@ -1978,27 +2354,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Añade elementos estándares al menú del icono de estado"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Configurar dispositivo nuevo"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Enviar _archivos al dispositivo"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Dispositivos"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_tadores"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "miniaplicación"
 
@@ -2012,27 +2388,27 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Añade un opción de salida al menú para salir de la miniaplicación"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Proporciona un cliente dhcp básico para las conexiones PAN Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Red Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interfaz %(0)s ligada a la dirección IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "No se ha podido obtener la dirección IP en %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2041,7 +2417,7 @@ msgstr ""
 "Intentando obtener una dirección de IP en %s\n"
 "Aguarde un momento…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2050,24 +2426,27 @@ msgstr ""
 "muestra el número de conexiones \n"
 "en la descripción."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth activo"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d conexión activa</b>"
 msgstr[1] "<b>%d conexiones activas</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth desactivado"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Usa libappindicator para mostrar un icono de estado"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2076,35 +2455,36 @@ msgstr ""
 "sea temporalmente visible cuando se ha configurado para estar oculto por "
 "defecto."
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Tiempo límite para ser descubierto"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Cantidad de segundos que el modo descubrible durará"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Permitir su descubrimiento"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Hacer temporalmente visible el adaptador predeteminado"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Detectable… %s"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Proporciona un menú para la miniaplicación y una API para que otros "
 "complementos lo manipulen"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2113,24 +2493,24 @@ msgstr ""
 "Se ha conectado correctamente al servicio <b>DUN</b> en <b>%(0)s.</b>\n"
 "La red está disponible ahora a través de <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Proporciona compatibilidad básica para conectarse a internet a través del "
 "perfil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Gestor de conexión de perfiles SPP estándar, permite ejecutar acciones "
 "personalizadas"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script para ejecutar en la conexión"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2148,11 +2528,11 @@ msgstr ""
 "\n"
 "Al desconectar el dispositivo, el script enviará una señal HUP </span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Puerto en serie conectado"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2160,11 +2540,11 @@ msgstr ""
 "El servicio de puerto serie en el dispositivo <b>%s</b> ahora estará "
 "disponible mediante <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Ha fallado la secuencia de órdenes de conexión de puertos"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2173,37 +2553,37 @@ msgstr ""
 "Hubo un problema al lanzar el script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Controla los estados de energía del adaptador Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Encendido automático"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Encender automáticamente los adaptadores"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Desactivar Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Apagar todos los adaptadores"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Activar Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Encender todos los adaptadores"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2211,22 +2591,21 @@ msgstr ""
 "Suspende temporalmente el salvapantallas cuando se conecta un controlador de "
 "juegos Bluetooth."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Red"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Dirección IP no válida"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "La dirección IP conflictúa con la interfaz %s que tiene la misma dirección"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2237,8 +2616,8 @@ msgstr ""
 "configuración siguiente  %s/%s\n"
 "Esto puede causar un comportamiento incorrecto de la red"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Actualmente no es compatible con esta configuración."
 
@@ -2256,10 +2635,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Establecer propiedades del adaptador Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Miniaplicación Blueman"
@@ -2267,11 +2642,6 @@ msgstr "Miniaplicación Blueman"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Gestor de conexiones Bluetooth Blueman"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2312,6 +2682,31 @@ msgstr "Establecer estado de RfKill"
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr "Configurar el estado de RfKill requiere privilegios"
+
+#~ msgid "Enter PIN code"
+#~ msgstr "Escriba el código PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Escriba la clave de paso"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Puerto en serie conectado con %s"
+
+#~ msgid "palm"
+#~ msgstr "Palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "auriculares"
+
+#~ msgid "handsfree"
+#~ msgstr "manos libres"
+
+#~ msgid "unknown"
+#~ msgstr "desconocido"
 
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Dispositivos Bluetooth"

--- a/po/et.po
+++ b/po/et.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Estonian (http://www.transifex.com/mate/MATE/language/et/)\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Nähtavaloleku sätted</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Nähtamatu"
 
@@ -67,8 +67,8 @@ msgstr "_Seade"
 msgid "_View"
 msgstr "_Vaade"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "A_bi"
 
@@ -81,7 +81,7 @@ msgstr "Lähedalasuvate seadmete otsimine"
 msgid "Search"
 msgstr "Otsi"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Seadmega paari loomine"
 
@@ -90,17 +90,17 @@ msgstr "Seadmega paari loomine"
 msgid "Pair"
 msgstr "Paari loomine"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Seadme usaldatavuse märkimine"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Usalda"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Seadme häälestusabilise käivitamine"
 
@@ -109,7 +109,7 @@ msgstr "Seadme häälestusabilise käivitamine"
 msgid "Setup..."
 msgstr "Seadista..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Selle seadme eemaldamine tuntud seadmete nimekirjast"
 
@@ -285,7 +285,12 @@ msgstr "Pole määratud"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -347,7 +352,7 @@ msgstr "_Lähtesta"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -355,32 +360,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth'i adapterid"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Alati"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minut"
 msgstr[1] "%d minutit"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Tõrge Bluez'iga ühendumisel"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -394,142 +397,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Otsimine"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetoothi abiline"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adapteri eelistused"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetoothi failiülekanne"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Ühendumine"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd pole saadaval"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Tühistamine"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Faili saatmine"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Faili %s saatmise käigus tekkis viga"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Jäta vahele"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Proovi uuesti"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Ilmnes tõrge"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Kohalikud teenused"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Paari loomise päring seadmele %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetoothi autentimine"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Autentimiseks sisesta PIN-kood:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Sisesta PIN-kood"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Autentimiseks sisesta parool:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Sisesta parool"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Paari loomise PIN-kood seadmele"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Paari loomise päring seadmele:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Autentimise kinnituskood:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Kinnita"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Keela"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Autoriseerimispäring seadmele:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Teenus:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Alati nõustu"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Võta vastu"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -560,241 +555,239 @@ msgstr "Jah"
 msgid "No"
 msgstr "Ei"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Seadmehaldur"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Näita _tööriistariba"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Näida _olekuriba"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nimi"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Lisatud"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Kahanevalt"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Pluginad"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Kohalikud teenused"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Teenuse eelistused"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Otsing"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Adapteri eelistused"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "liigitamata"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Usaldatud</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Kehv"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Alla optimaalse"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimaalne"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Palju"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Liiga palju"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Madal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Kõrge"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Väga kõrge"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Edukas!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Jadaport on ühendatud kohta %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Nurjus"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Ühendus nurjus: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Ühendumine"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Ühenduse katkestamine..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Ühendu:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Katkesta:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Faada _fail..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "Loo _paar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Muuda seadme nime"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Eemalda"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Toimingu tühistamine"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Edastusaktiivsuse indikaator"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Vastuvõetud andmete maht ja edastuse kiirus"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Saadetud andmete maht ja edastuse kiirus"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Ära usalda"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Seadme valimine"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Veel"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Ivar Smolin, 2014–2015, 2018\n"
@@ -808,7 +801,7 @@ msgstr ""
 "  mahfiaz https://launchpad.net/~mahfiaz\n"
 "  veidu https://launchpad.net/~viljarveidenberg"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman on GTK+ Bluetooth haldur"
 
@@ -816,17 +809,17 @@ msgstr "Blueman on GTK+ Bluetooth haldur"
 msgid "GSM Settings"
 msgstr "GSMi sätted"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Pluginad"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Sõltuvusprobleem"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -834,7 +827,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -842,884 +835,1258 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Adapteri valik"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Ühenduse katkestamine..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "liigitamata"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Võrgupääsukoht"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "töölaud"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "sülearvuti"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "pihuarvuti"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobiil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "juhtmeta"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "nutitelefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd pole saadaval"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "peakomplekt"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "käedvabad"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "tundmatu"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Heli vastuvõtmine"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Heli vastuvõtmine"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Heli vastuvõtmine"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "klaviatuur"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "osutamine"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "klaviatuur"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "osutamine"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Ühendu"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Ühendu"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Ühendu"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Ühendu"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetoothi failiülekanne"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Ühendu"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetoothi failiülekanne"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetoothi failiülekanne"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Gruppvõrk"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetoothi failiülekanne"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Ühendu"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Ühendu"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetoothi failiülekanne"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Ühendu"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Gruppvõrk"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Jadapordid"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Sissehelistamisega võrk (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetoothi failiülekanne"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "peakomplekt"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Heli vastuvõtmine"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Heli saatmine"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Võrgupääsukoht"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Gruppvõrk"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "käedvabad"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Võrgupääsukoht (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Võrgupääsukoht (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Gruppvõrk"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetoothi failiülekanne"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Heli vastuvõtmine"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Heli saatmine"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Heli vastuvõtmine"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Muuda seadme nime"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Kohalikud teenused"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Ülekanne"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "rakend"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Kohalikud teenused"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Lähedalasuvate seadmete otsimine"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Ülekanne"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "rakend"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Local Services"
-msgid "Primary Service"
-msgstr "Kohalikud teenused"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Lähedalasuvate seadmete otsimine"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Seadmehaldur"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "_Viimased ühendused"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Seadmehaldur"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Adapteri eelistused"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "jah"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "ei"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1744,34 +2111,35 @@ msgstr "Audioprofiil"
 msgid "Select audio profile for PulseAudio"
 msgstr "Audioprofiili valimine PulseAudio jaoks"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Jadaport %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "IP-aadressi uuendamine"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Sissehelistamise sätted"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Jadapordid"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Määramata"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Ühendatud"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1838,146 +2206,137 @@ msgstr "_Võrgukasutus"
 msgid "Shows network traffic usage"
 msgstr "Võrguliikluse kasutuse näitamine"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth on lubatud"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth on keelatud"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Kohalike võrguteenuste (näiteks NAP-sillad) haldamine"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "Menüükirje lisamine kiireks ligipääsuks viimati kasutatud ühendustele"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Suurim kirjete arv"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Menüüs kuvatavate viimatiste ühenduste suurima arv."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Viimased ühendused"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Ühendatud seadmega %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Ühendumine nurjus"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s seadmes %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Selle ühenduse adapter ei ole kättesaadav"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Teiste Bluemani komponentide DBus'i API võimaldamine"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Bluetoothi kaudu saadetakse faili"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Seadmest %(1)s saadetakse sulle fail %(0)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Keeldu"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Faili vastuvõtmine"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Faili %(0)s vastuvõtmine seadmest %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "OBEX failiülekannete tagamine"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Fail vastu võetud"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Fail %(0)s seadmest %(1)s on edukalt vastu võetud"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Ülekanne nurjus"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Faili %(0)s ülekandmine nurjus"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Failid vastu võetud"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Taustal võeti vastu %d fail"
 msgstr[1] "Taustal võeti vastu %d faili"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Taustal võeti vastu veel %d fail"
@@ -1990,27 +2349,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Standardmenüü kirjete lisamine olekuikooni menüüsse"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Saada seadmele _faile"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Seadmed"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_terid"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "rakend"
 
@@ -2022,34 +2381,34 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Rakendi lõpetamiseks vajaliku menüükirje lisamine"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Bluetoothi PAN-ühenduste jaoks põhilise DHCP-kliendi tagamine."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetoothi võrk"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2057,24 +2416,27 @@ msgstr ""
 "Aktiivse Bluetoothi korral olekuikoonile näidiku lisamine ja vihjetekstis "
 "ühenduste arvu näitamine."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d aktiivne ühendus</b>"
 msgstr[1] "<b>%d aktiivset ühendust</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth on keelatud"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Kasutab olekuikooni näitamiseks libappindicator teeki"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2082,57 +2444,58 @@ msgstr ""
 "Vaikimisi adapteri menüükirje ajutine nähtavakstegemine, kui see on "
 "vaikimisi peidetuks määratud"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Tee avastatavaks"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Vaikimisi adapteri ajutiselt avastatavaks tegemine"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Rakendi menüü ja teistele pluginatele selle manipuleerimiseks vajaliku API "
 "tagamine."
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "DUN-profiili abil internetti ühendumise põhilise toe tagamine."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standardne SPP profiili ühendustehaldur, mis võimaldab käivitada kohandatud "
 "tegevusi."
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Ühendamisel käivitatav skript"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2150,78 +2513,77 @@ msgstr ""
 "\n"
 "Seadmega ühenduse katkestamisel saadetakse skriptile HUP-signaal</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Jadaport ühendatud"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Jadapordi ühendamisskripti tõrge"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Bluetooth adapteri toiteolekute juhtimine"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Lülita välja kõik adapterid"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Lülita sisse kõik adapterid"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Võrk"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Vigane IP-aaddress"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP-aadress on vastuolus sama aadressi omava liidesega %s"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2229,8 +2591,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2244,40 +2606,26 @@ msgstr "Rakendite ülekandeteenuse plugin on keelatud"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth'i adapterid"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "rakend"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman on GTK+ Bluetooth haldur"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth on lubatud"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetoothi seadmed"
 
@@ -2313,6 +2661,31 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Sisesta PIN-kood"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Sisesta parool"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Jadaport on ühendatud kohta %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "peakomplekt"
+
+#~ msgid "handsfree"
+#~ msgstr "käedvabad"
+
+#~ msgid "unknown"
+#~ msgstr "tundmatu"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetoothi seadmed"
 
@@ -2333,11 +2706,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Eemalda..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Ühendu"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Bluetooth peab failide saatmiseks olema sisse lülitatud"

--- a/po/eu.po
+++ b/po/eu.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Basque (http://www.transifex.com/mate/MATE/language/eu/)\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Bistaratze ezarpen</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Ezkutatuta"
 
@@ -67,8 +67,8 @@ msgstr "_Gailua"
 msgid "_View"
 msgstr "_Ikusi"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Laguntza"
 
@@ -81,7 +81,7 @@ msgstr "Bilatu hurbil dauden tresnak"
 msgid "Search"
 msgstr "Bilatu"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Sortu parekatzea gailuarekin"
 
@@ -90,17 +90,17 @@ msgstr "Sortu parekatzea gailuarekin"
 msgid "Pair"
 msgstr "Parekatu"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Markatu/Desmarkatu gailu hau fidagarri gisa"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Fidagarritzat jo"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Abiatu konfigurazio laguntzailea gailu honentzat"
 
@@ -109,7 +109,7 @@ msgstr "Abiatu konfigurazio laguntzailea gailu honentzat"
 msgid "Setup..."
 msgstr "Konfiguratu..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Kendu gailu hau gailu ezagunen zerrendatik"
 
@@ -286,7 +286,12 @@ msgstr "Zehaztu gabea"
 msgid "<b>Author:</b>"
 msgstr "<b>Egilea:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -348,7 +353,7 @@ msgstr "_Berrezarri"
 msgid "Send note"
 msgstr "Bidali oharra"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -356,32 +361,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth-egokigailuak"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Beti"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "minutu %d"
 msgstr[1] "%d minutu"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Moldagailua"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -392,142 +395,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Bilatzen"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth laguntzailea"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Moldagailuen hobespenak"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Fitxategi bidaltzailea"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth Fitxategi Transferentzia"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Konektatzen"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd ez dago erabilgarri"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Bertan behera uzten"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Fitxategia bidaltzen"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Errorea gertatu da %s fitxategia bidaltzean"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Saltatu"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Saiatu berriz"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Errorea gertatu da"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Zerbitzu lokalak"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "%s(r)entzako parekatze eskaera"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth autentifikazioa"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Sartu PIN kodea autentifikatzeko:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Sartu PIN kodea"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Sartu gakoa autentifikatzeko:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Sartu gakoa"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Honentzako gakoa parekatzen:"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Honentzako PIN kodea parekatzen:"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Honentzako eskaera parekatzen:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Berretsi balioa autentifikatzeko:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Berretsi"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Ukatu"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Zerbitzua:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Onartu beti"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Onartu"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -558,247 +553,245 @@ msgstr "Bai"
 msgid "No"
 msgstr "Ez"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Jakinarazi arazoa"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Gailu kudeatzailea"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Erakutsi _tresna-barra"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Erakutsi _egoera-barra"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_Ordenatu honen arabera"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Izena"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Gehitua"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Beherantz"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Pluginak"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Zerbitzu _lokalak"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Zerbitzuaren hobespenak"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Bilatu"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Moldagailuen hobespenak"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "kategoriarik gabe"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Ahula"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Baxua"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Altua"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Oso altua"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Arrakasta!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Huts egin du"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Konexioak huts egin du:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Konektatzen"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Deskonektatzen..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Konektatu hona:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Deskonektatu:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Bidali _fitxategi bat..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Parekatu"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Fidagarritzat jo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Aldatu izena gailuari"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Kendu"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Utzi eragiketa"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Hautatu gailua"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Gehiago"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Asier Iturralde Sarasola <asier.iturralde@gmail.com>\n"
 "Aritz Jorge Sánchez"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -806,17 +799,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr "GSM ezarpenak"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Pluginak"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -824,7 +817,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -832,876 +825,1254 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Moldagailuaren hautapena"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Deskonektatzen..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "kategoriarik gabe"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Onartu"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "mahaigainekoa"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "zerbitzaria"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "eramangarria"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "eskukoa"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "zelularra"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "haririk gabekoa"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "telefono adimentsua"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modema"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
-
-#. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd ez dago erabilgarri"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "ezezaguna"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofonoa"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Audioaren iturburua"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Audioaren iturburua"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Audioaren iturburua"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "teklatua"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "Konektatzen"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "teklatua"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Konektatu"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Konektatu"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Konektatu"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Konektatu"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth Fitxategi Transferentzia"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Konektatu"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth Fitxategi Transferentzia"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth Fitxategi Transferentzia"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Bluetooth Fitxategi Transferentzia"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth Fitxategi Transferentzia"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Konektatu"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Konektatu"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth Fitxategi Transferentzia"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Konektatu"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Konektatu"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Serieko atakak"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth Fitxategi Transferentzia"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr ""
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Audioaren iturburua"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr ""
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Sareko Sarbide Puntua (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Sareko Sarbide Puntua (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr ""
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth Fitxategi Transferentzia"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Audioaren iturburua"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Audioaren iturburua"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Aldatu izena gailuari"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Erakutsi gailuaren informazioa"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Zerbitzu lokalak"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 #, fuzzy
-#| msgid "applet"
 msgid "AppleAgent"
 msgstr "applet-a"
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 #, fuzzy
-#| msgid "Pair Device"
 msgid "Primary Service"
 msgstr "Parekatu gailua"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 #, fuzzy
-#| msgid "Search for nearby devices"
 msgid "Secondary Service"
 msgstr "Bilatu hurbil dauden tresnak"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Gailu kudeatzailea"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Renew IP Address"
 msgid "Reconnection Address"
 msgstr "Berritu IP helbidea"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Gailu kudeatzailea"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Moldagailuen hobespenak"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "bai"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "ez"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Informazioa"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Erakutsi gailuaren informazioa"
 
@@ -1726,34 +2097,35 @@ msgstr "Audio profila"
 msgid "Select audio profile for PulseAudio"
 msgstr "Hautatu PulseAudioren audio profila"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Serieko ataka %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Berritu IP helbidea"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Serieko atakak"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Zehaztu gabea"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Konektatuta"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1816,141 +2188,136 @@ msgstr "Sarearen _erabilera"
 msgid "Shows network traffic usage"
 msgstr "Sareko trafikoaren erabilera erakusten du"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth gaituta"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth desgaituta"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "NAP zubiak bezalako sare lokaleko zerbitzuak kudeatzen ditu"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "'%s(e)ra konektatuta"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Huts egin du konektatzean"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Fitxategia jasotzen"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Fitxategia jasota"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Transferentziak huts egin du"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "%(0)s fitxategiaren transferentziak huts egin du"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1964,27 +2331,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Konfiguratu gailu berria"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Bidali _fitxategiak gailura"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Gailuak"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "_Moldagailuak"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet-a"
 
@@ -1996,107 +2363,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth sarea"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth desgaituta"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2107,78 +2480,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Serieko ataka konektatuta"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Sarea"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "IP helbide baliogabea"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2186,8 +2558,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2201,40 +2573,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth-egokigailuak"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet-a"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth gaituta"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth gaituta"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth gailuak"
 
@@ -2270,6 +2628,21 @@ msgstr "Ezarri RfKill egoera"
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Sartu PIN kodea"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Sartu gakoa"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "unknown"
+#~ msgstr "ezezaguna"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth gailuak"
 
@@ -2290,11 +2663,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Kendu..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Konektatu"
 
 #~ msgid "Select files to send"
 #~ msgstr "Hautatu fitxategiak bidaltzeko"

--- a/po/fa.po
+++ b/po/fa.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Persian (http://www.transifex.com/mate/MATE/language/fa/)\n"
@@ -24,7 +24,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>تنظیمات قابل دیدن</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "مخفی"
 
@@ -68,8 +68,8 @@ msgstr ""
 msgid "_View"
 msgstr "_نمایش"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_راهنما"
 
@@ -82,7 +82,7 @@ msgstr "جست و جوی دستگاه هی اطراف"
 msgid "Search"
 msgstr "جستجو"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "جفت شدن با دستگاه"
 
@@ -91,17 +91,17 @@ msgstr "جفت شدن با دستگاه"
 msgid "Pair"
 msgstr "جفت"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "تیک زدن/تیک نزدن این دستگاه به عنوان دستگاه مورد اعتماد"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "اعتماد کن"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr ""
 
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Setup..."
 msgstr "تنظیمات..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "حذف این دستگاه از دستگاه های شناخته شده"
 
@@ -285,7 +285,12 @@ msgstr "تعریف نشده"
 msgid "<b>Author:</b>"
 msgstr ""
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -347,7 +352,7 @@ msgstr "_شروع دوباره"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -355,30 +360,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "سازگار کننده‌ی بلوتوث"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "همیشه"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "اتصال با BlueZ ناموفق بود"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -389,142 +394,134 @@ msgstr ""
 msgid "Searching"
 msgstr ""
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr ""
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr ""
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr ""
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr ""
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "سرویس داخلی"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "وارد کردن پین کد"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "انکار کردن"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "خدمت:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr ""
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -555,246 +552,244 @@ msgstr "بله"
 msgid "No"
 msgstr "خیر"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_جستجو"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "ضعیف"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "بهینه"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "زیاد"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "خیلی زیاد"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "کم"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "زیاد‌"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "بسیار زیاد"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "شکست"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting..."
 msgid "Connecting…"
 msgstr "در حال اتصال..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Connecting..."
 msgid "Disconnecting…"
 msgstr "در حال اتصال..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send File"
 msgid "Send a _File…"
 msgstr "ارسال پرونده"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "تغییر نام دستگاه"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "حذف"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr ""
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Artin https://launchpad.net/~artin\n"
 "  Valmantas Palikša https://launchpad.net/~walmis"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -802,17 +797,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "متصل شونده‌ها"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -820,7 +815,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -828,854 +823,1219 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:10
+msgid "Phone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:12
+msgid "Access point"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+msgid "Desktop"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
+msgstr "خدمت:"
+
+#. translators: device class
+#: blueman/DeviceClass.py:35
+msgid "Laptop"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+msgid "Smart phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
+msgid "17-33 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
+msgid "50-67 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
+msgid "67-83 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "نامعلوم"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:88
+msgid "Microphone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+msgid "Video camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+msgid "Video monitor"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+msgid "Video conferencing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+msgid "Keyboard"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
+msgid "Pointing"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "شبکه گروهی"
+
+#: blueman/DeviceClass.py:170
+msgid "Generic Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:171
+msgid "Generic Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "شبکه گروهی"
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "شبکه گروهی"
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "شبکه گروهی"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "شبکه گروهی"
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+msgid "Generic Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:181
+msgid "Generic Thermometer"
+msgstr ""
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+msgid "Generic Glucose Meter"
+msgstr ""
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "شبکه گروهی"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 msgid "OBEX File Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr ""
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr ""
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "شبکه گروهی"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "شبکه گروهی"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr ""
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr ""
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr ""
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "تغییر نام دستگاه"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "سرویس داخلی"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 #, fuzzy
-#| msgid "Local Services"
 msgid "Primary Service"
 msgstr "سرویس داخلی"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 #, fuzzy
-#| msgid "Search for nearby devices"
 msgid "Secondary Service"
 msgstr "جست و جوی دستگاه هی اطراف"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Device"
 msgid "Device Name"
 msgstr "دستگاه"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Service:"
 msgid "Service Changed"
 msgstr "خدمت:"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "بله"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "خیر"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1700,34 +2060,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1790,141 +2151,136 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "رد کردن‌"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1938,27 +2294,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
@@ -1970,107 +2326,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "یک کلاینت DHCP پایه برای اتصالات پان بلوتوث ارائه میدهد."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2081,79 +2443,78 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "مادامی که یک کنترل کننده بلوتوث بازی متصل است، محافظ صفحه نمایش فعال نمیشود."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "شبکه"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2161,8 +2522,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2176,13 +2537,8 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "سازگار کننده‌ی بلوتوث"
-
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
 
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
@@ -2190,24 +2546,16 @@ msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Blueman Bluetooth Manager"
 msgstr "سازگار کننده‌ی بلوتوث"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Bluetooth Manager"
 msgstr "سازگار کننده‌ی بلوتوث"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "بلوتوث ها"
 
@@ -2242,6 +2590,12 @@ msgstr ""
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr ""
+
+#~ msgid "Enter PIN code"
+#~ msgstr "وارد کردن پین کد"
+
+#~ msgid "unknown"
+#~ msgstr "نامعلوم"
 
 #~ msgid "Bluetooth Devices"
 #~ msgstr "بلوتوث ها"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Tuomas Lähteenmäki <lahtis@gmail.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -27,7 +27,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Näkyvyysasetus</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Piilotettu"
 
@@ -71,8 +71,8 @@ msgstr "_Laite"
 msgid "_View"
 msgstr "_Näytä"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Ohje"
 
@@ -85,7 +85,7 @@ msgstr "Etsi lähellä olevia laitteita"
 msgid "Search"
 msgstr "Etsi"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Parita laitteet"
 
@@ -94,17 +94,17 @@ msgstr "Parita laitteet"
 msgid "Pair"
 msgstr "Parita"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Merkitse tai poista laitteen luottamus"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Aseta luottamus"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Suorita asetusvelho tälle laitteelle"
 
@@ -113,7 +113,7 @@ msgstr "Suorita asetusvelho tälle laitteelle"
 msgid "Setup..."
 msgstr "Asetukset..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Poista laite tunnettujen laitteiden listalta"
 
@@ -295,7 +295,12 @@ msgstr "Ei määritelty"
 msgid "<b>Author:</b>"
 msgstr "<b>Tekijä:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -357,7 +362,7 @@ msgstr "_Alusta"
 msgid "Send note"
 msgstr "Lähetä muistiinpano"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetoothin pitää olla päällä, jotta sovitinhallinta toimisi"
 
@@ -365,32 +370,30 @@ msgstr "Bluetoothin pitää olla päällä, jotta sovitinhallinta toimisi"
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth-sovittimet"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Aina"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minuutti"
 msgstr[1] "%d minuuttia"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapteri"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetoothin pitää olla päällä, jotta laitehallinta toimisi"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Blueziin yhdistäminen epäonnistui"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -404,144 +407,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Etsitään"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth-avustaja"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Sovittimen asetukset"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Tiedoston lähettäjä"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth-tiedostonsiirto"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Yhdistetään"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd ei ole saatavilla"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Obex-palvelun automaattinen käynnistäminen epäonnistui. Varmista, että obex-"
 "demoni on käynnissä"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Perutaan"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Lähetetään tiedostoa"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Tapahtui virhe lähetettäessä tiedostoa %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Ohita"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Yritä uudelleen"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Tapahtui virhe"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Paikalliset palvelut"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Parituspyyntö laitteelta %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth-autentikointi"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Syötä PIN-koodi tunnistusta varten:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Syötä PIN-koodi"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Anna tunnusluku todennusta varten:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Anna tunnusluku"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Paritus salasana"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Pariliitoksen PIN-koodi"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Parituspyyntö kohteelle:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Varmista arvo todennusta varten:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Vahvista"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Kiellä"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Todentamispyyntö:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Palvelu:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Hyväksy aina"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Hyväksy"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -575,243 +570,240 @@ msgstr "Kyllä"
 msgid "No"
 msgstr "Ei"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Raportoi ongelma"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Laitehallinta"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Näytä _työkalurivi"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Näytä _Tilarivi"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Lajittele"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nimi"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Lisätty"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Laskeva"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Liitännäiset"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Paikalliset palvelut"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Palveluasetukset"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Etsi"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Sovittimen asetukset"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Lopeta"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "luokittelematon"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Luotettu ja paritettu</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Paritettu</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Luotettu</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Kriittinen"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Huono"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimaalinen"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Paljon"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Aivan liikaa"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Matala"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Korkea"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Hyvin korkea"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Onnistui!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Sarjaportti kytketty kohteeseen %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Epäonnistui"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Yhteys epäonnistui: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Yhdistetään"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Yhteyden katkaiseminen epäonnistui: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Katkaistaan yhteyttä..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Yhdistä</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Yhdistää automaattisen yhteysprofiilin A2DP-lähde, A2DP-nielu ja HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Katkaise yhteys</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Irrota laite väkisin"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Yhdistä Kohteeseen:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Katkaise:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Lähetä tiedostoja..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Pari"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Luotettu"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Epäluotettava"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Aseta ylös…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Nimeä laite uudelleen"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Poista"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Peru toiminto"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Datan aktiivisuuden ilmaisin"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Vastaanotettu kokonaisdata ja vastaanottonopeus"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Lähetetty kokonaisdata ja lähetysnopeus"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Poista luottamus"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Valitse laite"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Lisää"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -827,7 +819,7 @@ msgstr ""
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  Ville Lindfors https://launchpad.net/~villi"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman on GTK+ Bluetooth- manageri"
 
@@ -835,17 +827,17 @@ msgstr "Blueman on GTK+ Bluetooth- manageri"
 msgid "GSM Settings"
 msgstr "GSM-asetukset"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Liitännäiset"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Riippuvuusongelma"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -857,7 +849,7 @@ msgstr ""
 "\"%(0)s\"</b> poistamisen käytöstä.\n"
 "Jatketaanko?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -869,886 +861,1259 @@ msgstr ""
 "poistamisen.\n"
 "Jatketaanko?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Sovittimen valinta"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Havaittavissa… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "luokittelematon"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Verkon tukiasema"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "työpöytä"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "palvelin"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "kannettava tietokone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "kämmentietokone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "matkapuhelin"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "langaton"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "älypuhelin"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modeemi"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd ei ole saatavilla"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "kuulokemikrofoni"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "tuntematon"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofoni"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Äänilähde"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Äänilähde"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Äänilähde"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "näppäimistö"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "osoitinlaite"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "näppäimistö"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "osoitinlaite"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Yhdistä"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Yhdistä"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Yhdistä"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Yhdistä"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth-tiedostonsiirto"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Yhdistä"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth-tiedostonsiirto"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth-tiedostonsiirto"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Ryhmäverkko"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth-tiedostonsiirto"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Yhdistä"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Yhdistä"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth-tiedostonsiirto"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Yhdistä"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Ryhmäverkko"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Sarjaportit"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Puhelinverkkoyhteys (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth-tiedostonsiirto"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "kuulokemikrofoni"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Äänilähde"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Ääninielu"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Verkon tukiasema"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Ryhmäverkko"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Verkon tukiasema (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Verkon tukiasema (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Ryhmäverkko"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth-tiedostonsiirto"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Äänilähde"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Ääninielu"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Äänilähde"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Nimeä laite uudelleen"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Näytä laitetiedot"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Paikalliset palvelut"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Siirrot"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "sovelma"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Laitepari"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Etsi lähellä olevia laitteita"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Siirrot"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "sovelma"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Laitepari"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Etsi lähellä olevia laitteita"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Laitehallinta"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Viimeisimmät _yhteydet"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Laitehallinta"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Sovittimen asetukset"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Yhdistä profiilit automaattisesti"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Omisteinen"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "kyllä"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "ei"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Tiedot"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Näytä laitetiedot"
 
@@ -1773,34 +2138,35 @@ msgstr "Ääniprofiili"
 msgid "Select audio profile for PulseAudio"
 msgstr "Valitse PulseAudion ääniprofiili"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Sarjaportti %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Uusi IP-osoite"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Soittoasetukset"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Sarjaportit"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Määrittämätön"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Yhdistetty"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1869,29 +2235,24 @@ msgstr "Verkko _käyttö"
 msgid "Shows network traffic usage"
 msgstr "Näyttää verkkoliikenteen määrän"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Otettu Käyttöön"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth Poistettu Käytöstä"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Hallitsee paikallisia verkkopalveluja, kuten NAP-siltoja"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 "Tukee puhelinverkkoyhteyttä (DUN) ModemManagerilla ja NetworkManagerilla"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1899,78 +2260,78 @@ msgstr ""
 "pikavalintana"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Enimmäismäärä kohtia"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Näyttöön tulee viimeksi käytettyjen yhteyksien valikon enimmäismäärä."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Viimeisimmät _yhteydet"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Yhdistetty kohteeseen %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Yhdistäminen epäonnistui"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s laitteella %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Sovitinta tälle yhteydelle ei ole saatavilla"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 "Tarjoaa tuen Likiverkolle (PAN) joka on saatavilla NetworkManager 0.8:ssa"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Tarjoaa DBus API:n muille Blueman-komponenteille"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Bluetoothin kautta saapuu tiedosto"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Saapuva tiedosto %(0)s lähteestä %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Hylkää"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Vastaanotetaan tiedostoa"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Vastaanotetaan tiedostoa %(0)s kohteesta %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Tarjoaa OBEX-tiedostonsiirtotuen"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Konfiguroitua hakemistoa tuleville tiedostoille ei ole"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1979,42 +2340,38 @@ msgstr ""
 "Varmista, että hakemisto \"<b>%s</b>\" on olemassa, tai määritä se blueman-"
 "palveluiden kanssa. Siihen asti oletusasetusta \"%s\" käytetään"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Vastaanotettiin tiedosto"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Tiedosto %(0)s kohteesta %(1)s vastaanotettiin onnistuneesti"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Siirto epäonnistui"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Tiedoston %(0)s siirto epäonnistui"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Vastaanotettiin tiedostot"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Vastaanotettiin %d tiedosto taustalla"
 msgstr[1] "Vastaanotettiin %d tiedostoa taustalla"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Vastaanotettu %d tiedosto taustalla"
@@ -2027,27 +2384,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Lisää vakiovalikkokohteita tilakuvakevalikkoon"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Asenna uusi laite"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Lähetä tiedostoja laitteelle"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Laitteet"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Sovi_ttimet"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "sovelma"
 
@@ -2059,27 +2416,27 @@ msgstr "Tarjoaa tunnusluvun, todennuspalvelut BlueZ-taustaprosessille"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Lisää lopetusvalikon vaihtoehdon sovelman lopettamiseksi"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Tarjoaa dhcp-perusohjelman Bluetooth PAN -yhteyksille."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth-verkko"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Sovitin %(0)s on liitetty IP-osoitteeseen %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "IP-osoitteen saaminen epäonnistui kohteessa %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2088,7 +2445,7 @@ msgstr ""
 "Yritetään saada IP-osoitetta kohteessa %s\n"
 "Ole hyvä ja odota…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2096,24 +2453,27 @@ msgstr ""
 "Lisää tilakuvakkeen merkin kun Bluetooth on aktiivinen ja näyttää "
 "työkaluvihjeessä yhteyksien määrän."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth Aktiivinen"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d aktiivinen yhteys</b>"
 msgstr[1] "<b>%d aktiivista yhteyttä</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth Poistettu Käytöstä"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Näyttää tilakuvakkeen libappindicatorin avulla"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2121,34 +2481,35 @@ msgstr ""
 "Tarjoaa valikkokohdan, jolla saa oletussovittimen väliaikaisesti näkyväksi, "
 "vaikka se on asetettu piilotetuksi"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Näkyvillä olon aikaraja"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Aika sekunneissa, jonka näkyvä tila kestää"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Tee näkyväksi"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Aseta oletussovitin väliaikaisesti näkyväksi"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Havaittavissa… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Tarjoaa valikon appletille ja API:n muille liitännäisille sen muokkaamiseen"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2157,23 +2518,23 @@ msgstr ""
 "Kytkeydyttiin onnistuneesti <b>DUN</b>-palveluun kohteessa <b>%(0)s.</b>\n"
 "Verkko on nyt käytettävissä kohteen <b>%(1)s</b> kautta"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Tarjoaa perustuen internet-yhteyden muodostamiselle DUN-profiilin kautta."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Tavallinen SPP-profiiliyhteyskäsittelijä, mahdollistaa mukautettujen "
 "toimintojen suorittamisen"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skripti suorittaa yhteyden"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2191,11 +2552,11 @@ msgstr ""
 "\n"
 "Kun laite katkaisee yhteyden, komentosarja lähetetään HUP-signaalilla</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Sarjaportti yhdistetty"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2203,11 +2564,11 @@ msgstr ""
 "Sarjaporttipalvelu laitteessa <b>%s</b> on käytettävissä kohteen <b>%s</b> "
 "kautta"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Sarjaportin yhteyskomentosarja epäonnistui"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2216,59 +2577,58 @@ msgstr ""
 "Komentosarjan käynnistämisessä oli ongelma %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Ohjaa Bluetooth-sovittimen virtatiloja"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automaattinen käynnistys"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Kytke sovittimet automaattisesti päälle"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Kytke bluetooth _pois päältä</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Kytke kaikki sovittimet pois päältä"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Kytke _bluetooth päälle</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Ota kaikki sovittimet käyttöön"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "Keskeytä näytönsäästäjä tilapäisesti, kun bluetooth-peliohjain on liitetty."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Verkko"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Virheellinen IP-osoite"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "IP-osoite on ristiriidassa käyttöliittymän %s kanssa, jolla on sama osoite"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2279,8 +2639,8 @@ msgstr ""
 "seuraavat määritykset  %s/%s\n"
 "Tämä saattaa aiheuttaa virheellisen verkon toiminnan"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Ei tällä hetkellä tuettu tällä kokoonpanolla"
 
@@ -2296,10 +2656,6 @@ msgstr "Appletin siirtopalveluliitännäinen on poistettu käytöstä"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Aseta Bluetooth-sovittimen ominaisuudet"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-laite"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman-sovelma"
@@ -2307,11 +2663,6 @@ msgstr "Blueman-sovelma"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman bluetooth-hallinta"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2353,6 +2704,37 @@ msgstr "Aseta RfKill-tila"
 msgid "Setting RfKill State requires privileges"
 msgstr "RfKill-tilan asettaminen vaatii lisäoikeuksia"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Syötä PIN-koodi"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Anna tunnusluku"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Sarjaportti kytketty kohteeseen %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "kuulokemikrofoni"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "tuntematon"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-laite"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth-laitteet"
 
@@ -2373,11 +2755,6 @@ msgstr "RfKill-tilan asettaminen vaatii lisäoikeuksia"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Poista…"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Yhdistä"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/fr.po
+++ b/po/fr.po
@@ -23,7 +23,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-29 15:23+0000\n"
 "Last-Translator: Boris Faure <billiob@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -39,7 +39,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Options de visibilité</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Caché"
 
@@ -83,8 +83,8 @@ msgstr "_Périphérique"
 msgid "_View"
 msgstr "_Affichage"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "Aid_e"
 
@@ -97,7 +97,7 @@ msgstr "Recherche de périphériques à proximité"
 msgid "Search"
 msgstr "Rechercher"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Associer avec le périphérique"
 
@@ -106,17 +106,17 @@ msgstr "Associer avec le périphérique"
 msgid "Pair"
 msgstr "Associer"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Cocher/décocher ce périphérique comme étant sûr"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Confiance"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Exécuter l'assistant de configuration pour ce périphérique"
 
@@ -125,7 +125,7 @@ msgstr "Exécuter l'assistant de configuration pour ce périphérique"
 msgid "Setup..."
 msgstr "Installation..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Retirer ce périphérique de la liste des périphériques connus"
 
@@ -308,7 +308,12 @@ msgstr "Pas spécifié"
 msgid "<b>Author:</b>"
 msgstr "<b>Auteur :</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -370,7 +375,7 @@ msgstr "_Réinitialiser"
 msgid "Send note"
 msgstr "Envoyer le pense-bête"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "Bluetooth doit être activé pour que ce gestionnaire de périphériques puisse "
@@ -380,34 +385,32 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Adaptateurs Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Toujours"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minute"
 msgstr[1] "%d minutes"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptateur"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "Bluetooth doit être activé pour pouvoir utiliser le gestionnaire de "
 "périphériques"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "La connexion à BlueZ a échoué"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -421,143 +424,135 @@ msgstr ""
 msgid "Searching"
 msgstr "Recherche en cours"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Assistant Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Préférences de l'adaptateur"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Expéditeur de fichiers"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transfert de fichiers Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Connexion en cours"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd non disponible"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Échec du démarrage du service obex. Assurez-vous que le démon obex est activé"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Annulation"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Envoi du fichier"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Heure de fin estimée :"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Une erreur est survenue lors de l'envoi du fichier %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Passer"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Réessayer"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Une erreur est survenue"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Services locaux"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Requête de liaison pour %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Authentification Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Saisissez votre code PIN pour l'authentification :"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Entrez le code PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Saisir le mot de passe pour l'authentification :"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Entrer la clé de sécurité"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Pairage de la clé d'accès pour"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Pairage du code PIN pour"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Requête de liaison pour :"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirmez la valeur pour l'authentification :"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Refuser"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Requête d'autorisation pour :"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Service :"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Toujours accepter"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Accepter"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -591,241 +586,240 @@ msgstr "Oui"
 msgid "No"
 msgstr "Non"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "Signale_r un problème"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Gestionnaire de périphériques"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Afficher la barre d'ou_tils"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Afficher la barre de _statut"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_Trier par"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nom"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Ajouté"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Descendant"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Plugins"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Services _Locaux"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Préférences du service"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Rechercher"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "_Préférences"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "_Quitter"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "sans catégorie"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Sûr et associé</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Associé</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Sûr</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Médiocre"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Très bon"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Trop"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Beaucoup trop"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Faible"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Élevé"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Très haute"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Succès !"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Port série connecté à %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Échec"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "La connexion a échoué : "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Connexion en cours"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "La déconnexion a échoué : "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Déconnexion..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Connecter</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Connecte les profils de connexion automatique à la source A2DP, au récepteur "
 "A2DP et au HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Déconnecter</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Forcer la déconnexion de l'équipement"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Connecter à :</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Déconnecter :</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Envoyer un _fichier..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "Cou_plage"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "Faire _confiance"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "Ne _pas faire confiance"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Configurer…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Renommer le périphérique"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Retirer"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Annuler l'opération"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indication de l'activité des données"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Somme des données reçues et vitesse de transmission"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Somme des données envoyées et vitesse de transmission"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Suspect"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Sélectionner un périphérique"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Plus"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -863,7 +857,7 @@ msgstr ""
 "  jad_jay https://launchpad.net/~jay-man3\n"
 "  ooliver27 https://launchpad.net/~ooliver27"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman est un gestionnaire de Bluetooth basé sur GTK+"
 
@@ -871,17 +865,17 @@ msgstr "Blueman est un gestionnaire de Bluetooth basé sur GTK+"
 msgid "GSM Settings"
 msgstr "Paramètres GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Plugins"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problème de dépendances"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -892,7 +886,7 @@ msgstr ""
 "désactivera aussi <b>\"%(0)s\"</b>.\n"
 "Voulez-vous poursuivre ?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -903,840 +897,1254 @@ msgstr ""
 "%(1)s</b> va décharger <b>%(0)s</b>.\n"
 "Continuer ?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Sélection de l'adaptateur"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr "Exploration en cours…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "sans catégorie"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Point d'accès réseau"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+#, fuzzy
+msgid "Audio/video"
+msgstr "Audio/Vidéo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+#, fuzzy
+msgid "Imaging"
+msgstr "Imaging (BIP)"
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "bureau"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "serveur"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "ordinateur portable"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "ordinateur de poche"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "téléphone portable"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "sans fil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smartphone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "rnis"
+msgid "83-99 percent"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "oreillette"
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd non disponible"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "kit mains-libres"
-
-#. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "inconnu"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
-msgstr "microphone"
-
-#. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
-msgstr "haut-parleur"
-
-#. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
-msgstr "écouteurs"
-
-#. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
-msgstr "audio portable"
-
-#. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr "audio véhicule"
-
-#. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
-msgstr "décodeur (set-top box)"
-
-#. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
-msgstr "chaîne hifi"
-
-#. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
-msgstr "magnétoscope"
-
-#. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
-msgstr "caméra vidéo"
-
-#. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
-msgstr "caméscope"
-
-#. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr "moniteur vidéo"
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr "écran vidéo et enceinte"
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
-msgstr "système de visioconférence"
-
-#. translators: device class
-#: blueman/DeviceClass.py:145
-msgid "gaming/toy"
-msgstr "appareil de jeu vidéo ou jouet"
-
-#. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "clavier"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "pointage"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
-msgstr "combo"
-
-#: blueman/Sdp.py:93
-msgid "SDP"
-msgstr "SDP"
-
-#: blueman/Sdp.py:94
-msgid "UDP"
-msgstr "UDP"
-
-#: blueman/Sdp.py:95
-msgid "RFCOMM"
-msgstr "RFCOMM"
-
-#: blueman/Sdp.py:96
-msgid "TCP"
-msgstr "TCP"
-
-#: blueman/Sdp.py:97
-msgid "TCS-BIN"
-msgstr "TCS-BIN"
-
-#: blueman/Sdp.py:98
-msgid "TCS-AT"
-msgstr "TCS-AT"
-
-#: blueman/Sdp.py:99
-msgid "ATT"
-msgstr "ATT"
-
-#: blueman/Sdp.py:100
-msgid "OBEX"
-msgstr "OBEX"
-
-#: blueman/Sdp.py:101
-msgid "IP"
-msgstr "IP"
-
-#: blueman/Sdp.py:102
-msgid "FTP"
-msgstr "FTP"
-
-#: blueman/Sdp.py:103
-msgid "HTTP"
-msgstr "HTTP"
-
-#: blueman/Sdp.py:104
-msgid "WSP"
-msgstr "WSP"
-
-#: blueman/Sdp.py:105
-msgid "BNEP"
-msgstr "BNEP"
-
-#: blueman/Sdp.py:106
-msgid "UPnP/ESDP"
-msgstr "UPnP ou ESDP"
-
-#: blueman/Sdp.py:107
-msgid "HIDP"
-msgstr "HIDP"
-
-#: blueman/Sdp.py:108
-msgid "Hardcopy Control Channel"
-msgstr "Hardcopy Control Channel"
-
-#: blueman/Sdp.py:109
-msgid "Hardcopy Data Channel"
-msgstr "Hardcopy Data Channel"
-
-#: blueman/Sdp.py:110
-msgid "Hardcopy Notification"
-msgstr "Hardcopy Notification"
-
-#: blueman/Sdp.py:111
-msgid "AVCTP"
-msgstr "AVCTP"
-
-#: blueman/Sdp.py:112
-msgid "AVDTP"
-msgstr "AVDTP"
-
-#: blueman/Sdp.py:113
-msgid "CMTP"
-msgstr "CMTP"
-
-#: blueman/Sdp.py:114
-msgid "UDI_C-Plane"
-msgstr "UDI_C-Plane"
-
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
-msgid "Multi-Channel Adaptation Protocol (MCAP)"
-msgstr "Multi-Channel Adaptation Protocol (MCAP)"
-
-#: blueman/Sdp.py:117
-msgid "L2CAP"
-msgstr "L2CAP"
-
-#: blueman/Sdp.py:118
-msgid "ServiceDiscoveryServerServiceClassID"
-msgstr "ServiceDiscoveryServerServiceClassID"
-
-#: blueman/Sdp.py:119
-msgid "BrowseGroupDescriptorServiceClassID"
-msgstr "BrowseGroupDescriptorServiceClassID"
-
-#: blueman/Sdp.py:120
-msgid "Public Browse Group"
-msgstr "Public Browse Group"
-
-#: blueman/Sdp.py:121
-msgid "Serial Port"
-msgstr "Port série"
-
-#: blueman/Sdp.py:122
-msgid "LAN Access Using PPP"
-msgstr "Accès LAN en utilisant PPP"
-
-#: blueman/Sdp.py:123
-msgid "Dialup Networking (DUN)"
-msgstr "Réseau téléphonique (DUN)"
-
-#: blueman/Sdp.py:124
-msgid "IrMC Sync"
-msgstr "Synchro IrMC"
-
-#: blueman/Sdp.py:125
-msgid "OBEX Object Push"
-msgstr "Push d'objet OBEX"
-
-#: blueman/Sdp.py:126
-msgid "OBEX File Transfer"
-msgstr "Transfert de fichiers OBEX"
-
-#: blueman/Sdp.py:127
-msgid "IrMC Sync Command"
-msgstr "Commande de synchro IrMC"
-
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
 msgid "Headset"
 msgstr "Oreillette"
 
-#: blueman/Sdp.py:129
-msgid "Cordless Telephony"
-msgstr "Téléphonie sans fil"
-
-#: blueman/Sdp.py:130
-msgid "Audio Source"
-msgstr "Entrée audio"
-
-#: blueman/Sdp.py:131
-msgid "Audio Sink"
-msgstr "Sortie audio"
-
-#: blueman/Sdp.py:132
-msgid "Remote Control Target"
-msgstr "Cible de télécommande"
-
-#: blueman/Sdp.py:133
-msgid "Advanced Audio"
-msgstr "Audio avancé"
-
-#: blueman/Sdp.py:134
-msgid "Remote Control"
-msgstr "Télécommande"
-
-#: blueman/Sdp.py:135
-msgid "Video Conferencing"
-msgstr "Visioconférence"
-
-#: blueman/Sdp.py:136
-msgid "Intercom"
-msgstr "Interphone"
-
-#: blueman/Sdp.py:137
-msgid "Fax"
-msgstr "Fax"
-
-#: blueman/Sdp.py:138
-msgid "Headset Audio Gateway"
-msgstr "Passerelle audio pour casque"
-
-#: blueman/Sdp.py:139
-msgid "WAP"
-msgstr "WAP"
-
-#: blueman/Sdp.py:140
-msgid "WAP Client"
-msgstr "Client WAP"
-
-#: blueman/Sdp.py:141
-msgid "PANU"
-msgstr "PANU"
-
-#: blueman/Sdp.py:142
-msgid "Network Access Point"
-msgstr "Point d'accès réseau"
-
-#: blueman/Sdp.py:143
-msgid "Group Network"
-msgstr "Groupe réseau"
-
-#: blueman/Sdp.py:144
-msgid "DirectPrinting (BPP)"
-msgstr "DirectPrinting (BPP)"
-
-#: blueman/Sdp.py:145
-msgid "ReferencePrinting (BPP)"
-msgstr "ReferencePrinting (BPP)"
-
-#: blueman/Sdp.py:146
-msgid "Imaging (BIP)"
-msgstr "Imaging (BIP)"
-
-#: blueman/Sdp.py:147
-msgid "ImagingResponder (BIP)"
-msgstr "ImagingResponder (BIP)"
-
-#: blueman/Sdp.py:148
-msgid "ImagingAutomaticArchive (BIP)"
-msgstr "ImagingAutomaticArchive (BIP)"
-
-#: blueman/Sdp.py:149
-msgid "ImagingReferencedObjects (BIP)"
-msgstr "ImagingReferencedObjects (BIP)"
-
-#: blueman/Sdp.py:150
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
 msgid "Handsfree"
 msgstr "Kit mains-libres"
 
-#: blueman/Sdp.py:151
+#. translators: device class
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
+msgstr "microphone"
+
+#. translators: device class
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
+msgstr "haut-parleur"
+
+#. translators: device class
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
+msgstr "écouteurs"
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
+msgstr "audio portable"
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
+msgstr "audio véhicule"
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
+msgstr "décodeur (set-top box)"
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
+msgstr "chaîne hifi"
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
+msgstr "magnétoscope"
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "caméra vidéo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
+msgstr "caméscope"
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "moniteur vidéo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
+msgstr "écran vidéo et enceinte"
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "système de visioconférence"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+#, fuzzy
+msgid "Gaming/Toy"
+msgstr "appareil de jeu vidéo ou jouet"
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "clavier"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "pointage"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+#, fuzzy
+msgid "Combo"
+msgstr "combo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+#, fuzzy
+msgid "Display"
+msgstr "Écran 3D"
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+#, fuzzy
+msgid "Glasses"
+msgstr "Lunettes 3D"
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Connexion générique"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Connexion générique"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Accès générique"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Connexion générique"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Audio générique"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Télécommande"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Accès générique"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Audio générique"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Réseau générique"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transfert de fichiers générique"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Connexion générique"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Connexion générique"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transfert de fichiers générique"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+#, fuzzy
+msgid "Generic Blood Pressure"
+msgstr "Accès générique"
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+#, fuzzy
+msgid "Human Interface Device (HID)"
+msgstr "Service de périphérique d'interface humaine (HID)"
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Connexion générique"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Réseau générique"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+#, fuzzy
+msgid "Generic Insulin Pump"
+msgstr "Audio générique"
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
+msgid "SDP"
+msgstr "SDP"
+
+#: blueman/Sdp.py:88
+msgid "UDP"
+msgstr "UDP"
+
+#: blueman/Sdp.py:89
+msgid "RFCOMM"
+msgstr "RFCOMM"
+
+#: blueman/Sdp.py:90
+msgid "TCP"
+msgstr "TCP"
+
+#: blueman/Sdp.py:91
+msgid "TCS-BIN"
+msgstr "TCS-BIN"
+
+#: blueman/Sdp.py:92
+msgid "TCS-AT"
+msgstr "TCS-AT"
+
+#: blueman/Sdp.py:93
+msgid "ATT"
+msgstr "ATT"
+
+#: blueman/Sdp.py:94
+msgid "OBEX"
+msgstr "OBEX"
+
+#: blueman/Sdp.py:95
+msgid "IP"
+msgstr "IP"
+
+#: blueman/Sdp.py:96
+msgid "FTP"
+msgstr "FTP"
+
+#: blueman/Sdp.py:97
+msgid "HTTP"
+msgstr "HTTP"
+
+#: blueman/Sdp.py:98
+msgid "WSP"
+msgstr "WSP"
+
+#: blueman/Sdp.py:99
+msgid "BNEP"
+msgstr "BNEP"
+
+#: blueman/Sdp.py:100
+msgid "UPnP/ESDP"
+msgstr "UPnP ou ESDP"
+
+#: blueman/Sdp.py:101
+msgid "HIDP"
+msgstr "HIDP"
+
+#: blueman/Sdp.py:102
+msgid "Hardcopy Control Channel"
+msgstr "Hardcopy Control Channel"
+
+#: blueman/Sdp.py:103
+msgid "Hardcopy Data Channel"
+msgstr "Hardcopy Data Channel"
+
+#: blueman/Sdp.py:104
+msgid "Hardcopy Notification"
+msgstr "Hardcopy Notification"
+
+#: blueman/Sdp.py:105
+msgid "AVCTP"
+msgstr "AVCTP"
+
+#: blueman/Sdp.py:106
+msgid "AVDTP"
+msgstr "AVDTP"
+
+#: blueman/Sdp.py:107
+msgid "CMTP"
+msgstr "CMTP"
+
+#: blueman/Sdp.py:108
+msgid "UDI_C-Plane"
+msgstr "UDI_C-Plane"
+
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
+msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgstr "Multi-Channel Adaptation Protocol (MCAP)"
+
+#: blueman/Sdp.py:111
+msgid "L2CAP"
+msgstr "L2CAP"
+
+#: blueman/Sdp.py:112
+msgid "ServiceDiscoveryServerServiceClassID"
+msgstr "ServiceDiscoveryServerServiceClassID"
+
+#: blueman/Sdp.py:113
+msgid "BrowseGroupDescriptorServiceClassID"
+msgstr "BrowseGroupDescriptorServiceClassID"
+
+#: blueman/Sdp.py:114
+msgid "Public Browse Group"
+msgstr "Public Browse Group"
+
+#: blueman/Sdp.py:115
+msgid "Serial Port"
+msgstr "Port série"
+
+#: blueman/Sdp.py:116
+msgid "LAN Access Using PPP"
+msgstr "Accès LAN en utilisant PPP"
+
+#: blueman/Sdp.py:117
+msgid "Dialup Networking (DUN)"
+msgstr "Réseau téléphonique (DUN)"
+
+#: blueman/Sdp.py:118
+msgid "IrMC Sync"
+msgstr "Synchro IrMC"
+
+#: blueman/Sdp.py:119
+msgid "OBEX Object Push"
+msgstr "Push d'objet OBEX"
+
+#: blueman/Sdp.py:120
+msgid "OBEX File Transfer"
+msgstr "Transfert de fichiers OBEX"
+
+#: blueman/Sdp.py:121
+msgid "IrMC Sync Command"
+msgstr "Commande de synchro IrMC"
+
+#: blueman/Sdp.py:123
+msgid "Cordless Telephony"
+msgstr "Téléphonie sans fil"
+
+#: blueman/Sdp.py:124
+msgid "Audio Source"
+msgstr "Entrée audio"
+
+#: blueman/Sdp.py:125
+msgid "Audio Sink"
+msgstr "Sortie audio"
+
+#: blueman/Sdp.py:126
+msgid "Remote Control Target"
+msgstr "Cible de télécommande"
+
+#: blueman/Sdp.py:127
+msgid "Advanced Audio"
+msgstr "Audio avancé"
+
+#: blueman/Sdp.py:128
+msgid "Remote Control"
+msgstr "Télécommande"
+
+#: blueman/Sdp.py:129
+msgid "Video Conferencing"
+msgstr "Visioconférence"
+
+#: blueman/Sdp.py:130
+msgid "Intercom"
+msgstr "Interphone"
+
+#: blueman/Sdp.py:131
+msgid "Fax"
+msgstr "Fax"
+
+#: blueman/Sdp.py:132
+msgid "Headset Audio Gateway"
+msgstr "Passerelle audio pour casque"
+
+#: blueman/Sdp.py:133
+msgid "WAP"
+msgstr "WAP"
+
+#: blueman/Sdp.py:134
+msgid "WAP Client"
+msgstr "Client WAP"
+
+#: blueman/Sdp.py:135
+msgid "PANU"
+msgstr "PANU"
+
+#: blueman/Sdp.py:136
+msgid "Network Access Point"
+msgstr "Point d'accès réseau"
+
+#: blueman/Sdp.py:137
+msgid "Group Network"
+msgstr "Groupe réseau"
+
+#: blueman/Sdp.py:138
+msgid "DirectPrinting (BPP)"
+msgstr "DirectPrinting (BPP)"
+
+#: blueman/Sdp.py:139
+msgid "ReferencePrinting (BPP)"
+msgstr "ReferencePrinting (BPP)"
+
+#: blueman/Sdp.py:140
+msgid "Imaging (BIP)"
+msgstr "Imaging (BIP)"
+
+#: blueman/Sdp.py:141
+msgid "ImagingResponder (BIP)"
+msgstr "ImagingResponder (BIP)"
+
+#: blueman/Sdp.py:142
+msgid "ImagingAutomaticArchive (BIP)"
+msgstr "ImagingAutomaticArchive (BIP)"
+
+#: blueman/Sdp.py:143
+msgid "ImagingReferencedObjects (BIP)"
+msgstr "ImagingReferencedObjects (BIP)"
+
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr "Passerelle audio mains libres"
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr "DirectPrintingReferenceObjectsService (BPP)"
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr "ReflectedUI (BPP)"
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr "Impression simple (BPP)"
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr "État d'impression (BPP)"
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr "Service de périphérique d'interface humaine (HID)"
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr "HardcopyCableReplacement (HCR)"
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr "HCR_Print (HCR)"
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr "HCR_Scan (HCR)"
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr "Accès ISDN usuels (CIP)"
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr "VideoConferencingGW (VCP)"
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr "UDI-MT"
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr "UDI-TA"
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr "Audio/Vidéo"
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr "Accès SIM (SAP)"
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr "Accès au répertoire téléphonique (PBAP) - PCE"
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr "Accès au répertoire téléphonique (PBAP) - PCE"
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr "Accès au répertoire téléphonique (PBAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr "Serveur d'accès aux messages"
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr "Serveur de notification des messages"
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr "Profil d’accès au message (MAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr "GNSS"
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr "Serveur GNSS"
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr "Écran 3D"
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr "Lunettes 3D"
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr "Synchronisation 3D (3DSP)"
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr "Profil de spécification multi-profil (MPS)"
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr "Service de spécifications multiprofil (MPS)"
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr "Service d'accès au calendrier, aux tâches et aux notes (CTN)"
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr "Service de notification d'agenda, de tâche et de notes (CTN)"
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr "Profil de Calendrier, Tâche et Notes (CTN)"
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr "Informations PnP"
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr "Réseau générique"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr "Transfert de fichiers générique"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr "Audio générique"
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr "Téléphonie générique"
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr "Entrée vidéo"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr "Sortie vidéo"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr "Distribution vidéo"
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr "Source HDP"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr "Accès générique"
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr "Attribut générique"
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr "Alerte Immédiate"
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr "Lien perdu"
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr "Service d'heure actuelle"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr "Informations sur le périphérique"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr "Service de batterie"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr "Proxy HTTP"
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr "Transfert d'objets"
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr "AgentApple"
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr "Service principal"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr "Service secondaire"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 msgid "Device Name"
 msgstr "Nom du périphérique"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr "Adresse de reconnexion"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr "Service modifié"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr "Référence du rapport"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Connecter automatiquement les profils"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Propriétaire"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "oui"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "non"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Affiche les informations sur le périphérique"
 
@@ -1761,34 +2169,35 @@ msgstr "Profil audio"
 msgid "Select audio profile for PulseAudio"
 msgstr "Sélectionnez un profil audio pour PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Port Série %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Renouveler l'adresse IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Paramètres de connexion"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Ports série"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Non spécifié"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Connecté(e)"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Connecté automatiquement à %(service)s sur %(device)s"
@@ -1856,22 +2265,17 @@ msgstr "Utilisation du réseau"
 msgid "Shows network traffic usage"
 msgstr "Montre l'utilisation du trafic réseau"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth activé"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth désactivé"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Gère les services de réseaux locaux, tels que les ponts NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1879,7 +2283,7 @@ msgstr ""
 "Fournit le support pour les connexions via le réseau téléphonique commuté "
 "(RTC ou DUN) avec ModemManager et NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1887,38 +2291,38 @@ msgstr ""
 "un accès rapide"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Nombre d'éléments maximum"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Le nombre maximal d'éléments que le menu de connexions récentes affichera."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Connexions récentes"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Connecté(e) à %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Impossible de se connecter"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s sur %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "L'adaptateur pour cette connexion n'est pas disponible"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1926,41 +2330,41 @@ msgstr ""
 "Fournit le support pour les réseaux personnels (Personal Area Networking, "
 "PAN) introduit dans NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Fournit une API DBus pour les autres composants de Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Nouveau fichier via Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Fichier %(0)s en arrivée depuis %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Refuser"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Réception d'un fichier"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Réception du fichier %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Fournit les capacités de transfert de fichiers OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Le répertoire configuré pour les fichiers entrants n'existe pas"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1969,42 +2373,38 @@ msgstr ""
 "Veuillez vous assurer que le dossier « <b>%s</b> » existe ou configurez-le "
 "avec blueman-services. Entretemps, « %s » sera utilisé par défaut"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Fichier reçu"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Fichier %(0)s de %(1)s reçu"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Transfert échoué"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Le transfert du fichier %(0)s a échoué"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Fichiers reçus"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "%d fichier reçu en arrière-plan"
 msgstr[1] "%d fichiers reçus en arrière-plan"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "%d fichier supplémentaire reçu en arrière-plan"
@@ -2017,27 +2417,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Rajoute des éléments standards de menu au menu de l'icône d'état"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Configurer Un Nouveau Périphérique"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Envoyer des _fichiers à l'appareil"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Périphériques"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_tateurs"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2049,27 +2449,27 @@ msgstr "Fournit une clé, authentifie les services pour le démon BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Rajoute au menu un élément de sortie pour quitter l'applet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Fournit un client dhcp simple pour les connexions Bluetooth PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Réseau Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interface %(0)s attachée à l'adresse IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Échec lors de l'obtention d'une adresse IP sur %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2078,7 +2478,7 @@ msgstr ""
 "Tentative d'obtention d'une adresse IP sur %s\n"
 "Veuillez patienter…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2086,24 +2486,27 @@ msgstr ""
 "Ajoute une indication sur l'icône d'état lorsque le Bluetooth est actif et "
 "affiche le nombre de connexions dans l'infobulle."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth activé"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Connexion active</b>"
 msgstr[1] "<b>%d Connexions actives</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth désactivé"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Utilise libappindicator pour afficher une icône d'état"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2111,35 +2514,36 @@ msgstr ""
 "Fournit un élément de menu pour rendre l'adaptateur par défaut "
 "temporairement visible quand il est caché par défaut"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Temps limite de visibilité"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Temps en secondes pendant lequel le mode de visibilité est activé"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Rendre découvrable"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Rendre l'adaptateur par défaut temporairement visible"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Visible... %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Fournit un menu pour l'applet et une API afin que les autres plugins "
 "puissent le manipuler"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2148,23 +2552,23 @@ msgstr ""
 "Connecté avec succès au service <b>RTC</b> sur <b>%(0)s.</b>\n"
 "Le réseau est désormais disponible via <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Fournit un support simple pour la connexion à Internet via un profil RTC."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Gestionnaire de profils SPP standard, permet l'exécutions d'actions "
 "personnalisées"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Le script à exécuter lors de la connexion"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2183,11 +2587,11 @@ msgstr ""
 "Lors de la déconnexion de l'appareil un signal HUP sera envoyé au script</"
 "span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Port série connecté"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2195,11 +2599,11 @@ msgstr ""
 "Le service port série sur le périphérique <b>%s</b> sera maintenant "
 "disponible via <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Le script de connexion par le port série a échoué"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2208,37 +2612,37 @@ msgstr ""
 "Une erreur est survenue lors du lancement du script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Contrôle l'état d'alimentation de l'adaptateur Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Alimentation automatique"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Alimente automatiquement les adaptateurs"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Désactiver Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Éteindre tous les adaptateurs"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Activer Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Activer tous les adaptateurs"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2246,21 +2650,20 @@ msgstr ""
 "Suspend temporairement l'économiseur d'écran lorsqu'une manette de jeu "
 "Bluetooth est connectée."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Réseau"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Adresse IP invalide"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "Conflit d'adresses IP avec l'interface %s qui a la même adresse"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2271,8 +2674,8 @@ msgstr ""
 "configuration %s/%s\n"
 "Ceci peut causer un mauvais comportement réseau"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Non pris en charge actuellement avec cette configuration"
 
@@ -2288,10 +2691,6 @@ msgstr "Le plugin d'applet de service de transfert est désactivé"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Définir les propriétés de l'adaptateur Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Applet Blueman"
@@ -2299,11 +2698,6 @@ msgstr "Applet Blueman"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Gestionnaire Bluetooth Blueman"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2349,6 +2743,37 @@ msgid "Setting RfKill State requires privileges"
 msgstr ""
 "Des permissions supplémentaires sont nécessaires pour modifier l'état RfKill"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Entrez le code PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Entrer la clé de sécurité"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Port série connecté à %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "rnis"
+
+#~ msgid "headset"
+#~ msgstr "oreillette"
+
+#~ msgid "handsfree"
+#~ msgstr "kit mains-libres"
+
+#~ msgid "unknown"
+#~ msgstr "inconnu"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Périphériques Bluetooth"
 
@@ -2367,9 +2792,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Retirer..."
-
-#~ msgid "Generic Connect"
-#~ msgstr "Connexion générique"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/gl.po
+++ b/po/gl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Galician (http://www.transifex.com/mate/MATE/language/gl/)\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Axustes de visibilidade</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Agochado"
 
@@ -67,8 +67,8 @@ msgstr "_Dispositivo"
 msgid "_View"
 msgstr "_Ver"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Axuda"
 
@@ -81,7 +81,7 @@ msgstr "Buscar dispositivos próximos"
 msgid "Search"
 msgstr "Buscar"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Crear emparellamento co dispositivo"
 
@@ -90,17 +90,17 @@ msgstr "Crear emparellamento co dispositivo"
 msgid "Pair"
 msgstr "Emparellar"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Marcar/Desmarcar este dispositivo como de confianza"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Confianza"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Executar o asistente de configuración para este dispositivo"
 
@@ -109,7 +109,7 @@ msgstr "Executar o asistente de configuración para este dispositivo"
 msgid "Setup..."
 msgstr "Configurar..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Retirar este dispositivo da lista de dispositivos coñecidos"
 
@@ -290,7 +290,12 @@ msgstr "Non especificado"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -352,7 +357,7 @@ msgstr "_Restabelecer"
 msgid "Send note"
 msgstr "Enviar nota"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "Bluetooth necesita estar acendido para que o xestor do adaptador funcione"
@@ -361,32 +366,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Adaptadores de Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Sempre"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minuto"
 msgstr[1] "%d minutos"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptador"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Cómpre acender o adaptador para que o xestor de dispositivos funcione"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Non foi posíbel conectar co BlueZ"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -400,144 +403,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Buscando"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Asistente do Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Preferencias do adaptador"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Transmisor de ficheiros"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transferencia de ficheiros por Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Conectando"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "«obexd» non está dispoñíbel"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Produciuse un fallo no inicio automático do servizo obex. Asegúrese de que o "
 "servizo obex está a executarse."
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Cancelando"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Enviando un ficheiro"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Produciuse un erro ao enviar o ficheiro %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Omitir"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Volver tentar"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Produciuse un erro"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Servizos locais"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Solicitude de emparellamento para %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autenticación Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Escriba o código PIN para autenticarse:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Escriba o código PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Escriba a clave para autenticarse:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Escriba a clave"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Clave de de emparellamento para"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Código PIN de emparellamento para"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Pedimento de emparellamento para:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirme o valor para a autenticación:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Denegar"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Solicitude de autorización para:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Servizo:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Aceptar sempre"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Aceptar"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -571,250 +566,247 @@ msgstr "Si"
 msgid "No"
 msgstr "Non"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Informar dun problema"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Xestor de dispositivos"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Mosar a barra de _ferramentas"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Amosar a barra de e_stado"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_Ordenar por.."
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nome:"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Engadido"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Descendente"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "En_gadidos"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Servizos locais"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferencias do servizo"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Buscar"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Preferencias do adaptador"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Saír"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "sen categoría"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Fiábeis e emparellados</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Emparellados</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Fiábel</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Pobre"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Por baixo do ideal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Excelente"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Bo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Bastante bo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Baixo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Alto"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Moi alto"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Logrado!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Porto serie conectado a %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Produciuse un fallo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Produciuse un fallo na conexión: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Conectando"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Produciuse un fallo na desconexión"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Desconectando..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Conecta os perfís de conexión automática de orixe A2DP, receptor A2DP e HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Forzar a desconexión do dispositivo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Conectar a:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Desconectar:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Enviar un _ficheiro..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Emparellar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Fiábel"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Non fiábel"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Renomear dispositivo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Retirar"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Cancelar a operación"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indicación da actividade dos datos"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Totalidade de datos recibidos e taxa de transferencia"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Totalidade de datos enviados e taxa de transferencia"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Non confiar"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Seleccione o dispositivo"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Máis"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Miguel Anxo Bouzada <mbouzada@gmail.com>\n"
 "Proxecto Trasno <proxecto@trasno.gal>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman é un xestor GTK+ do Bluetooth"
 
@@ -822,17 +814,17 @@ msgstr "Blueman é un xestor GTK+ do Bluetooth"
 msgid "GSM Settings"
 msgstr "Axustes de GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Engadidos"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problema de dependencia"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -843,7 +835,7 @@ msgstr ""
 "%(1)s</b> tamén desconectará <b>\"%(0)s\"</b>.\n"
 "Continuar?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -854,886 +846,1259 @@ msgstr ""
 "b> descargará <b>%(0)s</b>.\n"
 "Proceder?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Selección do adaptador"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Descubríbel… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "sen categoría"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Punto de acceso á rede"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "escritorio"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "servidor"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "portátil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "dispositivo móbil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "PDA"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "móbil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "sen fios"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "teléfono intelixente"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "módem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "adsl"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "«obexd» non está dispoñíbel"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "auriculares"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "mans libres"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "descoñecido"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "micrófono"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Fonte de son"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Fonte de son"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Fonte de son"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "teclado"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "punteiro"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "teclado"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "punteiro"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Conectar"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Conectar"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Conectar"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Conectar"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Transferencia de ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Conectar"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Transferencia de ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Transferencia de ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Grupo de rede"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transferencia de ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Conectar"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Conectar"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transferencia de ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Conectar"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Grupo de rede"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Portos serie"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Rede de acceso telefónico (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Transferencia de ficheiros por Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "auriculares"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Fonte de son"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Receptor de son"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Punto de acceso á rede"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Grupo de rede"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "mans libres"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Punto de acceso á rede (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Punto de acceso á rede (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Grupo de rede"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Transferencia de ficheiros por Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Fonte de son"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Receptor de son"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Fonte de son"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Renomear dispositivo"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Amosar información do dispositivo"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Servizos locais"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Transferir"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "miniaplicación"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Emparellar o dispositivo"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Buscar dispositivos próximos"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Transferir"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "miniaplicación"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Emparellar o dispositivo"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Buscar dispositivos próximos"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Xestor de dispositivos"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "_Conexións recentes"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Xestor de dispositivos"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Preferencias do adaptador"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Perfís de conexión automática"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietario"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "si"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "non"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Información"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Amosar información do dispositivo"
 
@@ -1758,34 +2123,35 @@ msgstr "Perfil de son"
 msgid "Select audio profile for PulseAudio"
 msgstr "Escolla o perfil de son para PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Porto serie %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Renovar o enderezo de IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Axustes da marcación"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Portos serie"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Sen especificar"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Conectado"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Conectado automaticamente a %(service)s en %(device)s"
@@ -1853,22 +2219,17 @@ msgstr "_Uso da rede"
 msgid "Shows network traffic usage"
 msgstr "Amosa o uso de tráfico de rede"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooh activado"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth desactivado"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Xestiona servizos locais de rede como pontes NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1876,7 +2237,7 @@ msgstr ""
 "Fornece compatibilidade para acceso telefónico a redes DUN (Dial Up "
 "Networking) con ModemManager e Network Manager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1884,37 +2245,37 @@ msgstr ""
 "rápido"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Número máximo de elementos"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Número máximo de conexións recentes amosadas no menú"
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Conexións recentes"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Conectado a %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Produciuse un fallo ao conectar"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s en %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "O adaptador para esta conexión non está dispoñíbel"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1922,41 +2283,41 @@ msgstr ""
 "Fornece compatibilidade para Personal Area Networking (PAN) introducido en "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Fornece unha API DBus para outros compoñentes Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Ficheiro entrante por Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Chegando o ficheiro %(0)s dende %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Rexeitar"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Recibindo un ficheiro"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Recibindo o ficheiro %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Fornece capacidade de transferencia para ficheiros OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "O directorio configurado para ficheiros entrantes non existe"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1965,42 +2326,38 @@ msgstr ""
 "Asegúrese de que o directorio «<b>%s</b>» existe ou configúreo con blueman-"
 "services. Ata entón empregarase o «%s» predeterminado."
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Ficheiro recibido"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Ficheiro %(0)s de %(1)s recibido"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Produciuse un fallo na transferencia"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Produciuse un fallo na transferencia do ficheiro %(0)s"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Ficheiros recibidos"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Recibiuse %d ficheiro en segundo plano"
 msgstr[1] "Recibíronse %d ficheiros en segundo plano"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Recibiuse %d ficheiro en segundo plano"
@@ -2013,27 +2370,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Engade os elementos do menú estándar ao menú da icona de estado"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Configurar un dispositivo novo"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Enviar _ficheiros ao dispositivo"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Dispositivos"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_tadores"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "miniaplicación"
 
@@ -2045,27 +2402,27 @@ msgstr "Fornece o servizo de autenticación por clave para o servizo BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Engadir un elemento «Saír» ao menú para saír da miniaplicación"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Fornece un cliente básico de DHCP para as conexións Bluetooth PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Rede Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "A interface %(0)s liga co enderezo de IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Produciuse un fallo ao obter o enderezo IP en %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2074,7 +2431,7 @@ msgstr ""
 "Tentando obter un enderezo IP en %s\n"
 "Agarde..."
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2082,24 +2439,27 @@ msgstr ""
 "Engade unha indicación sobre a icona de estado cando Bluetooth está activo e "
 "amosa o número de conexións na suxestión."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth activo"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Activar a conexión</b>"
 msgstr[1] "<b>%d Activar as conexións</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth desactivado"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Utiliza libappindicator para amosar unha icona de estado"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2107,35 +2467,36 @@ msgstr ""
 "Fornece un elemento do menú para facer temporalmente visíbel o adaptador "
 "cando se configura para estar agochado de modo predeterminado"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Tempo en descuberto"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Cantidade de tempo en segundos que permanecerá en modo descuberto"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Facer descubríbel"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Volver o adaptador predeterminado temporalmente visíbel"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Descubríbel… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Fornece un menú para a miniaplicación e unha API para outros engadidos "
 "manipuláreno"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2144,24 +2505,24 @@ msgstr ""
 "Conectado ao servizo <b>DUN</b> en <b>%(0)s.</b>\n"
 "A rede está agora dispoñíbel a través de <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Fornece compatibilidade básica para conectar á Internet a través dun perfil "
 "DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Perfíl estándar de conexión SPP do controlador, permite a execución de "
 "accións personalizadas"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script a executar na conexión"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2179,22 +2540,22 @@ msgstr ""
 "\n"
 "Ao desconectar o dispositivo, o script envía un sinal HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Porto serie conectado"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "O porto serie no dispositivo <b>%s</b> estará agora dispoñíbel vía<b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Produciuse un fallo no script de conexión ao porto serie"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2203,37 +2564,37 @@ msgstr ""
 "Xurdíu un problema executando o script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Estado dos controles de enerxía do adaptador Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Acendido automático"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Acender automaticamente os adaptadores"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>A_pagar o Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Apagar todos os adaptadores"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Acender o Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Acender todos os adaptadores"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2241,21 +2602,20 @@ msgstr ""
 "Suspende temporalmente o salvapantallas cando está conectado un controlador "
 "de xogos Bluetooth."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Rede"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Enderezo IP incorrecto"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "Conflito de enderezos IP coa interface %s que ten o mesmo enderezo"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2266,8 +2626,8 @@ msgstr ""
 "configuración %s/%s\n"
 "Isto pode provocar un comportamento incorrecto da rede"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Non é actualmente compatíbel con esta configuración"
 
@@ -2282,40 +2642,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptadores de Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "miniaplicación"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman é un xestor GTK+ do Bluetooth"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooh activado"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Dispositivos de Bluetooth"
 
@@ -2351,6 +2697,31 @@ msgstr "Estabelecer o estado do RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Axustar o estado do RfKill require privilexios"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Escriba o código PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Escriba a clave"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Porto serie conectado a %s"
+
+#~ msgid "palm"
+#~ msgstr "PDA"
+
+#~ msgid "isdn"
+#~ msgstr "adsl"
+
+#~ msgid "headset"
+#~ msgstr "auriculares"
+
+#~ msgid "handsfree"
+#~ msgstr "mans libres"
+
+#~ msgid "unknown"
+#~ msgstr "descoñecido"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Dispositivos de Bluetooth"
 
@@ -2371,11 +2742,6 @@ msgstr "Axustar o estado do RfKill require privilexios"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Retirar..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Conectar"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/he.po
+++ b/po/he.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-30 11:35+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -27,7 +27,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>הגדרות גילוי</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "מוסתר"
 
@@ -71,8 +71,8 @@ msgstr "_התקן"
 msgid "_View"
 msgstr "_תצוגה"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_עזרה"
 
@@ -85,7 +85,7 @@ msgstr "חיפוש מכשירים קרובים"
 msgid "Search"
 msgstr "חיפוש"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "יצירת חיבור עם המכשיר"
 
@@ -94,17 +94,17 @@ msgstr "יצירת חיבור עם המכשיר"
 msgid "Pair"
 msgstr "צימוד"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "סימון/ביטול הסימון של מכשיר זה כמהימן"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "מהימן"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "הפעלת מסייע ההגדרות עבור מכשיר זה"
 
@@ -113,7 +113,7 @@ msgstr "הפעלת מסייע ההגדרות עבור מכשיר זה"
 msgid "Setup..."
 msgstr "התקנה…"
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "הסרת התקן זה מרשימת ההתקנים הידועים"
 
@@ -292,7 +292,12 @@ msgstr "לא צוין"
 msgid "<b>Author:</b>"
 msgstr "<b>יוצר:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -354,7 +359,7 @@ msgstr "_איפוס"
 msgid "Send note"
 msgstr "שלח הערה"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "אנא הפעל את שירות הBLUETOOTH בכדי שמנהל המתאמים יעבוד"
 
@@ -362,14 +367,12 @@ msgstr "אנא הפעל את שירות הBLUETOOTH בכדי שמנהל המתא
 msgid "Bluetooth Adapters"
 msgstr "מתאמי Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "תמיד"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "דקה %d"
@@ -377,19 +380,19 @@ msgstr[1] "%d דקות"
 msgstr[2] "%d דקות"
 msgstr[3] "%d דקות"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "מתא"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "אנא הפעל את שירות הBLUETOOTH בכדי שמנהל המכשירים יעבוד"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "חיבור ל BlueZ נכשל"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -403,48 +406,48 @@ msgstr ""
 msgid "Searching"
 msgstr "מתבצע חיפוש"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "אשף הbluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "העדפות מתאם"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "שולח הקבצים"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "העברת קבצים ב־Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "בהתחברות"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd אינו זמין"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr "הפעלת שירות ה־obex אוטומטית נכשלה. נא לוודא שסוכן ה־obex פעיל"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "התהליך מבוטל"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "קובץ נשלח"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "מועד הגעה משוער:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -453,94 +456,86 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "אירעה שגיאה בעת שליחת הקובץ %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "דילוג"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "ניסיון חוזר"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "אירעה שגיאה"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "שירותים מקומיים"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "בקשת צימוד עבור %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "אימות Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "אנא הזן את קוד הזיהוי האישי:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "נא למלא את קוד הזיהוי האישי"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "אמת על ידי הזנת סיסמא:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "הזן סיסמא"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "סיסמת חיבור ל"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "קוד חיבור ל"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "בקשת צימוד עבור:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "ערך אישור לאימות:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "אישור"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "סירוב"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "בקשת אימות עבור:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "שירות:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "לקבל תמיד"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "אישור"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -573,243 +568,242 @@ msgstr "כן"
 msgid "No"
 msgstr "לא"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_דיווח על תקלה"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "מנהל התקנים"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "הצגת _סרגל כלים"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "הצגת _שורת מצב"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_סידור לפי"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_שם"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_נוסף"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "יו_רד"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_תוספים"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_שירותים מקומיים"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "העדפות שירות"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_חיפוש"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "ה_עדפות"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "י_ציאה"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "ללא קטגוריה"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>מהימן ומצומד</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>מצומד</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>מהימן</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "עני"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "לא מיטבי"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "מיטבי"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "הרבה"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "יותר מדי"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "נמוך"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "גבוה"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "גבוה מאוד"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "הצליח!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "הפתחה הטורית מחוברת אל %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "נכשל"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "חיבור נכשל: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "בהתחברות"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "ניתוק נכשל: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "מתבצע ניתוק…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>חיבור</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "מחבר פרופילים לחיבור אוטומטי של מקור A2DP, מקלט A2DP והתקני מנשק אנוש"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>ניתוק</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "ניתוק ההתקן בכוח"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>התחברות אל:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>ניתוק:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "_שליחת קובץ…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_צימוד"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "מ_הימנות"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "ה_סרת מהימנות"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "ה_גדרה…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "שינוי שם ההתקן"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "הסרה"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "ביטול הפעולה"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "מחוון פעילות נתונים"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "סך הכל נתונים שהתקבלו ומהירות הקבלה"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "סך הכל נתונים שנשלחו ומהירות השליחה"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "אל תסמוך"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "בחירת התקן"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "עוד"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr "Yaron Shahrabani <sh.yaron@gmail.com>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman הוא מנהל Bluetooth לסביבתGTK+ ‎"
 
@@ -817,17 +811,17 @@ msgstr "Blueman הוא מנהל Bluetooth לסביבתGTK+ ‎"
 msgid "GSM Settings"
 msgstr "הגדרות GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "תוספים"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "בעיית תלות"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -838,7 +832,7 @@ msgstr ""
 "<b>”%(0)s„</b>.\n"
 "להמשיך?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -849,842 +843,1248 @@ msgstr ""
 "%(0)s</b>.\n"
 "להמשיך?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "בחירת מתאם"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr "מתבצע גילוי…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "ללא קטגוריה"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "נקודת גישה לרשת"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "שולחן עבודה"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "שרת"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "מחשב נייד"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "מכשיר כף יד"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "כף יד"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "סלולרי"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "אלחוטי"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "סמארטפון"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "מודם"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
-
-#. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "אוזניות"
-
-#. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "דיבורית"
-
-#. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "לא ידוע"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
-msgstr "מיקרופון"
-
-#. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
-msgstr "רמקול"
-
-#. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
-msgstr "אוזניות"
-
-#. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
-msgstr "מכשיר שמע נייד"
-
-#. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr "דיבורית רכב"
-
-#. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
-msgstr "קופסת מולטימדיה"
-
-#. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
-msgstr "שמע באיכות גבוהה"
-
-#. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
-msgstr "מקליט"
-
-#. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
-msgstr "מצלמת וידאו"
-
-#. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
-msgstr "מצלמה מקליטה"
-
-#. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr "צג וידאו"
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr "צג וידאו ורמקול"
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
-msgstr "ועידת וידאו"
-
-#. translators: device class
-#: blueman/DeviceClass.py:145
-msgid "gaming/toy"
-msgstr "משחק/צעצוע"
-
-#. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "מקלדת"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "מצביע"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
-msgstr "משולב"
-
-#: blueman/Sdp.py:93
-msgid "SDP"
-msgstr "SDP"
-
-#: blueman/Sdp.py:94
-msgid "UDP"
-msgstr "UDP"
-
-#: blueman/Sdp.py:95
-msgid "RFCOMM"
-msgstr "RFCOMM"
-
-#: blueman/Sdp.py:96
-msgid "TCP"
-msgstr "TCP"
-
-#: blueman/Sdp.py:97
-msgid "TCS-BIN"
-msgstr "TCS-BIN"
-
-#: blueman/Sdp.py:98
-msgid "TCS-AT"
-msgstr "TCS-AT"
-
-#: blueman/Sdp.py:99
-msgid "ATT"
-msgstr "ATT"
-
-#: blueman/Sdp.py:100
-msgid "OBEX"
-msgstr "OBEX"
-
-#: blueman/Sdp.py:101
-msgid "IP"
-msgstr "IP"
-
-#: blueman/Sdp.py:102
-msgid "FTP"
-msgstr "FTP"
-
-#: blueman/Sdp.py:103
-msgid "HTTP"
-msgstr "HTTP"
-
-#: blueman/Sdp.py:104
-msgid "WSP"
-msgstr "WSP"
-
-#: blueman/Sdp.py:105
-msgid "BNEP"
-msgstr "BNEP"
-
-#: blueman/Sdp.py:106
-msgid "UPnP/ESDP"
-msgstr "UPnP/ESDP"
-
-#: blueman/Sdp.py:107
-msgid "HIDP"
-msgstr "HIDP"
-
-#: blueman/Sdp.py:108
-msgid "Hardcopy Control Channel"
+msgid "83-99 percent"
 msgstr ""
 
-#: blueman/Sdp.py:109
-msgid "Hardcopy Data Channel"
-msgstr ""
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd אינו זמין"
 
-#: blueman/Sdp.py:110
-msgid "Hardcopy Notification"
-msgstr ""
-
-#: blueman/Sdp.py:111
-msgid "AVCTP"
-msgstr "AVCTP"
-
-#: blueman/Sdp.py:112
-msgid "AVDTP"
-msgstr "AVDTP"
-
-#: blueman/Sdp.py:113
-msgid "CMTP"
-msgstr "CMTP"
-
-#: blueman/Sdp.py:114
-msgid "UDI_C-Plane"
-msgstr ""
-
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
-msgid "Multi-Channel Adaptation Protocol (MCAP)"
-msgstr "פרוטוקול הסתגלות רב ערוצי (MCAP)"
-
-#: blueman/Sdp.py:117
-msgid "L2CAP"
-msgstr "L2CAP"
-
-#: blueman/Sdp.py:118
-msgid "ServiceDiscoveryServerServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:119
-msgid "BrowseGroupDescriptorServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:120
-msgid "Public Browse Group"
-msgstr ""
-
-#: blueman/Sdp.py:121
-msgid "Serial Port"
-msgstr "פתחה טורית"
-
-#: blueman/Sdp.py:122
-msgid "LAN Access Using PPP"
-msgstr "גישה לרשת מקומית דרך PPP"
-
-#: blueman/Sdp.py:123
-msgid "Dialup Networking (DUN)"
-msgstr "חיבור אינטרנט דרך טלפון (DUP)"
-
-#: blueman/Sdp.py:124
-msgid "IrMC Sync"
-msgstr "סנכרון IrMC"
-
-#: blueman/Sdp.py:125
-msgid "OBEX Object Push"
-msgstr ""
-
-#: blueman/Sdp.py:126
-msgid "OBEX File Transfer"
-msgstr "העברת קבצים ב־OBEX"
-
-#: blueman/Sdp.py:127
-msgid "IrMC Sync Command"
-msgstr "פקודת סנכרון של IrMC"
-
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
 msgid "Headset"
 msgstr "אוזניות"
 
-#: blueman/Sdp.py:129
-msgid "Cordless Telephony"
-msgstr ""
-
-#: blueman/Sdp.py:130
-msgid "Audio Source"
-msgstr "מקור שמע"
-
-#: blueman/Sdp.py:131
-msgid "Audio Sink"
-msgstr "שקע שמע"
-
-#: blueman/Sdp.py:132
-msgid "Remote Control Target"
-msgstr "יעד שליטה מרחוק"
-
-#: blueman/Sdp.py:133
-msgid "Advanced Audio"
-msgstr "שמע מתקדם"
-
-#: blueman/Sdp.py:134
-msgid "Remote Control"
-msgstr "שליטה מרחוק"
-
-#: blueman/Sdp.py:135
-msgid "Video Conferencing"
-msgstr "ועידה בווידאו"
-
-#: blueman/Sdp.py:136
-msgid "Intercom"
-msgstr "אינטרקום"
-
-#: blueman/Sdp.py:137
-msgid "Fax"
-msgstr "פקס"
-
-#: blueman/Sdp.py:138
-msgid "Headset Audio Gateway"
-msgstr "שער שמע לאוזניות"
-
-#: blueman/Sdp.py:139
-msgid "WAP"
-msgstr ""
-
-#: blueman/Sdp.py:140
-msgid "WAP Client"
-msgstr ""
-
-#: blueman/Sdp.py:141
-msgid "PANU"
-msgstr ""
-
-#: blueman/Sdp.py:142
-msgid "Network Access Point"
-msgstr "נקודת גישה לרשת"
-
-#: blueman/Sdp.py:143
-msgid "Group Network"
-msgstr "קבוצת רשת"
-
-#: blueman/Sdp.py:144
-msgid "DirectPrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:145
-msgid "ReferencePrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:146
-msgid "Imaging (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:147
-msgid "ImagingResponder (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:148
-msgid "ImagingAutomaticArchive (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:149
-msgid "ImagingReferencedObjects (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:150
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
 msgid "Handsfree"
 msgstr "דיבורית"
 
-#: blueman/Sdp.py:151
+#. translators: device class
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
+msgstr "מיקרופון"
+
+#. translators: device class
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
+msgstr "רמקול"
+
+#. translators: device class
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
+msgstr "אוזניות"
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
+msgstr "מכשיר שמע נייד"
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
+msgstr "דיבורית רכב"
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
+msgstr "קופסת מולטימדיה"
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
+msgstr "שמע באיכות גבוהה"
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
+msgstr "מקליט"
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "מצלמת וידאו"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
+msgstr "מצלמה מקליטה"
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "צג וידאו"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
+msgstr "צג וידאו ורמקול"
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "ועידת וידאו"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+#, fuzzy
+msgid "Gaming/Toy"
+msgstr "משחק/צעצוע"
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "מקלדת"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "מצביע"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+#, fuzzy
+msgid "Combo"
+msgstr "משולב"
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+msgid "Display"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "חיבור גנרי"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "חיבור גנרי"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "חיבור גנרי"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "חיבור גנרי"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "העברת קבצים גנרית"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "שליטה מרחוק"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "העברת קבצים גנרית"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "העברת קבצים גנרית"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "רשת תקשורת גנרית"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "העברת קבצים גנרית"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "חיבור גנרי"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "חיבור גנרי"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "העברת קבצים גנרית"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "חיבור גנרי"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "רשת תקשורת גנרית"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
+msgid "SDP"
+msgstr "SDP"
+
+#: blueman/Sdp.py:88
+msgid "UDP"
+msgstr "UDP"
+
+#: blueman/Sdp.py:89
+msgid "RFCOMM"
+msgstr "RFCOMM"
+
+#: blueman/Sdp.py:90
+msgid "TCP"
+msgstr "TCP"
+
+#: blueman/Sdp.py:91
+msgid "TCS-BIN"
+msgstr "TCS-BIN"
+
+#: blueman/Sdp.py:92
+msgid "TCS-AT"
+msgstr "TCS-AT"
+
+#: blueman/Sdp.py:93
+msgid "ATT"
+msgstr "ATT"
+
+#: blueman/Sdp.py:94
+msgid "OBEX"
+msgstr "OBEX"
+
+#: blueman/Sdp.py:95
+msgid "IP"
+msgstr "IP"
+
+#: blueman/Sdp.py:96
+msgid "FTP"
+msgstr "FTP"
+
+#: blueman/Sdp.py:97
+msgid "HTTP"
+msgstr "HTTP"
+
+#: blueman/Sdp.py:98
+msgid "WSP"
+msgstr "WSP"
+
+#: blueman/Sdp.py:99
+msgid "BNEP"
+msgstr "BNEP"
+
+#: blueman/Sdp.py:100
+msgid "UPnP/ESDP"
+msgstr "UPnP/ESDP"
+
+#: blueman/Sdp.py:101
+msgid "HIDP"
+msgstr "HIDP"
+
+#: blueman/Sdp.py:102
+msgid "Hardcopy Control Channel"
+msgstr ""
+
+#: blueman/Sdp.py:103
+msgid "Hardcopy Data Channel"
+msgstr ""
+
+#: blueman/Sdp.py:104
+msgid "Hardcopy Notification"
+msgstr ""
+
+#: blueman/Sdp.py:105
+msgid "AVCTP"
+msgstr "AVCTP"
+
+#: blueman/Sdp.py:106
+msgid "AVDTP"
+msgstr "AVDTP"
+
+#: blueman/Sdp.py:107
+msgid "CMTP"
+msgstr "CMTP"
+
+#: blueman/Sdp.py:108
+msgid "UDI_C-Plane"
+msgstr ""
+
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
+msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgstr "פרוטוקול הסתגלות רב ערוצי (MCAP)"
+
+#: blueman/Sdp.py:111
+msgid "L2CAP"
+msgstr "L2CAP"
+
+#: blueman/Sdp.py:112
+msgid "ServiceDiscoveryServerServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:113
+msgid "BrowseGroupDescriptorServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:114
+msgid "Public Browse Group"
+msgstr ""
+
+#: blueman/Sdp.py:115
+msgid "Serial Port"
+msgstr "פתחה טורית"
+
+#: blueman/Sdp.py:116
+msgid "LAN Access Using PPP"
+msgstr "גישה לרשת מקומית דרך PPP"
+
+#: blueman/Sdp.py:117
+msgid "Dialup Networking (DUN)"
+msgstr "חיבור אינטרנט דרך טלפון (DUP)"
+
+#: blueman/Sdp.py:118
+msgid "IrMC Sync"
+msgstr "סנכרון IrMC"
+
+#: blueman/Sdp.py:119
+msgid "OBEX Object Push"
+msgstr ""
+
+#: blueman/Sdp.py:120
+msgid "OBEX File Transfer"
+msgstr "העברת קבצים ב־OBEX"
+
+#: blueman/Sdp.py:121
+msgid "IrMC Sync Command"
+msgstr "פקודת סנכרון של IrMC"
+
+#: blueman/Sdp.py:123
+msgid "Cordless Telephony"
+msgstr ""
+
+#: blueman/Sdp.py:124
+msgid "Audio Source"
+msgstr "מקור שמע"
+
+#: blueman/Sdp.py:125
+msgid "Audio Sink"
+msgstr "שקע שמע"
+
+#: blueman/Sdp.py:126
+msgid "Remote Control Target"
+msgstr "יעד שליטה מרחוק"
+
+#: blueman/Sdp.py:127
+msgid "Advanced Audio"
+msgstr "שמע מתקדם"
+
+#: blueman/Sdp.py:128
+msgid "Remote Control"
+msgstr "שליטה מרחוק"
+
+#: blueman/Sdp.py:129
+msgid "Video Conferencing"
+msgstr "ועידה בווידאו"
+
+#: blueman/Sdp.py:130
+msgid "Intercom"
+msgstr "אינטרקום"
+
+#: blueman/Sdp.py:131
+msgid "Fax"
+msgstr "פקס"
+
+#: blueman/Sdp.py:132
+msgid "Headset Audio Gateway"
+msgstr "שער שמע לאוזניות"
+
+#: blueman/Sdp.py:133
+msgid "WAP"
+msgstr ""
+
+#: blueman/Sdp.py:134
+msgid "WAP Client"
+msgstr ""
+
+#: blueman/Sdp.py:135
+msgid "PANU"
+msgstr ""
+
+#: blueman/Sdp.py:136
+msgid "Network Access Point"
+msgstr "נקודת גישה לרשת"
+
+#: blueman/Sdp.py:137
+msgid "Group Network"
+msgstr "קבוצת רשת"
+
+#: blueman/Sdp.py:138
+msgid "DirectPrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:139
+msgid "ReferencePrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:140
+msgid "Imaging (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:141
+msgid "ImagingResponder (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:142
+msgid "ImagingAutomaticArchive (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:143
+msgid "ImagingReferencedObjects (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr "שער השמעת דיבורית"
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr "גישה לספר טלפונים (PBAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr "פרופיל גישה להודעות (MAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr "רשת תקשורת גנרית"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr "העברת קבצים גנרית"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr "מקור וידאו"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr "שקע וידאו"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr "מקור HDP"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr "שירות זמן נוכחי"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr "פרטי המכשיר"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr "שירות סוללה"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr "העברת פריטים"
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr "שירות עיקרי"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr "שירות משני"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 msgid "Device Name"
 msgstr "שם המכשיר"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr "כתובת לחיבור מחדש"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr "השירות השתנה"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "העדפות מתאם"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "פרופילים להתחברות אוטומטית"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "קנייני"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "כן"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "לא"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "מי_דע"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "הצגת פרטי התקן"
 
@@ -1709,34 +2109,35 @@ msgstr "פרופיל שמע"
 msgid "Select audio profile for PulseAudio"
 msgstr "בחירת פרופיל שמע ל־PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "חידוש כתובת ה־IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "הגדרות חיוג"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "פתחות טוריות"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "לא צוין"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "מחובר"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1809,105 +2210,100 @@ msgstr "שימוש ב_רשת"
 msgid "Shows network traffic usage"
 msgstr "הצגת שימוש בתעבורת הרשת"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth פעיל"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth כבוי"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 "מספק תמיכה בחיבור בחיוג (DUN - Dial-Up) עם ModemManager ו־NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "מספק פריט המכיל את החיבור האחרון לגישה נוחה"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "מרב הפריטים"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "מירב הפריטים שתפריט החיבורים האחרונים יציג."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_חיבורים אחרונים"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "מחובר ל%s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "החיבור נכשל"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)sב%(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "המתאם לחיבור הזה אינו זמין"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr "מספק תמיכה ברשת בטווח מיידי (PAN) שהופיעה ב־NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "מספק API ל־DBus עבור רכיבים נוספים של Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "קובץ מתקבל על ידי Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "הקובץ %(0)s מתקבל מ%(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "דחייה"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "קובץ מתקבל"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "התקבל קובץ %(0)s מתוך %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "מספק שירותי החלפת קבצים בעזרת OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "התיקייה המוגדרת לקובץ המתקבל לא קיימת"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1916,33 +2312,31 @@ msgstr ""
 "נא לוודא שהתיקייה „<b>%s</b>” קיימת או להגדיר אותה עם blueman-services. עד "
 "אז ייעשה שימוש בבררת המחדל „%s”"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "קובץ התקבל"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "הקובץ %(0)s מ%(1)s התקבל בהצלחה"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "העברה נכשלה"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "העברה של קובץ %(0)s נכשלה"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "קבצים התקבלו"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "התקבל קובץ אחד ברקע"
@@ -1950,10 +2344,8 @@ msgstr[1] "התקבלו שני קבצים ברקע"
 msgstr[2] "התקבלו %d קבצים ברקע"
 msgstr[3] "התקבלו %d קבצים ברקע"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "התקבל קובץ נוסף ברקע"
@@ -1968,27 +2360,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "מ_כשירים"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "מת_אמים"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "יישומון"
 
@@ -2000,47 +2392,45 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>חיבור פעיל אחד</b>"
@@ -2048,11 +2438,16 @@ msgstr[1] "<b>%d חיבורים פעילים</b>"
 msgstr[2] "<b>%d חיבורים פעילים</b>"
 msgstr[3] "<b>%d חיבורים פעילים</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth כבוי"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "משתמש ב־libappindicator כדי להציג סמל מצב"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2060,53 +2455,54 @@ msgstr ""
 "מספק פריט בתפריט להפוך את מתאם בררת המחדל לזמין לגילוי כאשר הוא מוגדר לנסתר "
 "כבררת מחדל"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "תום משך זמינות לגילוי"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "משך הזמן בשניות שמצב הזמינות לגילוי יימשך"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "לה_פוך לזמין לגילוי"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "להפוך את מתאם בררת המחדל לזמין לגילוי באופן זמני"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "זמין לגילוי… %s שניות"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "מספק תמיכה בסיסית להתחברות לאינטרנט דרך פרופיל חיוג לרשת."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "סקריפט להפעלה עם החיבור"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2124,21 +2520,21 @@ msgstr ""
 "\n"
 "עם ניתוק המכשיר יישלח לסקריפט אות HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "הפתחה הטורית מחוברת"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr "שירות הפתחה הטורית בהתקן <b>%s</b> יהיה זמין מעתה דרך <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "סקריפט חיבור הפתחה הטורית נכשל"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2147,57 +2543,56 @@ msgstr ""
 "אירעה שגיאה בהפעלת הסקריפט %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "שולט במצבי הפעילות החשמלית של מתאים ה־Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "הדלקה אוטומטית"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "הדלקה אוטומטית של מתאמים"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_כיבוי Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "כיבוי כל המתאמים"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>ה_פעלת Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "הפעלת כל המתאמים"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr "להשהות זמנית את שומר המסך כאשר מחובר התקן משחק דרך bluetooth."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "רשת"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "כתובת IP שגויה"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "כתובת ה־IP סותרת את המנשק %s שמוגדר עם אותה כתובת ה־IP"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2207,8 +2602,8 @@ msgstr ""
 "כתובת ה־IP חופפת למסכת הרשת של המנשק %s, שמוגדר כך: %s/%s\n"
 "מצב זה עלול להוביל להתנהגות רשת פסולה"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "אין תמיכה עם תצורה זו"
 
@@ -2224,10 +2619,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr "הגדרת מאפייני מתאם Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
@@ -2235,11 +2626,6 @@ msgstr ""
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman - מנהל Bluetooth"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2281,6 +2667,34 @@ msgstr "הגדרת מצב RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "הגדרת מצב ה־RfKill דורשת הרשאות"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "נא למלא את קוד הזיהוי האישי"
+
+#~ msgid "Enter passkey"
+#~ msgstr "הזן סיסמא"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "הפתחה הטורית מחוברת אל %s"
+
+#~ msgid "palm"
+#~ msgstr "כף יד"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "אוזניות"
+
+#~ msgid "handsfree"
+#~ msgstr "דיבורית"
+
+#~ msgid "unknown"
+#~ msgstr "לא ידוע"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "התקני Bluetooth"
 
@@ -2303,9 +2717,6 @@ msgstr "הגדרת מצב ה־RfKill דורשת הרשאות"
 
 #~ msgid "_Remove..."
 #~ msgstr "ה_סרה…"
-
-#~ msgid "Generic Connect"
-#~ msgstr "חיבור גנרי"
 
 #~ msgid "Select files to send"
 #~ msgstr "בחירת קבצים לשליחה"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Hindi (http://www.transifex.com/mate/MATE/language/hi/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>दृश्यता सेटिंग</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "छिपा"
 
@@ -65,8 +65,8 @@ msgstr ""
 msgid "_View"
 msgstr "देखें (_V)"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "मदद (_H)"
 
@@ -79,7 +79,7 @@ msgstr "पास के उपकरण खोजें"
 msgid "Search"
 msgstr "खोजें"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "उपकरण के साथ बाँधना बनाएँ"
 
@@ -88,17 +88,17 @@ msgstr "उपकरण के साथ बाँधना बनाएँ"
 msgid "Pair"
 msgstr "युग्म"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "विश्वास"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "इस उपकरण के लिए सेटअप सहायक चलाएँ"
 
@@ -107,7 +107,7 @@ msgstr "इस उपकरण के लिए सेटअप सहायक 
 msgid "Setup..."
 msgstr "सेटअप..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "ज्ञात यंत्रों की सूची में से इस यन्त्र को निकलें"
 
@@ -282,7 +282,12 @@ msgstr ""
 msgid "<b>Author:</b>"
 msgstr ""
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -344,7 +349,7 @@ msgstr "रीसेट करें (_R)"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -352,30 +357,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "ब्लूटूथ एडाप्टर"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "हमेशा"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -386,142 +391,134 @@ msgstr ""
 msgid "Searching"
 msgstr "खोज रहा है"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr ""
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "जुड़ रहा है..."
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr ""
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr ""
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr ""
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "स्थानीय सेवाएँ"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "सेवा:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr ""
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -552,237 +549,236 @@ msgstr "हाँ"
 msgid "No"
 msgstr "नहीं"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "ढूंढें (_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "गरीब"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "निम्न"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "उच्च"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "सफल!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "असफल"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "जुड़ रहा है..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "डिसकनेक्ट कर रहा है..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send File"
 msgid "Send a _File…"
 msgstr "फाइल भेजें"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "निकलें"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr ""
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "राजेश रंजन (rajeshkajha@yahoo.com)\n"
@@ -790,7 +786,7 @@ msgstr ""
 "रविशंकर श्रीवास्तव (raviratlami@gmail.com)\n"
 "राघवन गोपालकृष्णन्  (g.raghavan.g@gmail.com)"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -798,17 +794,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "प्लगइन"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -816,7 +812,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -824,860 +820,1231 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "डिसकनेक्ट कर रहा है..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+msgid "Access point"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "डेस्कटॉप"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "सर्वर"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "लैपटॉप"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+msgid "Smart phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
+msgid "17-33 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
+msgid "50-67 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
+msgid "67-83 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "हेडसेट"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "अज्ञात"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+msgid "Microphone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+msgid "Video camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+msgid "Video monitor"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+msgid "Video conferencing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "कुंजीपटल"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "जुड़ रहा है..."
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "कुंजीपटल"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "कनेक्ट"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Transfer"
 msgid "OBEX File Transfer"
 msgstr "हस्तांतरण"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "हेडसेट"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr ""
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr ""
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr ""
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr ""
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr ""
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr ""
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr ""
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "स्थानीय सेवाएँ"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "हस्तांतरण"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "एप्पलेट"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "स्थानीय सेवाएँ"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "पास के उपकरण खोजें"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "हस्तांतरण"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "एप्पलेट"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Local Services"
-msgid "Primary Service"
-msgstr "स्थानीय सेवाएँ"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "पास के उपकरण खोजें"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device"
 msgid "Device Name"
 msgstr "उपकरण"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Service:"
 msgid "Service Changed"
 msgstr "सेवा:"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "हाँ"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "नहीं"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1702,34 +2069,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "कनेक्टेड"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1792,141 +2160,136 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1940,27 +2303,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "एप्पलेट"
 
@@ -1972,107 +2335,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2083,78 +2452,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "संजाल"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2162,8 +2530,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2177,40 +2545,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "ब्लूटूथ एडाप्टर"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "एप्पलेट"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Blueman Bluetooth Manager"
 msgstr "ब्लूटूथ एडाप्टर"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Bluetooth Manager"
 msgstr "ब्लूटूथ एडाप्टर"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "ब्लूटूथ यन्त्र"
 
@@ -2246,13 +2600,14 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "headset"
+#~ msgstr "हेडसेट"
+
+#~ msgid "unknown"
+#~ msgstr "अज्ञात"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "ब्लूटूथ यन्त्र"
 
 #~ msgid "_Remove..."
 #~ msgstr "हटाएं... (_R)"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "कनेक्ट"

--- a/po/hr.po
+++ b/po/hr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-16 13:59+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -27,7 +27,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Postavke vidljivosti</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Skriven"
 
@@ -71,8 +71,8 @@ msgstr "_Uređaj"
 msgid "_View"
 msgstr "P_ogled"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Pomoć"
 
@@ -85,7 +85,7 @@ msgstr "Pretraži uređaje u blizini"
 msgid "Search"
 msgstr "Traži"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Uparivanje s uređajem"
 
@@ -94,17 +94,17 @@ msgstr "Uparivanje s uređajem"
 msgid "Pair"
 msgstr "Upari"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Dodaj/Ukloni oznaku povjerenja ovom uređaju"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Povjerenje"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Pokreni pomoćnika postavljanja za ovaj uređaj"
 
@@ -113,7 +113,7 @@ msgstr "Pokreni pomoćnika postavljanja za ovaj uređaj"
 msgid "Setup..."
 msgstr "Postavljanje..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Ukloni ovaj uređaj s popisa poznatih uređaja"
 
@@ -294,7 +294,12 @@ msgstr "Nije navedeno"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -356,7 +361,7 @@ msgstr "_Vrati izvorno"
 msgid "Send note"
 msgstr "Pošalji napomenu"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth mora biti uključen kako bi upravitelj adaptera radio"
 
@@ -364,33 +369,31 @@ msgstr "Bluetooth mora biti uključen kako bi upravitelj adaptera radio"
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth adapteri"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Uvijek"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minuta"
 msgstr[1] "%d Minute"
 msgstr[2] "%d Minuta"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth mora biti uključen kako bi upravitelj uređaja radio"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Povezivanje s BlueZ neuspjelo"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -405,50 +408,50 @@ msgstr ""
 msgid "Searching"
 msgstr "Pretraživanje"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth pomoćnik"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Osobitosti adaptera"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Pošiljatelj datoteka"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth prijenos datoteka"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Povezivanje"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd nije dostupan"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Neuspjelo automatsko pokretanje obex usluge. Pozadinski program obex mora "
 "biti pokrenut"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Odustajanje"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Slanje datoteke"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Procijenjeno vrijeme dolaska:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -456,94 +459,86 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Nastala je greška pri slanju datoteke %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Preskoči"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Pokušaj ponovo"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Dogodila se greška"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokalne usluge"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Zahtjev uparivanja za %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth ovjera"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Upiši PIN kôd ovjere:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Upiši PIN kôd"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Upiši lozinku ovjere:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Upiši lozinku"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Uparivanje lozinke za"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Uparivanje PIN koda za"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Zahtjev uparivanja za:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Potvrdi vrijednost ovjere:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Potvrdi"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Odbij"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Zahtjev ovjere za:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Usluga:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Uvijek prihvati"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Prihvati"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -578,240 +573,239 @@ msgstr "Da"
 msgid "No"
 msgstr "Ne"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Prijavi problem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Upravitelj uređaja"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Prikaži _alatnu traku"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Prikaži _traku stanja"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "R_azvrstaj po"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nazivu"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Dodavanju"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Silazno"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Priključci"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokalne usluge"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Osobitosti usluga"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Traži"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "_Osobitosti"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "_Zatvori"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "nekategorizirano"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Povjerljiv i uparen</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Uparen</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Povjerljiv</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Slaba"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Slabije pogodna"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Pogodna"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Mnogo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Previše"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Niska"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Visoka"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Vrlo visoka"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Uspjeh!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Serijski ulaz povezan na %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Neuspjelo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Neuspjelo povezivanje: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Povezivanje"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Prekidanje povezivanje neuspjelo: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Prekidanje povezivanja..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Povezivanje</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Povezuje profile automatskog povezivanja A2DP izvora, A2DP slivnika, i HID-a"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Prekidanje povezivanja</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Prisilno isključi uređaj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Povezivanje sa:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Prekidanje povezivanja:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Pošalji _datoteku..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Upari"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Vjeruj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Ne vjeruj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Postavi…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Preimenuj uređaj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Ukloni"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Otkaži radnju"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Pokazatelj aktivnosti podataka"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Ukupno primljenih podataka i brzina prijenosa"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Ukupno primljenih podataka i brzina prijenosa"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Ne vjeruj"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Odaberi uređaj"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Više"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -821,7 +815,7 @@ msgstr ""
 "  Saša Teković https://launchpad.net/~hseagle2015\n"
 "  nafterburner https://launchpad.net/~nafterburner"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman je GTK+ Bluetooth upravitelj"
 
@@ -829,17 +823,17 @@ msgstr "Blueman je GTK+ Bluetooth upravitelj"
 msgid "GSM Settings"
 msgstr "GSM postavke"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Priključci"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problem zavisnosti"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -850,7 +844,7 @@ msgstr ""
 "će također ukloniti <b>\"%(0)s\"</b>.\n"
 "Nastaviti?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -861,854 +855,1269 @@ msgstr ""
 "će ukloniti <b>%(0)s</b>.\n"
 "Nastaviti?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Odabir adaptera"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr "Otkrivanje…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "nekategorizirano"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Mrežna pristupna točka"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+#, fuzzy
+msgid "Audio/video"
+msgstr "Audio/Video"
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "radna površina"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "poslužitelj"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "prijenosno računalo"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "ručni"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "dlanovnik"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobilni"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "bežični"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "pametni telefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
-
-#. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "slušalice s mikrofonom"
-
-#. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "uređaj bez korištenja ruku"
-
-#. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "nepoznat"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
-msgstr "mikrofon"
-
-#. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
-msgstr "zvučnik"
-
-#. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
-msgstr "slušalice"
-
-#. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
-msgstr "prijenosni audio-uređaj"
-
-#. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr "audio-uređaj za auto"
-
-#. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
-msgstr "set-top boks"
-
-#. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
-msgstr "hifi audio-uređaj"
-
-#. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
-msgstr "vcr"
-
-#. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
-msgstr "videokamera"
-
-#. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
-msgstr "kamkorder"
-
-#. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr "videomonitor"
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr "videoekran i zvučnik"
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
-msgstr "videokonferencije"
-
-#. translators: device class
-#: blueman/DeviceClass.py:145
-msgid "gaming/toy"
-msgstr "igranje/igračka"
-
-#. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tipkovnica"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "pokazivački"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
-msgstr "kombinacija"
-
-#: blueman/Sdp.py:93
-msgid "SDP"
-msgstr "SDP"
-
-#: blueman/Sdp.py:94
-msgid "UDP"
-msgstr "UDP"
-
-#: blueman/Sdp.py:95
-msgid "RFCOMM"
-msgstr "RFCOMM"
-
-#: blueman/Sdp.py:96
-msgid "TCP"
-msgstr "TCP"
-
-#: blueman/Sdp.py:97
-msgid "TCS-BIN"
-msgstr "TCS-BIN"
-
-#: blueman/Sdp.py:98
-msgid "TCS-AT"
-msgstr "TCS-AT"
-
-#: blueman/Sdp.py:99
-msgid "ATT"
-msgstr "ATT"
-
-#: blueman/Sdp.py:100
-msgid "OBEX"
-msgstr "OBEX"
-
-#: blueman/Sdp.py:101
-msgid "IP"
-msgstr "IP"
-
-#: blueman/Sdp.py:102
-msgid "FTP"
-msgstr "FTP"
-
-#: blueman/Sdp.py:103
-msgid "HTTP"
-msgstr "HTTP"
-
-#: blueman/Sdp.py:104
-msgid "WSP"
-msgstr "WSP"
-
-#: blueman/Sdp.py:105
-msgid "BNEP"
-msgstr "BNEP"
-
-#: blueman/Sdp.py:106
-msgid "UPnP/ESDP"
-msgstr "UPnP/ESDP"
-
-#: blueman/Sdp.py:107
-msgid "HIDP"
-msgstr "HIDP"
-
-#: blueman/Sdp.py:108
-msgid "Hardcopy Control Channel"
+msgid "83-99 percent"
 msgstr ""
 
-#: blueman/Sdp.py:109
-msgid "Hardcopy Data Channel"
-msgstr ""
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd nije dostupan"
 
-#: blueman/Sdp.py:110
-msgid "Hardcopy Notification"
-msgstr ""
-
-#: blueman/Sdp.py:111
-msgid "AVCTP"
-msgstr "AVCTP"
-
-#: blueman/Sdp.py:112
-msgid "AVDTP"
-msgstr "AVDTP"
-
-#: blueman/Sdp.py:113
-msgid "CMTP"
-msgstr "CMTP"
-
-#: blueman/Sdp.py:114
-msgid "UDI_C-Plane"
-msgstr "UDI_C-Plane"
-
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
-msgid "Multi-Channel Adaptation Protocol (MCAP)"
-msgstr "Multi-Channel Adaptation Protocol (MCAP)"
-
-#: blueman/Sdp.py:117
-msgid "L2CAP"
-msgstr "L2CAP"
-
-#: blueman/Sdp.py:118
-msgid "ServiceDiscoveryServerServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:119
-msgid "BrowseGroupDescriptorServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:120
-msgid "Public Browse Group"
-msgstr ""
-
-#: blueman/Sdp.py:121
-msgid "Serial Port"
-msgstr "Serijski ulaz"
-
-#: blueman/Sdp.py:122
-msgid "LAN Access Using PPP"
-msgstr "LAN pristup koristeći PPP"
-
-#: blueman/Sdp.py:123
-msgid "Dialup Networking (DUN)"
-msgstr "Modemsko umrežavanje (DUN)"
-
-#: blueman/Sdp.py:124
-msgid "IrMC Sync"
-msgstr "IrMC sinkronizacija"
-
-#: blueman/Sdp.py:125
-msgid "OBEX Object Push"
-msgstr ""
-
-#: blueman/Sdp.py:126
-msgid "OBEX File Transfer"
-msgstr "OBEX prijenos datoteka"
-
-#: blueman/Sdp.py:127
-msgid "IrMC Sync Command"
-msgstr "Naredba za IrMC sinkronizaciju"
-
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
 msgid "Headset"
 msgstr "Slušalice s mikrofonom"
 
-#: blueman/Sdp.py:129
-msgid "Cordless Telephony"
-msgstr "Bežićno telefoniranje"
-
-#: blueman/Sdp.py:130
-msgid "Audio Source"
-msgstr "Izvor zvuka"
-
-#: blueman/Sdp.py:131
-msgid "Audio Sink"
-msgstr "Slivnik zvuka"
-
-#: blueman/Sdp.py:132
-msgid "Remote Control Target"
-msgstr "Cilj daljinskog upravljanja"
-
-#: blueman/Sdp.py:133
-msgid "Advanced Audio"
-msgstr "Napredni zvuk"
-
-#: blueman/Sdp.py:134
-msgid "Remote Control"
-msgstr "Daljinsko upravljanje"
-
-#: blueman/Sdp.py:135
-msgid "Video Conferencing"
-msgstr "Videokonferencije"
-
-#: blueman/Sdp.py:136
-msgid "Intercom"
-msgstr "Interkom"
-
-#: blueman/Sdp.py:137
-msgid "Fax"
-msgstr "Faks"
-
-#: blueman/Sdp.py:138
-msgid "Headset Audio Gateway"
-msgstr ""
-
-#: blueman/Sdp.py:139
-msgid "WAP"
-msgstr "WAP"
-
-#: blueman/Sdp.py:140
-msgid "WAP Client"
-msgstr "WAP klijent"
-
-#: blueman/Sdp.py:141
-msgid "PANU"
-msgstr "PANU"
-
-#: blueman/Sdp.py:142
-msgid "Network Access Point"
-msgstr "Mrežna pristupna točka"
-
-#: blueman/Sdp.py:143
-msgid "Group Network"
-msgstr "Mrežna grupa"
-
-#: blueman/Sdp.py:144
-msgid "DirectPrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:145
-msgid "ReferencePrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:146
-msgid "Imaging (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:147
-msgid "ImagingResponder (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:148
-msgid "ImagingAutomaticArchive (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:149
-msgid "ImagingReferencedObjects (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:150
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
 msgid "Handsfree"
 msgstr "Bez korištenja ruku"
 
-#: blueman/Sdp.py:151
+#. translators: device class
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
+msgstr "mikrofon"
+
+#. translators: device class
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
+msgstr "zvučnik"
+
+#. translators: device class
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
+msgstr "slušalice"
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
+msgstr "prijenosni audio-uređaj"
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
+msgstr "audio-uređaj za auto"
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
+msgstr "set-top boks"
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
+msgstr "hifi audio-uređaj"
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
+msgstr "vcr"
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "videokamera"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
+msgstr "kamkorder"
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "videomonitor"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
+msgstr "videoekran i zvučnik"
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "videokonferencije"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+#, fuzzy
+msgid "Gaming/Toy"
+msgstr "igranje/igračka"
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tipkovnica"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "pokazivački"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+#, fuzzy
+msgid "Combo"
+msgstr "kombinacija"
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+#, fuzzy
+msgid "Display"
+msgstr "3D ekran"
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+#, fuzzy
+msgid "Glasses"
+msgstr "3D naočale"
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Generičko povezivanje"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Generičko povezivanje"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Generički pristup"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Generičko povezivanje"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Generički zvuk"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Daljinsko upravljanje"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Generički pristup"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Generički zvuk"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Mrežna grupa"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Generički prijenos datoteka"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Generičko povezivanje"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Termometar"
+
+#: blueman/DeviceClass.py:182
+#, fuzzy
+msgid "Thermometer: Ear"
+msgstr "Termometar"
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Generički prijenos datoteka"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+#, fuzzy
+msgid "Generic Blood Pressure"
+msgstr "Krvni tlak"
+
+#: blueman/DeviceClass.py:186
+#, fuzzy
+msgid "Blood Pressure: Arm"
+msgstr "Krvni tlak"
+
+#: blueman/DeviceClass.py:187
+#, fuzzy
+msgid "Blood Pressure: Wrist"
+msgstr "Krvni tlak"
+
+#: blueman/DeviceClass.py:188
+#, fuzzy
+msgid "Human Interface Device (HID)"
+msgstr "Uređaj korisničkog sučelja"
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Generičko povezivanje"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Mrežna grupa"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+#, fuzzy
+msgid "Cycling: Speed Sensor"
+msgstr "Brzina pedaliranja i ritam"
+
+#: blueman/DeviceClass.py:205
+#, fuzzy
+msgid "Cycling: Cadence Sensor"
+msgstr "Brzina pedaliranja i ritam"
+
+#: blueman/DeviceClass.py:206
+#, fuzzy
+msgid "Cycling: Power Sensor"
+msgstr "Snaga pedaliranja"
+
+#: blueman/DeviceClass.py:207
+#, fuzzy
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr "Brzina pedaliranja i ritam"
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+#, fuzzy
+msgid "Generic Insulin Pump"
+msgstr "Generički zvuk"
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+#, fuzzy
+msgid "Location and Navigation Display Device"
+msgstr "Lociranje i navigiranje"
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+#, fuzzy
+msgid "Location and Navigation Pod"
+msgstr "Lociranje i navigiranje"
+
+#: blueman/Sdp.py:87
+msgid "SDP"
+msgstr "SDP"
+
+#: blueman/Sdp.py:88
+msgid "UDP"
+msgstr "UDP"
+
+#: blueman/Sdp.py:89
+msgid "RFCOMM"
+msgstr "RFCOMM"
+
+#: blueman/Sdp.py:90
+msgid "TCP"
+msgstr "TCP"
+
+#: blueman/Sdp.py:91
+msgid "TCS-BIN"
+msgstr "TCS-BIN"
+
+#: blueman/Sdp.py:92
+msgid "TCS-AT"
+msgstr "TCS-AT"
+
+#: blueman/Sdp.py:93
+msgid "ATT"
+msgstr "ATT"
+
+#: blueman/Sdp.py:94
+msgid "OBEX"
+msgstr "OBEX"
+
+#: blueman/Sdp.py:95
+msgid "IP"
+msgstr "IP"
+
+#: blueman/Sdp.py:96
+msgid "FTP"
+msgstr "FTP"
+
+#: blueman/Sdp.py:97
+msgid "HTTP"
+msgstr "HTTP"
+
+#: blueman/Sdp.py:98
+msgid "WSP"
+msgstr "WSP"
+
+#: blueman/Sdp.py:99
+msgid "BNEP"
+msgstr "BNEP"
+
+#: blueman/Sdp.py:100
+msgid "UPnP/ESDP"
+msgstr "UPnP/ESDP"
+
+#: blueman/Sdp.py:101
+msgid "HIDP"
+msgstr "HIDP"
+
+#: blueman/Sdp.py:102
+msgid "Hardcopy Control Channel"
+msgstr ""
+
+#: blueman/Sdp.py:103
+msgid "Hardcopy Data Channel"
+msgstr ""
+
+#: blueman/Sdp.py:104
+msgid "Hardcopy Notification"
+msgstr ""
+
+#: blueman/Sdp.py:105
+msgid "AVCTP"
+msgstr "AVCTP"
+
+#: blueman/Sdp.py:106
+msgid "AVDTP"
+msgstr "AVDTP"
+
+#: blueman/Sdp.py:107
+msgid "CMTP"
+msgstr "CMTP"
+
+#: blueman/Sdp.py:108
+msgid "UDI_C-Plane"
+msgstr "UDI_C-Plane"
+
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
+msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgstr "Multi-Channel Adaptation Protocol (MCAP)"
+
+#: blueman/Sdp.py:111
+msgid "L2CAP"
+msgstr "L2CAP"
+
+#: blueman/Sdp.py:112
+msgid "ServiceDiscoveryServerServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:113
+msgid "BrowseGroupDescriptorServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:114
+msgid "Public Browse Group"
+msgstr ""
+
+#: blueman/Sdp.py:115
+msgid "Serial Port"
+msgstr "Serijski ulaz"
+
+#: blueman/Sdp.py:116
+msgid "LAN Access Using PPP"
+msgstr "LAN pristup koristeći PPP"
+
+#: blueman/Sdp.py:117
+msgid "Dialup Networking (DUN)"
+msgstr "Modemsko umrežavanje (DUN)"
+
+#: blueman/Sdp.py:118
+msgid "IrMC Sync"
+msgstr "IrMC sinkronizacija"
+
+#: blueman/Sdp.py:119
+msgid "OBEX Object Push"
+msgstr ""
+
+#: blueman/Sdp.py:120
+msgid "OBEX File Transfer"
+msgstr "OBEX prijenos datoteka"
+
+#: blueman/Sdp.py:121
+msgid "IrMC Sync Command"
+msgstr "Naredba za IrMC sinkronizaciju"
+
+#: blueman/Sdp.py:123
+msgid "Cordless Telephony"
+msgstr "Bežićno telefoniranje"
+
+#: blueman/Sdp.py:124
+msgid "Audio Source"
+msgstr "Izvor zvuka"
+
+#: blueman/Sdp.py:125
+msgid "Audio Sink"
+msgstr "Slivnik zvuka"
+
+#: blueman/Sdp.py:126
+msgid "Remote Control Target"
+msgstr "Cilj daljinskog upravljanja"
+
+#: blueman/Sdp.py:127
+msgid "Advanced Audio"
+msgstr "Napredni zvuk"
+
+#: blueman/Sdp.py:128
+msgid "Remote Control"
+msgstr "Daljinsko upravljanje"
+
+#: blueman/Sdp.py:129
+msgid "Video Conferencing"
+msgstr "Videokonferencije"
+
+#: blueman/Sdp.py:130
+msgid "Intercom"
+msgstr "Interkom"
+
+#: blueman/Sdp.py:131
+msgid "Fax"
+msgstr "Faks"
+
+#: blueman/Sdp.py:132
+msgid "Headset Audio Gateway"
+msgstr ""
+
+#: blueman/Sdp.py:133
+msgid "WAP"
+msgstr "WAP"
+
+#: blueman/Sdp.py:134
+msgid "WAP Client"
+msgstr "WAP klijent"
+
+#: blueman/Sdp.py:135
+msgid "PANU"
+msgstr "PANU"
+
+#: blueman/Sdp.py:136
+msgid "Network Access Point"
+msgstr "Mrežna pristupna točka"
+
+#: blueman/Sdp.py:137
+msgid "Group Network"
+msgstr "Mrežna grupa"
+
+#: blueman/Sdp.py:138
+msgid "DirectPrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:139
+msgid "ReferencePrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:140
+msgid "Imaging (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:141
+msgid "ImagingResponder (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:142
+msgid "ImagingAutomaticArchive (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:143
+msgid "ImagingReferencedObjects (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr "Osnovni ispis (BPP)"
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr "Stanje ispisa (BPP)"
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr "Human Interface Device usluga (HID)"
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr "Zajednički ISDN pristup (CIP)"
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr "UDI-MT"
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr "UDI-TA"
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr "SIM pristup (SAP)"
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr "Pristup adresaru (PBAP) - PCE"
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr "Pristup adresaru (PBAP) - PSE"
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr "Pristup adresaru (PBAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Mrežna pristupna točka (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr "GNSS"
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr "GNSS poslužitelj"
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr "3D ekran"
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr "3D naočale"
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr "3D sinkronizacija (3DSP)"
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr "PnP podaci"
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Mrežna grupa"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr "Generički prijenos datoteka"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr "Generički zvuk"
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr "Generičko telefoniranje"
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr "Izvor videa"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr "Slivnik videa"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr "Distribucija videa"
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr "HDP"
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr "Izvor HDP-a"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr "Slivnik HDP-a"
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr "Generički pristup"
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr "Generičko svojstvo"
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr "Trenutno upozorenje"
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Preimenuj uređaj"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr "Glukoza"
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr "Termometar"
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr "Podaci uređaja"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr "Otkucaji srca"
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Lokalne usluge"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr "Krvni tlak"
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr "Usluga obavještavanja o upozorenjima"
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr "Uređaj korisničkog sučelja"
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr "Pretraži parametre"
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr "Brzina trčanja i ritam"
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr "Brzina pedaliranja i ritam"
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr "Snaga pedaliranja"
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr "Lociranje i navigiranje"
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 #, fuzzy
-#| msgid "Transfer"
 msgid "Object Transfer"
 msgstr "Prijenos"
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 #, fuzzy
-#| msgid "applet"
 msgid "AppleAgent"
 msgstr "programčić"
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr "Primarna usluga"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr "Sekundarna usluga"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 msgid "Device Name"
 msgstr "Ime uređaja"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr "Adresa za ponovno povezivanje"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr "Usluga se promijenila"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Osobitosti adaptera"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Profili automatskog povezivanja"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Svojstva"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "da"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "ne"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Informacije"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Prikaži podatke uređaja"
 
@@ -1733,34 +2142,35 @@ msgstr "Zvučni profil"
 msgid "Select audio profile for PulseAudio"
 msgstr "Odaberi profil zvuka za PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Serijski ulaz %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Obnovi IP adresu"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Postavke modemskog povezivanja"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Serijski ulazi"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Neodređen"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Povezan"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Automatski povezano s %(service)s na %(device)s"
@@ -1831,22 +2241,17 @@ msgstr "Upotreba _mreže"
 msgid "Shows network traffic usage"
 msgstr "Prikazuje korištenje mrežnog prometa"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth uključen"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth isključen"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Upravlja uslugama lokalne mreže, poput NAP mostova"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1854,7 +2259,7 @@ msgstr ""
 "Omogućuje podršku za modemsko umrežavanje (DUN) s Modemskim i Mrežnim "
 "upraviteljem"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1862,38 +2267,38 @@ msgstr ""
 "svrhu bržeg pristupa"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Najviše stavki"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Najveći broj stavki nedavnih povezivanja koja će se prikazati u izborniku."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Nedavna _povezivanja"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Povezan sa %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Neuspjelo povezivanje"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s na %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adapter za ovo povezivanje nije dostupan"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1901,41 +2306,41 @@ msgstr ""
 "Omogućuje podršku za Umrežavanje osobnog područja (PAN) predstavljeno u "
 "Mrežnom upravitelju 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Omogućuje DBus API za ostale Blueman komponente"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Dolazna datoteka putem Bluetootha"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Dolazna datoteka %(0)s sa %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Odbaci"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Prijem datoteke"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Prijem datoteke %(0)s sa %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Omogućuje OBEX mogućnosti prijenosa datoteka"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Postavljeni direktorij za dolazne datoteke ne postoji"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1944,43 +2349,39 @@ msgstr ""
 "Provjeri da direktorij \"<b>%s</b>\" postoji ili ga postavi s blueman-"
 "services. Do tada će se koristiti \"%s\" kao zadani"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Datoteka primljena"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Datoteka %(0)s sa %(1)s uspješno primljena"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Prijenos neuspio"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Prijenos datoteke %(0)s neuspio"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Datoteke primljene"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Primljena %d datoteka u pozadini"
 msgstr[1] "Primljene %d datoteke u pozadini"
 msgstr[2] "Primljeno %d datoteka u pozadini"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Primljena još %d datoteka u pozadini"
@@ -1994,27 +2395,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Dodaje uobičajene stavke izbornika u izbornik ikona stanja"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Postavi novi uređaj"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Pošalji _datoteku na uređaj"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Uređaji"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_teri"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "programčić"
 
@@ -2026,27 +2427,27 @@ msgstr "Omogućuje usluge lozinke i ovjere za BlueZ uslugu"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Dodaje izbornik izlaza za zatvaranje programčića"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Omogućuje osnovni dhcp klijent za Bluetooth PAN povezivanja."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth mreža"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Sučelje %(0)s povezano na IP adresu %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Neuspjelo dobavljanje IP adrese na %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2055,7 +2456,7 @@ msgstr ""
 "Pokušaj dobavljanja IP adrese na %s\n"
 "Malo pričekajte…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2063,25 +2464,28 @@ msgstr ""
 "Dodaje oznaku na ikonu stanja kada je Bluetooth aktivan i prikazuje broj "
 "povezivanja u napomenama."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth aktivan"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d aktivna veza</b>"
 msgstr[1] "<b>%d aktivne veze</b>"
 msgstr[2] "<b>%d aktivnih veza</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth isključen"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Koristi libappindicator za prikazivanje ikone stanja"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2089,34 +2493,35 @@ msgstr ""
 "Omogućuje stavku izbornika za postavljanje privremeno vidljivog zadanog "
 "adaptera kada je adapter po zadanome postavljen kao skriven"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Istek vremena otkrivanja"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Trajanje načina rada otkrivanja u sekundama"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Omogući otkrivanje"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Postavi zadani adapter privremeno vidljivim"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Vidljiv… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Omogućuje izbornik za programčić i API za druge priključke radi manipuliranja"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2125,23 +2530,23 @@ msgstr ""
 "Uspješno povezan sa <b>DUN</b> uslugom na <b>%(0)s.</b>\n"
 "Mreža je sada dostupna putem <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Omogućuje osnovnu podršku za povezivanje na internet putem DUN profila."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standardan rukovatelj SPP profilom povezivanja, dopušta pokretanje "
 "prilagođenih radnji"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skripta za pokretanje na povezivanju"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2159,11 +2564,11 @@ msgstr ""
 "\n"
 "Nakon isključenja uređaja skripta će biti poslana HUP signalom</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Serijski ulaz priključen"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2171,11 +2576,11 @@ msgstr ""
 "Usluga serijskog ulaza na uređaju <b>%s</b> sada će biti dostupna putem <b>"
 "%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Neuspješno pokretanje skripte povezivanja serijskog ulaza"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2184,37 +2589,37 @@ msgstr ""
 "Pojavio se problem pokretanja skripte %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Upravlja stanjem energije Bluetooth adaptera"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatsko uključivanje"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automatski uključi adaptere"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Isključi _Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Isključi sve adaptere"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Uključi _Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Uključi sve adaptere"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2222,21 +2627,20 @@ msgstr ""
 "Privremeno onemogućuje čuvara zaslona kad je Bluetooth upravljač za igre "
 "povezan."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Mreža"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Neispravna IP adresa"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP adresa je u sukobu sa sučeljem %s koje ima istu adresu"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2247,8 +2651,8 @@ msgstr ""
 "%s/%s\n"
 "To može prouzrokovati neželjeno ponašanje mreže"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Trenutačno nije podržano s ovom postavkom"
 
@@ -2264,10 +2668,6 @@ msgstr "Priključak za programčić prijenosa usluge je isključen"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Postavi svojstva Bluetooth adaptera"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-uređaj"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman programčić"
@@ -2275,11 +2675,6 @@ msgstr "Blueman programčić"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Bluetooth upravljač"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2321,6 +2716,37 @@ msgstr "Postavi RfKill stanje"
 msgid "Setting RfKill State requires privileges"
 msgstr "Postavljanje RfKill stanja zahtijeva dozvole"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Upiši PIN kôd"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Upiši lozinku"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Serijski ulaz povezan na %s"
+
+#~ msgid "palm"
+#~ msgstr "dlanovnik"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "slušalice s mikrofonom"
+
+#~ msgid "handsfree"
+#~ msgstr "uređaj bez korištenja ruku"
+
+#~ msgid "unknown"
+#~ msgstr "nepoznat"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-uređaj"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth uređaji"
 
@@ -2341,9 +2767,6 @@ msgstr "Postavljanje RfKill stanja zahtijeva dozvole"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Ukloni..."
-
-#~ msgid "Generic Connect"
-#~ msgstr "Generičko povezivanje"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/hu.po
+++ b/po/hu.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Hungarian (http://www.transifex.com/mate/MATE/language/hu/)\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Láthatósági beállítás</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Rejtett"
 
@@ -72,8 +72,8 @@ msgstr "_Eszköz"
 msgid "_View"
 msgstr "_Nézet"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Súgó"
 
@@ -86,7 +86,7 @@ msgstr "Elérhető eszközök keresése"
 msgid "Search"
 msgstr "Keresés"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Párosítás az eszközzel"
 
@@ -95,17 +95,17 @@ msgstr "Párosítás az eszközzel"
 msgid "Pair"
 msgstr "Párosítás"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Az eszköz megbízható/nem megbízható"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Megbízható"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Beállítás varázsló futtatása ehhez az eszközhöz"
 
@@ -114,7 +114,7 @@ msgstr "Beállítás varázsló futtatása ehhez az eszközhöz"
 msgid "Setup..."
 msgstr "Beállítás…"
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Eszköz eltávolítása az ismert eszközök közül"
 
@@ -296,7 +296,12 @@ msgstr "Nem meghatározott"
 msgid "<b>Author:</b>"
 msgstr "<b>Szerző:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -358,7 +363,7 @@ msgstr "_Visszaállítás"
 msgid "Send note"
 msgstr "Jegyzet küldése"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "A Bluetooth-t be kell kapcsolni, a csatolókezelő működéséhez"
 
@@ -366,32 +371,30 @@ msgstr "A Bluetooth-t be kell kapcsolni, a csatolókezelő működéséhez"
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth csatolók"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Mindig"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d perc"
 msgstr[1] "%d perc"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Csatoló"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "A Bluetooth-t be kell kapcsolni, a eszközkezelő működéséhez"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "A BlueZ csatlakozás sikertelen"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -405,144 +408,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Keresés"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth segéd"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Csatoló beállítások"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Fájlküldő"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth fájlátvitel"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Kapcsolódás"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd nem elérhető"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Nem sikerült az obex szolgáltatás automatikus indítása. Győződjön meg róla, "
 "hogy az obex démon fut."
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Megszakítás"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Fájl küldése"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Hátralévő idő:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Hiba történt a(z)  „%s” fájl küldése során"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Kihagyás"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Újra"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Hiba történt"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Helyi szolgáltatások"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Párosítás kérés a(z) „%s” eszköztől"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth hitelesítés"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Adja meg a PIN-kódot a hitelesítéshez:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Adja meg a PIN-kódot"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Írja be a hitelesítéshez használt jelszót:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Adja meg a jelszót"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Párosítási kulcs ehhez:"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Párosítási PIN-kód ehhez:"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Párosítási kérelem ehhez:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Erősítse meg a hitelesítéshez használt értéket:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Megerősítés"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Elutasítás"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Engedélykérés ehhez:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Szolgáltatás:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Elfogadás mindig"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Elfogadás"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -577,245 +572,242 @@ msgstr "Engedélyezve"
 msgid "No"
 msgstr "Tiltva"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Hiba jelentése"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Eszközkezelő"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "_Eszköztár megjelenítése"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Á_llapotsor megjelenítése"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_Rendezés:"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Név"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Hozzáadva"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "Csö_kkenő"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Bővítmények"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Helyi szo_lgáltatások"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Szolgáltatás beállítások"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Keresés"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Csatoló beállítások"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Kilépés"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "besorolatlan"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Megbízható és párosított</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Párosított</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Megbízható</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Gyenge"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Nem optimális"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimális"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Sok"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Túl sok"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Alacsony"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Magas"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Nagyon magas"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Sikeres"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Soros port csatlakoztatva ehhez: %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Sikertelen"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Kapcsolódás sikertelen: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Kapcsolódás"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Leválasztás sikertelen:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Leválasztás…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Összekapcsolja az automatikusan kapcsolódó profillal rendelkező A2DP "
 "hangforrást, az A2DP hangfogadót és a HID eszközt."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Eszköz erőszakos eltávolítása"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Csatlakozva ehhez:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Leválasztás:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "_Fájl küldése…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Párosítás"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Megbízható"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Nem megbízható"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Eszköz átnevezése"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Eltávolítás"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Művelet megszakítása"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Adatforgalom kijelzés"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Összes fogadott adat és átviteli sebesség"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Összes küldött adat és átviteli sebesség"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Nem meghízható"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Válasszon eszközt"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Tovább"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "István Szőllősi <szollosi.istv4n@gmail.com>, 2014,2017\n"
@@ -845,7 +837,7 @@ msgstr ""
 "  kavkar https://launchpad.net/~kavkar\n"
 "  ricsko https://launchpad.net/~ricsi91"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "A Blueman egy GTK+ alapú Bluetooth-kezelő"
 
@@ -853,17 +845,17 @@ msgstr "A Blueman egy GTK+ alapú Bluetooth-kezelő"
 msgid "GSM Settings"
 msgstr "GSM beállítások"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Bővítmények"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Függőségi probléma"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -874,7 +866,7 @@ msgstr ""
 "eltávolítása eltávolítja ezt is: <b>„%(0)s”</b>.\n"
 "Folytatja?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -885,886 +877,1259 @@ msgstr ""
 "betöltése eltávolítja ezt: <b>%(0)s</b>.\n"
 "Folytatja?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Csatoló választása"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Látható… %s s"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "besorolatlan"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Hálózati hozzáférési pont"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "asztali"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "kiszolgáló"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "kéziszámítógép"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "vezeték nélküli"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "okostelefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd nem elérhető"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "headset"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "kéznélküli"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "ismeretlen"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Hangforrás"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Hangforrás"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Hangforrás"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "billentyűzet"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "mutató"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "billentyűzet"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "mutató"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Kapcsolódás"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Kapcsolódás"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Kapcsolódás"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Kapcsolódás"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth fájlátvitel"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Kapcsolódás"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth fájlátvitel"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth fájlátvitel"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Csoport hálózat"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth fájlátvitel"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Kapcsolódás"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Kapcsolódás"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth fájlátvitel"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Kapcsolódás"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Csoport hálózat"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Soros portok"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Betárcsázós (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth fájlátvitel"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "headset"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Hangforrás"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Hangfogadó"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Hálózati hozzáférési pont"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Csoport hálózat"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "kéznélküli"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Hálózati hozzáférési pont (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Hálózati hozzáférési pont (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Csoport hálózat"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth fájlátvitel"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Hangforrás"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Hangfogadó"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Hangforrás"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Eszköz átnevezése"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Eszközinformációk megjelenítése"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Helyi szolgáltatások"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Átvitel"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "kisalkalmazás"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Eszköz párosítás"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Elérhető eszközök keresése"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Átvitel"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "kisalkalmazás"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Eszköz párosítás"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Elérhető eszközök keresése"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Eszközkezelő"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Legutóbbi _kapcsolatok"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Eszközkezelő"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Csatoló beállítások"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Automatikusan csatlakozó profilok"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Tulajdonosi"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "igen"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nem"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Információ"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Eszközinformációk megjelenítése"
 
@@ -1789,34 +2154,35 @@ msgstr "Hangprofil"
 msgid "Select audio profile for PulseAudio"
 msgstr "Hangprofil beállítása a PulseAudiohoz"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Soros port %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "IP-cím megújítása"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Betárcsázási beállítások"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Soros portok"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nincs megadva"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Csatlakozva"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1883,22 +2249,17 @@ msgstr "Adat_használat"
 msgid "Shows network traffic usage"
 msgstr "Megjeleníti a hálózati forgalmat"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth engedélyezve"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth letiltva"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Kezeli a helyi hálózati szolgáltatásokat, például a NAP hidakat"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1906,44 +2267,44 @@ msgstr ""
 "Támogatja a betárcsázós hálózatokat (DUN) a modemkezelővel és a "
 "hálózatkezelővel"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "Hozzáadja a menühöz az utolsó használt kapcsolatot a gyors eléréshez"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Elemek maximális száma"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "A legutóbbi hálózati kapcsolatok maximális száma, amit megjelenít a menü."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Legutóbbi _kapcsolatok"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Csatlakozva ide: %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Sikertelen csatlakozás"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s ezen: %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Nem érhető el a csatoló ehhez a kapcsolathoz"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1951,41 +2312,41 @@ msgstr ""
 "Támogatja a személyes hálózatokat (PAN), amely a NetworkManager 0.8-as "
 "kiadásában jelent meg"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "DBus API-t biztosít más Blueman összetevőkhöz"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Bejövő fájl Bluetooth-on"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "A(z) %(0)s fájl érkezik innen: %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Elutasítás"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Fájl fogadása"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "A(z) %(0)s fájl fogadása innen: %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "OBEX fájlátviteli lehetőségeket nyújt"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "A bejövő fájlokhoz beállított könyvtár nem létezik"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1995,42 +2356,38 @@ msgstr ""
 "a blueman-services használatával. Addig az alapértelmezett „%s” lesz "
 "használva."
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Fájl fogadva"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "A(z) %(0)s fájl sikeresen fogadva innen: %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Átvitel sikertelen"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "A(z) %(0)s fájl átvitele sikertelen"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Fájlok fogadva"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Fogadott %d fájl a háttérben"
 msgstr[1] "%d fájl fogadva a háttérben"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Több fogadott %d fájl a háttérben"
@@ -2043,27 +2400,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "A szokásos menüpontok hozzáadása az állapotikon menüjéhez"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "Új eszköz b_eállítása"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "_Fájlok küldése az eszközre"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Eszközök"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Csa_tolók"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "kisalkalmazás"
 
@@ -2075,27 +2432,27 @@ msgstr "Jelszó- és hitelesítési szolgáltatásokat nyújt a BlueZ démonnak"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Bezárás menüelem hozzáadása a kisalkalmazásból kilépéshez"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Alap DHCP ügyfelet biztosít a Bluetooth PAN kapcsolatokhoz."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth hálózatok"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "A(z) %(0)s eszközhöz a(z) %(1)s IP-cím lett hozzárendelve"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Nem sikerült IP-címhez jutni itt: %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2104,7 +2461,7 @@ msgstr ""
 "IP-cím beszerzése itt: %s\n"
 "Kérem várjon…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2112,24 +2469,27 @@ msgstr ""
 "Az állapotikonra egy jelzést tesz, ha a Bluetooth aktív, és megjeleníti a "
 "kapcsolatok számát a buboréksúgóban."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth aktív"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Aktív kapcsolat</b>"
 msgstr[1] "<b>%d aktív kapcsolat</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth letiltva"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Állapotikon megjelenítésére a libappindicator segítségével"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2137,35 +2497,36 @@ msgstr ""
 "Egy menüpontot ad az alapértelmezett csatoló ideiglenes láthatóvá tételéhez, "
 "ha az alapértelmezésben rejtett állapotra van állítva."
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Keresési idő lejárt"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "A láthatóként töltött idő mennyisége másodpercben"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Láthatóvá tétel"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Az alapértelmezett csatoló átmenetileg láthatóvá tétele"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Látható… %s s"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Menüt biztosít a kisalkalmazásnak, valamint egy API-t, hogy más bővítmények "
 "is hozzáférjenek"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2174,23 +2535,23 @@ msgstr ""
 "Sikeresen csatlakozva a <b>DUN</b> szolgáltatáshoz, itt: <b>%(0)s.</b>\n"
 "A hálózat most már elérhető ezen keresztül: <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Alapvető támogatást nyújt a DUN profilon keresztül az internethez "
 "csatlakozáshoz."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Szabványos SPP profilkapcsolat kezelő, lehetővé teszi az egyéni műveleteket"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Csatlakozáskor futtatandó parancsfájl"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2208,11 +2569,11 @@ msgstr ""
 "\n"
 "Az eszköz leválasztásakor a parancsfájl HUP szignált kap</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Soros port csatlakoztatva"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2220,11 +2581,11 @@ msgstr ""
 "Soros port szolgáltatás most már lehetséges ezen eszközön: <b>%s</b>, ezen "
 "keresztül: <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Soros port kapcsolódási parancsfájl sikertelen"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2233,37 +2594,37 @@ msgstr ""
 "Hiba történt a(z) %s parancsfájl indításakor\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "A Bluetooth csatoló teljesítményállapotát vezérli"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatikus bekapcsolás"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Csatolók automatikus bekapcsolása"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Bluetooth _kikapcsolása</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Minden csatoló kikapcsolása"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Bluetooth _bekapcsolása</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Minden csatoló bekapcsolása"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2271,21 +2632,20 @@ msgstr ""
 "Ideiglenesen felfüggeszti a képernyővédőt, ha egy bluetooth játékvezérlő "
 "kapcsolódik."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Hálózat"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Érvénytelen IP-cím"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "Az IP-cím és a(z) %s eszköz címe ütközik, mivel megegyeznek"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2296,8 +2656,8 @@ msgstr ""
 "beállításokat használja: %s/%s\n"
 "Ez helytelen hálózati működést okozhat"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Jelenleg nem támogatott ezzel a beállítással"
 
@@ -2311,40 +2671,26 @@ msgstr "A kisalkalmazás átviteli szolgáltatásának bővítménye letiltva"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth csatolók"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "kisalkalmazás"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "A Blueman egy GTK+ alapú Bluetooth-kezelő"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth engedélyezve"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth eszközök"
 
@@ -2380,6 +2726,31 @@ msgstr "RfKill állapot beállítása"
 msgid "Setting RfKill State requires privileges"
 msgstr "Az RfKill állapot beállításához megfelelő jog szükséges"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Adja meg a PIN-kódot"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Adja meg a jelszót"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Soros port csatlakoztatva ehhez: %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "headset"
+
+#~ msgid "handsfree"
+#~ msgstr "kéznélküli"
+
+#~ msgid "unknown"
+#~ msgstr "ismeretlen"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth eszközök"
 
@@ -2400,11 +2771,6 @@ msgstr "Az RfKill állapot beállításához megfelelő jog szükséges"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Törlés…"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Kapcsolódás"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/id.po
+++ b/po/id.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Indonesian (http://www.transifex.com/mate/MATE/language/id/)\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Setelan keterlihatan</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Tersembunyi"
 
@@ -72,8 +72,8 @@ msgstr "_Perangkat"
 msgid "_View"
 msgstr "_Lihat"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Bantuan"
 
@@ -86,7 +86,7 @@ msgstr "Cari perangkat terdekat"
 msgid "Search"
 msgstr "Cari"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Lakukan pemasangan dengan perangkat"
 
@@ -95,17 +95,17 @@ msgstr "Lakukan pemasangan dengan perangkat"
 msgid "Pair"
 msgstr "Pasang"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Tandai/Hapus tanda perangkat ini sebagai terpercaya"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Dipercaya"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Jalankan bantuan setup untuk perangkat ini"
 
@@ -114,7 +114,7 @@ msgstr "Jalankan bantuan setup untuk perangkat ini"
 msgid "Setup..."
 msgstr "Setup..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Hapus perangkat ini dari daftar perangkat yang dikenali"
 
@@ -295,7 +295,12 @@ msgstr "Tidak terdefinisi"
 msgid "<b>Author:</b>"
 msgstr "<b>Pembuat:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -357,7 +362,7 @@ msgstr "_Atur Ulang"
 msgid "Send note"
 msgstr "Kirim catatan"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth perlu diaktifkan agar manager adapter bekerja"
 
@@ -365,31 +370,29 @@ msgstr "Bluetooth perlu diaktifkan agar manager adapter bekerja"
 msgid "Bluetooth Adapters"
 msgstr "Adapter Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Selalu"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Menit"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptor"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth harus diaktifkan agar manajer perangkat bisa bekerja"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Koneksi ke BlueZ gagal"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -403,142 +406,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Mencari"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bantuan Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Preferensi Adapter"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Pengirim Berkas"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transfer Berkas Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Menyambung"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd tidak tersedia"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Gagal memulai otomatis layanan obex. Pastikan bahwa daemon obex berjalan"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Membatalkan"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Mengirimkan Berkas"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Waktu Perkiraan:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Terjadi galat ketika mengirimkan berkas %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Lewati"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Coba kembali"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Terjadi galat"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Layanan Lokal"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Permintaan penyambungan untuk %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Otentikasi Bluetooth "
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Masukan kode PIN untuk otentikasi:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Masukan kode PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Masukan passkey untuk otentikasi:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Masukkan sandi"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Permintaan passkey untu"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Permintaan kode PIN untuk"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Permintaan sambungan untuk:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Konfirmasi nilai untuk otentikasi:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Konfirmasi"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Abaikan"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Permintaan otorisasi untuk:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Layanan:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Selalu terima"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Terima"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -573,243 +568,240 @@ msgstr "Ya"
 msgid "No"
 msgstr "Tidak"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Laporkan Permasalahan"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Manajer Perangkat"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Tampilkan Ba_tang Alat"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Tampilkan Batang _Status"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_Urutkan Berdasarkan"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nama"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "Dit_ambahkan"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "Urut _Turun"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Plugin"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Layanan _Lokal"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferensi Layanan"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Cari"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Preferensi Adapter"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Keluar"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "tidak terkategorisasi"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Dipercaya dan Diperpasangkan</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Diperpasangkan</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Terpercaya</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Jelek"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Sub-Optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Banyak"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Terlalu banyak"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Rendah"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Tinggi"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Sangat Tinggi"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Berhasil"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Port serial terhubung ke %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Gagal"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Sambungan Gagal"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Menyambung"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Pemutusan Gagal:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Memutuskan..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Menyambungkan profil sambungan otomatis A2DP, A2DP sink, dan HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Memaksa pemutusan perangkat"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Terhubung ke:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Terputus:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Kirim a_Berkas..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Menyambung"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Terpercaya"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Tidak Terpercaya"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Ubah nama perangkat"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Hapus"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Batalkan Operasi"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indikasi aktivitas data"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Jumlah data yang diterima dan laju transmisi"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Jumlah data yang dikirim dan laju transmisi"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Tidak terpercaya"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Pilih Perangkat"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Tambahan"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -819,7 +811,7 @@ msgstr ""
 "  Mulia Arifandy Nasution https://launchpad.net/~mul14\n"
 "  Prihantoosa https://launchpad.net/~prihantoosa"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman adalah sebuah manajer Bluetooth GTK+"
 
@@ -827,17 +819,17 @@ msgstr "Blueman adalah sebuah manajer Bluetooth GTK+"
 msgid "GSM Settings"
 msgstr "Settingan GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Pengaya"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Masalah ketergantungan"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -848,7 +840,7 @@ msgstr ""
 "b> juga akan tidak dimuat <b>\"%(0)s\"</b>.\n"
 "Lanjutkan?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -859,886 +851,1259 @@ msgstr ""
 "akan dimuat <b>%(0)s</b>.\n"
 "Lanjutkan?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Pemilihan adapter"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Dapat ditemukan... %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "tidak terkategorisasi"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Network Access Point"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "desktop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "handheld"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "selular"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "cordless"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smart phone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd tidak tersedia"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "headset"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "tidak diketahui"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Sumber Audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Sumber Audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Sumber Audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "keyboard"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "penunjuk"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "keyboard"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "penunjuk"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Transfer Berkas Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Transfer Berkas Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Transfer Berkas Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Kelompok Jaringan"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transfer Berkas Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transfer Berkas Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Kelompok Jaringan"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Port Serial"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Dialup Networking (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Transfer Berkas Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "headset"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Sumber Audio"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Sink Audio"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Network Access Point"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Kelompok Jaringan"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Kelompok Jaringan"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Transfer Berkas Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Sumber Audio"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Sink Audio"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Sumber Audio"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Ubah nama perangkat"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Tampilkan informasi perangkat"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Layanan Lokal"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Transfer"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "applet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Pasangan Perangkat"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Cari perangkat terdekat"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Transfer"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "applet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Pasangan Perangkat"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Cari perangkat terdekat"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Manajer Perangkat"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "_Koneksi Terkini"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Manajer Perangkat"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Preferensi Adapter"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Profil koneksi otomatis"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietari"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ya"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "tidak"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Tampilkan informasi perangkat"
 
@@ -1763,34 +2128,35 @@ msgstr "Profil Audio"
 msgid "Select audio profile for PulseAudio"
 msgstr "Memilih profil audio untuk PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Port Serial %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Perbaharui Alamat IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Setting Dialup"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Port Serial"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Tidak ditentukan"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Tersambung"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Secara otomatis tersambung ke %(service)s pada %(device)s"
@@ -1855,22 +2221,17 @@ msgstr "_Pemakaian Jaringan"
 msgid "Shows network traffic usage"
 msgstr "Tampilkan penggunaan beban jaringan"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Aktif"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth Nonaktif"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Mengelola layanan jaringan lokal, seperti NAP bridge"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1878,7 +2239,7 @@ msgstr ""
 "Sediakan dukungan untuk Jaringan Dial Up (DUN) dengan ModemManager dan "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1886,37 +2247,37 @@ msgstr ""
 "cepat"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Item maksimal"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Jumlah maksimal pada menu koneksi yang akan ditampilkan"
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Koneksi Terkini"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Tersambung ke %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Gagal terhubung"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s pada %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adapter untuk koneksi ini tidak tersedia"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1924,41 +2285,41 @@ msgstr ""
 "Menyediakan dukungan untuk Personal Area Networking (PAN) diperkenalkan pada "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Menyediakan DBus API untuk komponen Blueman lainnya"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Menerima berkas dari Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Menerima berkas %(0)s dari %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Tolak"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Menerima berkas"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Menerima berkas %(0)s dari %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Menyediakan kemampuan transfer berkas OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Direktori terkonfigurasi untuk berkas yang datang tidak ada"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1967,41 +2328,37 @@ msgstr ""
 "Mohon pastikan direktori \"<b>%s</b>\" ada atau konfigurasikan dengan "
 "blueman-services. Sebelum itu dilakukan baku \"%s\" akan dipakai"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Berkas diterima"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Berkas %(0)s dari %(1)s sukses diterima"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Pengiriman gagal"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Pengiriman berkas %(0)s gagal"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Berkas diterima"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Menerima %d berkas dibelakang layar"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Menerima %d berkas lagi dibelakang layar"
@@ -2013,27 +2370,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Menambahkan menu standar pada menu ikon status"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Atur Perangkat Baru"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Kirim _Berkas ke Perangkat"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Perangkat"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_ter"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2045,27 +2402,27 @@ msgstr "Menyediakan passkey, layanan otentikasi untuk daemon BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Menambahkan menu keluar untuk menghentikan applet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Menyediakan klien dhcp dasar untuk koneksi PAN Bluetooth."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Jaringan Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Antarmuka %(0)s terikat pada alamat IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Gagal mendapatkan alamat IP pada %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2074,7 +2431,7 @@ msgstr ""
 "Mencoba mendapatkan suatu alamat IP pada %s\n"
 "Harap tunggu..."
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2082,23 +2439,26 @@ msgstr ""
 "Menambahkan indikasi ikon status ketika Bluetooth sedang aktif dan "
 "menampilkan jumlah koneksi pada tooltip."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth Aktif"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Koneksi Aktif</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth Nonaktif"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Menggunakan libappindicator untuk menampilkan ikon status"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2106,34 +2466,35 @@ msgstr ""
 "Menyediakan menu untuk membuat adapter default secara temporer tampak ketika "
 "diset sebagai tersembunyi secara default"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Waktu timeout "
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Jumlah waktu dalam detik mode terbuka bertahan"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Buat Dapat Dicari"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Membuat adapter default secara temporer terlihat"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Dapat ditemukan... %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Menyediakan menu untuk applet dan API untuk plugin lain untuk memanipulasinya"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2142,21 +2503,21 @@ msgstr ""
 "Sukses tersambung ke layanan <b>DUN</b> pada <b>%(0)s.</b>\n"
 "Jaringan sekarang tersedia melalui <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Menyediakan dukungan dasar untuk menghubungkan ke Internet via profil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr "Standar koneksi profil SPP, mengijinkan eksekusi aksi kustom"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script yang dieksekusi pada saat koneksi"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2174,22 +2535,22 @@ msgstr ""
 "\n"
 "Saat pemutusan perangkat, script akan mengirimkan sinyal HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Port serial tersambung"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "Layanan port serial pada perangkat <b>%s</b> akan tersedia via <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Script koneksi port serial gagal"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2198,37 +2559,37 @@ msgstr ""
 "Terdapat masalah menjalankan script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Mengendalikan status sumber daya adapter Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Otomatis Menyala"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Otomatis menyalakan adapter"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Nonaktifkan Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Menonaktifkan semua adapter"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Aktifkan Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Mengaktifkan semua adapte"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2236,21 +2597,20 @@ msgstr ""
 "Sementara tangguhkan penghemat layar ketika pengendali permainan bluetooth "
 "sedang tersambung."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Jaringan"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Alamat IP tidak valid"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "Alamat IP konflik dengan antarmuka %s yang memiliki alamat yang sama"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2261,8 +2621,8 @@ msgstr ""
 "konfigurasi berikut %s/%s\n"
 "Hal ini bisa menyebabkan perilaku jaringan yang tidak benar"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Tidak mendukung pengaturan ini"
 
@@ -2276,40 +2636,26 @@ msgstr "Plugin layanan transfer Applet nonaktif"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adapter Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman adalah sebuah manajer Bluetooth GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Aktif"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Perangkat bluetooth"
 
@@ -2345,6 +2691,31 @@ msgstr "Atur Keadaan RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Mengatur Keadaan RfKill memerlukan hak khusus"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Masukan kode PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Masukkan sandi"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Port serial terhubung ke %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "headset"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "tidak diketahui"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Perangkat bluetooth"
 
@@ -2363,11 +2734,6 @@ msgstr "Mengatur Keadaan RfKill memerlukan hak khusus"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Hapus..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Sambung"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/it.po
+++ b/po/it.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-06-09 12:59+0000\n"
 "Last-Translator: Edoardo Facchinelli <silpheel@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -32,7 +32,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Impostazioni di visibilità</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Nascosto"
 
@@ -76,8 +76,8 @@ msgstr "_Dispositivo"
 msgid "_View"
 msgstr "_Visualizza"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Aiuto"
 
@@ -90,7 +90,7 @@ msgstr "Cerca dispositivi nelle vicinanze"
 msgid "Search"
 msgstr "Cerca"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Associa con il dispositivo"
 
@@ -99,17 +99,17 @@ msgstr "Associa con il dispositivo"
 msgid "Pair"
 msgstr "Associa"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Imposta/Rimuovi questo dispositivo come fidato"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Autorizza"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Esegui l'assistente di configurazione per questo dispositivo"
 
@@ -118,7 +118,7 @@ msgstr "Esegui l'assistente di configurazione per questo dispositivo"
 msgid "Setup..."
 msgstr "Configurazione..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Rimuovi questo dispositivo dalla lista dei dispositivi conosciuti"
 
@@ -299,7 +299,12 @@ msgstr "Non specificato"
 msgid "<b>Author:</b>"
 msgstr "<b>Autore:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -361,7 +366,7 @@ msgstr "_Ripristina"
 msgid "Send note"
 msgstr "Invia nota"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Il Bluetooth deve essere acceso perchè il gestore dispositivi funzioni"
 
@@ -369,32 +374,30 @@ msgstr "Il Bluetooth deve essere acceso perchè il gestore dispositivi funzioni"
 msgid "Bluetooth Adapters"
 msgstr "Adattatori Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Sempre"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minuto"
 msgstr[1] "%d Minuti"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adattarore"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Il Bluetooth deve essere acceso perchè il gestore dispositivi funzioni"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Connessione a BlueZ falita"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -408,144 +411,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Ricerca"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Assistente bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Preferenze Adattatore"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Mittente del file"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Trasferimento file bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Connessione in corso"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd non disponibile"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Avvio automatico del servizio obex fallito. Assicurati che il demone obex "
 "sia attivo"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Annullamento in corso"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Invio file"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Tempo rimanente:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Errore nel trasferimento file %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Ignora"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Riprova"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Insorto errore"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Servizi Locali"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Richiesta di associazione per %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autenticazione bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Inserire il codice PIN per l'autenticazione:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Inserire il codice PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Inserire la chiave per l'autenticazione:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Inserisci chiave d'accesso"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Password di associazione per"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Codice PIN di associazione per"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Richiesta di associazione per:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Conferma il valore per l'autenticazione:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Conferma"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Nega"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Richiesta di autorizzazione per:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Servizio:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Accetta sempre"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Accetta"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -580,243 +575,240 @@ msgstr "Sì"
 msgid "No"
 msgstr "No"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "Segnala un p_roblema"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Gestore dispositivi"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Mostra ba_rra degli strumenti"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Mostra barra di s_tato"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_Ordina per"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nome"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Aggiunto"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Discendente"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Plugin"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Servizi _locali"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferenze Servizio"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Cerca"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Preferenze Adattatore"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Esci"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "non categorizzato"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Fidato ed Accoppiato</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Accoppiato</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Autorizzato</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Scarso"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Sub-ottimale"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Ottimale"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Molto"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Troppo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Basso"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Alto"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Molto Alto"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Riuscito!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Porta seriale connessa su %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Fallito"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Connessione fallita: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Connessione in corso"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Disconessione fallita: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Disconnessione..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Connetti</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Auto connette i profili sorgente A2DP, sink A2DP, e HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Disconnetti</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Disconnessione forzata dal dispositivo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Connetti a:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Disconnetti:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Invia un _file..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Associa"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "Au_torizza"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Revoca autorizzazione"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Configura…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Rinomina dispositivo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Rimuovi"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Annulla Operazione"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indicazione attività dati"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Dati totali ricevuti e velocità di trasmissione"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Dati totali inviati e velocità di trasmissione"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Revoca autorizzazione"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Seleziona Dispositivo"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Altro"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -854,7 +846,7 @@ msgstr ""
 "  musmax https://launchpad.net/~musmax\n"
 "  r1348 https://launchpad.net/~req1348"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman è un gestore Bluetooth in GTK+"
 
@@ -862,17 +854,17 @@ msgstr "Blueman è un gestore Bluetooth in GTK+"
 msgid "GSM Settings"
 msgstr "Impostazioni GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Plugin"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problema di dipendenze"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -883,7 +875,7 @@ msgstr ""
 "disattiverà <b>\"%(0)s\"</b>.\n"
 "Procedere?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -894,886 +886,1259 @@ msgstr ""
 "b> verrà disattivato <b>%(0)s</b>.\n"
 "Procedere?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Selezione dell'adattatore"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Visibile… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "non categorizzato"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Punto di accesso alla rete"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "desktop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "portatile"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "palmare"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "cellulare"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "senza fili"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smartphone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd non disponibile"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "auricolare"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "vivavoce"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "sconosciuto"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "microfono"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Sorgente audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Sorgente audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Sorgente audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tastiera"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "puntamento"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tastiera"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "puntamento"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Connetti"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Connetti"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Connetti"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Connetti"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Trasferimento file bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Connetti"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Trasferimento file bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Trasferimento file bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Gruppo rete"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Trasferimento file bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Connetti"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Connetti"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Trasferimento file bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Connetti"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Gruppo rete"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Porte Seriali"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Connessione remota (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Trasferimento file bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "auricolare"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Sorgente audio"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Sincronizzazione audio"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Punto di accesso alla rete"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Gruppo rete"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "vivavoce"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Punto di accesso alla rete (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Punto di accesso alla rete (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Gruppo rete"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Trasferimento file bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Sorgente audio"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Sincronizzazione audio"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Sorgente audio"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Rinomina dispositivo"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Mostra informazioni sul dispositivo"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Servizi Locali"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Trasferimento"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "applet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Accoppia dispositivo"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Cerca dispositivi nelle vicinanze"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Trasferimento"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "applet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Accoppia dispositivo"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Cerca dispositivi nelle vicinanze"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Gestore dispositivi"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "_Connessioni recenti"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Gestore dispositivi"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Preferenze Adattatore"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Profili di connessione automatica"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietario"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "sì"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "no"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Informazioni"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Mostra informazioni sul dispositivo"
 
@@ -1798,34 +2163,35 @@ msgstr "Profilo audio"
 msgid "Select audio profile for PulseAudio"
 msgstr "Seleziona il profilo audio di PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Porta seriale %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Rinnova Indirizzo IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Impostazioni composizione"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Porte Seriali"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Non specificato"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Connesso"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Connesso automaticamente a %(service)s su %(device)s"
@@ -1893,22 +2259,17 @@ msgstr "_Uso della Rete"
 msgid "Shows network traffic usage"
 msgstr "Visualizza l'utilizzo del traffico di rete"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth abilitato"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth disabilitato"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Gestisci servizi di rete locali, come NAP bridge"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1916,7 +2277,7 @@ msgstr ""
 "Fornisce supporto per il Dial Up Networking (DUN) con ModemManager e "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1924,37 +2285,37 @@ msgstr ""
 "un accesso veloce"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Connessioni recenti visualizzate"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Il numero massimo di connessioni recenti visualizzate nel menu."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Connessioni recenti"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Connesso a %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Connessione fallita"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s su %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "L'adattatore non è disponibile per questa connessione"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1962,41 +2323,41 @@ msgstr ""
 "Fornisce supporto per la Personal Area Networking (PAN) introdotta in "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Fornisce le API DBus per altri componenti Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "File in arrivo tramite bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "File %(0)s in arrivo da %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Rifiuta"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Ricezione file in corso"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Ricezione del file %(0)s da %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Permette di trasferire file tramite OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Una cartella configurata per i file in entrata non esiste"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -2005,42 +2366,38 @@ msgstr ""
 "Assicurati che la cartella \"<b>%s</b>\" esista o sia configurata tramite "
 "blueman-services. Verrà usata la cartella predefinita \"%s\""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "File ricevuto"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Il file %(0)s è stato correttamente ricevuto da %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Trasferimento fallito"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Tasferimento del file %(0)s fallito"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "File ricevuti"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Ricevuto %d file in background"
 msgstr[1] "Ricevuti %d file in background"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Ricevuto %d ulteriore file in background"
@@ -2053,27 +2410,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Aggiunge elementi del menu standard allo status menu"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "Impo_sta un nuovo dispositivo"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Invia _file al dispositivo"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Dispositivi"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Ada_ttatori"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2085,27 +2442,27 @@ msgstr "Fornisce password e servizi di autenticazione per il demone BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Aggiunge un elemento del menu per chiudere l'applet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Fornisce un client dhcp di base per connessioni Bluetooth PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Rete Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interfaccia %(0)s collegata all'indirizzo IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Impossibile ottenere l'indirizzo IP di %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2114,7 +2471,7 @@ msgstr ""
 "Tentativo di ottenere indirizzo IP da %s\n"
 "Si prega di attendere…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2122,24 +2479,27 @@ msgstr ""
 "Aggiunge un indicatore all'icona di stato quando il Bluetooth è attivo e "
 "mostra il numero di connessioni nella tooltip."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth attivo"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d connessione attiva</b>"
 msgstr[1] "<b>%d connessioni attive</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth disabilitato"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Utilizza libappindicator per visualizzare un'icona di stato"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2147,35 +2507,36 @@ msgstr ""
 "Aggiunge un elemento del menu per rendere l'adattore predefinito visibile "
 "temporaneamente quando è nascosto di default"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Timeout rilevabilità"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Durata in secondi della rilevabilità"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Rendi rilevabile"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Rendi l'adattatore predefinito visibile temporaneamente"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Visibile… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Aggiunge un menu per l'applet e un'API per permettere ad altri plugin per "
 "manipolarlo"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2184,24 +2545,24 @@ msgstr ""
 "Connesso con successo al servizio <b>DUN</b> di <b>%(0)s.</b>\n"
 "La rete è ora disponibile attraverso <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Fornisce un supporto di base pr connettersi ad internet attraverso il "
 "profilo DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Gestore standard dei profili di connessione SPP, permette di eseguire azioni "
 "personalizzate"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script da eseguire alla connessione"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2219,11 +2580,11 @@ msgstr ""
 "\n"
 "Alla disconnessione di un dispositivo lo script invierà un segnale HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Porta seriale connessa"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2231,11 +2592,11 @@ msgstr ""
 "Il servizio porta seriale sul dispositivo <b>%s</b> sarà ora disponibile "
 "attraverso <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Script di connessione alla porta seriale fallito"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2244,37 +2605,37 @@ msgstr ""
 "Si è verificato un problema nell'esecuzione dello script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Gestisce lo stato di alimentazione degli adattatori Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Accensione automatica"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Accendi automaticamente adattatore"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Disattiva il bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Spegni tutti gli adattatori"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Attiva il bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Accendi tutti gli adattatori"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2282,23 +2643,22 @@ msgstr ""
 "Sospende temporaneamente lo screensaver quando viene collegato un controller "
 "di gioco bluetooth."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Rete"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Indirizzo IP non valido"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "L'indirizzo IP va in conflitto con l'interfaccia %s che ha lo stesso "
 "indirizzo"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2309,8 +2669,8 @@ msgstr ""
 "configurata %s/%s\n"
 "Ciò può causare comportamenti di rete anomali"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Non è attualmente supportato con questa configurazione"
 
@@ -2326,10 +2686,6 @@ msgstr "Il plugin del servizio di trasferimento dell'applet è disabilitato"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Imposta le Proprietà di un Adattatore Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "dispositivo-blueman"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman Applet"
@@ -2337,11 +2693,6 @@ msgstr "Blueman Applet"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Gestore Bluetooth"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2383,6 +2734,37 @@ msgstr "Imposta lo stato RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Impostare lo stato RfKill richiede privilegi"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Inserire il codice PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Inserisci chiave d'accesso"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Porta seriale connessa su %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "auricolare"
+
+#~ msgid "handsfree"
+#~ msgstr "vivavoce"
+
+#~ msgid "unknown"
+#~ msgstr "sconosciuto"
+
+#~ msgid "blueman-device"
+#~ msgstr "dispositivo-blueman"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Dispositivi Bluetooth"
 
@@ -2403,11 +2785,6 @@ msgstr "Impostare lo stato RfKill richiede privilegi"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Rimuovi..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Connetti"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/ja.po
+++ b/po/ja.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-03-28 10:09+0000\n"
 "Last-Translator: Takuya Ohe <hi@tohe.xyz>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>可視性の設定</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "非表示"
 
@@ -72,8 +72,8 @@ msgstr "デバイス(_D)"
 msgid "_View"
 msgstr "表示(_V)"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "ヘルプ(_H)"
 
@@ -86,7 +86,7 @@ msgstr "付近のデバイスを検索"
 msgid "Search"
 msgstr "検索"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "デバイスをペアリングする"
 
@@ -95,17 +95,17 @@ msgstr "デバイスをペアリングする"
 msgid "Pair"
 msgstr "ペア"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "信頼できるデバイスとしてマークを付ける・外す"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "信頼"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "このデバイスのセットアップウィザードを実行する"
 
@@ -114,7 +114,7 @@ msgstr "このデバイスのセットアップウィザードを実行する"
 msgid "Setup..."
 msgstr "セットアップ..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "このデバイスを既知のデバイス一覧から削除する"
 
@@ -293,7 +293,12 @@ msgstr "未指定"
 msgid "<b>Author:</b>"
 msgstr "<b>作者:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -355,7 +360,7 @@ msgstr "リセット(_R)"
 msgid "Send note"
 msgstr "付箋紙を送る"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "アダプターマネージャーを使うには Bluetooth の電源をオンにする必要があります"
@@ -364,32 +369,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth アダプター"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "常に"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d 分"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "アダプター"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "デバイスマネージャーを動作させるためには Bluetooth をオンにする必要があります"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "BlueZ への接続に失敗しました"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -403,143 +406,135 @@ msgstr ""
 msgid "Searching"
 msgstr "検索中"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth アシスタント"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "アダプター設定"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "ファイル送信者"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth ファイル転送"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "接続中"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd が利用できません"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "obexサービスの自動起動に失敗しました。obexデーモンが実行されているか確認して"
 "ください"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "キャンセル中"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "ファイルを送信中"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "転送完了時間:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "ファイル %s を送信中にエラーが発生しました"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "スキップ"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "再実行"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "エラーが発生しました"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "ローカルサービス"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "%s へのペアリングリクエスト"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth 認証"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "認証の PIN コードを入力:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "PIN コードを入力してください"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "認証用パスキーを入力してください:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "パスキーの入力"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "ペアリングパスキー"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "ペアリング PIN コード"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "ペアリング要求:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "認証確認用の値:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "確認"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "拒否"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "認証要求:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "サービス:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "常に許可"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "許可する"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -573,244 +568,241 @@ msgstr "はい"
 msgid "No"
 msgstr "いいえ"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "問題を報告 (_R)"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "デバイスマネージャー"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "ツールバーを表示(_T)"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "ステータスバーを表示(_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "並び替え(_O)"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "名前(_N)"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "追加済み(_A)"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "降順(_D)"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "プラグイン(_P)"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "ローカルサービス(_L)"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "サービス設定"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "検索(_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "アダプター設定"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "終了"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "未分類"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>信頼とペアリング済み</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>ペアリング済み</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>信頼</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "弱い"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "最適ではない"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "最適"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "多い"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "多すぎる"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "低い"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "高い"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "非常に高い"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "成功!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "%s に接続したシリアルポート"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "失敗"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "接続失敗: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "接続中"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "切断失敗: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "切断中..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "自動接続プロファイルの A2DP ソース、A2DP シンク、および HID を接続します"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "強制的にデバイスを切断する"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>接続中:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>切断:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "ファイルを送信(_F)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "ペア(_P)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "信頼する(_T)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "信頼しない(_U)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "デバイス名の変更"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "削除"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "操作のキャンセル"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "データアクティビティ表示"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "総受信データ量と転送速度"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "総送信データ量と転送速度"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "信頼を解除"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "デバイスを選択"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "もっと"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -818,7 +810,7 @@ msgstr ""
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  Yuki Kodama https://launchpad.net/~kuy"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman は GTK+ の Bluetooth マネージャーです"
 
@@ -826,17 +818,17 @@ msgstr "Blueman は GTK+ の Bluetooth マネージャーです"
 msgid "GSM Settings"
 msgstr "GSM の設定"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "プラグイン"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "依存問題"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -847,7 +839,7 @@ msgstr ""
 "b>をアンロードすると<b>\"%(0)s\"</b>もアンロードされます。\n"
 "よろしいですか？"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -858,886 +850,1259 @@ msgstr ""
 "ロードすると<b>\"%(0)s\"</b>はアンロードされます。\n"
 "よろしいですか？"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "アダプターの選択"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "検出可能... %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "未分類"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "ネットワークアクセスポイント"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "デスクトップ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "サーバ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "ラップトップ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "ハンドヘルド"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "Palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "携帯電話"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "無線"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "スマートフォン"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "モデム"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "ISDN"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd が利用できません"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "ヘッドセット"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "ハンドフリー"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "不明"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "マイクロフォン"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "オーディオソース"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "オーディオソース"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "オーディオソース"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "キーボード"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "ポインティング"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "キーボード"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "ポインティング"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "接続"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "接続"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "接続"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "接続"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth ファイル転送"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "接続"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth ファイル転送"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth ファイル転送"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "グループネットワーク"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth ファイル転送"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "接続"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "接続"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth ファイル転送"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "接続"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "グループネットワーク"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "シリアルポート"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "ダイアルアップネットワーキング (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth ファイル転送"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "ヘッドセット"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "オーディオソース"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "オーディオシンク"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "ネットワークアクセスポイント"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "グループネットワーク"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "ハンドフリー"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "ネットワークアクセスポイント (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "ネットワークアクセスポイント (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "グループネットワーク"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth ファイル転送"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "オーディオソース"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "オーディオシンク"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "オーディオソース"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "デバイス名の変更"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "デバイスの情報を表示します"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "ローカルサービス"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "転送"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "アプレット"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "デバイスとペアリングする"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "付近のデバイスを検索"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "転送"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "アプレット"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "デバイスとペアリングする"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "付近のデバイスを検索"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "デバイスマネージャー"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "最近使用した接続(_C)"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "デバイスマネージャー"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "アダプター設定"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "自動接続プロファイル"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "プロプライエタリー"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "はい"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "いいえ"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "情報(_I)"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "デバイスの情報を表示します"
 
@@ -1762,34 +2127,35 @@ msgstr "オーディオプロファイル"
 msgid "Select audio profile for PulseAudio"
 msgstr "PulseAudio のオーディオプロファイルを選択して下さい"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "シリアルポート %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "IP アドレスを再取得"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "ダイアルアップの設定"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "シリアルポート"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "未設定"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "接続しました"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1853,22 +2219,17 @@ msgstr "ネットワーク利用状況(_U)"
 msgid "Shows network traffic usage"
 msgstr "ネットワーク使用状況を表示する"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth が有効"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth が無効"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "NAP ブリッジのようなローカルネットワークデバイスを管理する"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1876,84 +2237,84 @@ msgstr ""
 "モデムマネージャーとネットワークマネージャーにダイヤルアップネットワーク "
 "(DUN) を提供します"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "次回以降のアクセスのために最後の接続をメニューに含める"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "最大表示項目数"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "最近使用した接続に表示される最大の項目数。"
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "最近使用した接続(_C)"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "%s に接続しています"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "接続に失敗しました"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(device)s 上の %(service)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "この接続のアダプターは使用できません"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 "パーソナルエリアネットワーク (PAN) は NetworkManager 0.8 で利用可能です"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "他の Blueman コンポーネントに DBus API を提供します"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Bluetooth 経由のファイル受信"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "%(1)s からファイル %(0)s が届いています"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "リジェクト"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "受信ファイル"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "%(1)s からファイル %(0)s を受信中"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "OBEX ファイル転送機能を提供する"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "設定された受信ディレクトリーが存在しません"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1962,41 +2323,37 @@ msgstr ""
 "ディレクトリ\"<b>%s</b>\"が存在するか確認してください。または、blueman-"
 "servicesで設定してください。それまでは、\"%s\"が使われます"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "ファイルを受信しました"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "%(1)s からファイル %(0)s を受信しました"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "転送に失敗しました"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "%(0)sの転送に失敗しました"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "ファイルを受信しました"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "%d 個のファイルをバックグラウンドで受信しました"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "%d 個以上のファイルをバックグラウンドで受信しました"
@@ -2008,27 +2365,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "ステータスアイコンメニューに通常メニューを追加します"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "新しいデバイスを設定する(_S)"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "デバイスにファイルを送信(_F)"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "デバイス(_D)"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "アダプター(_T)"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "アプレット"
 
@@ -2040,27 +2397,27 @@ msgstr "BlueZ デーモンのためにパスキーと認証サービスを提供
 msgid "Adds an exit menu item to quit the applet"
 msgstr "アプレットを終了するメニューを追加します"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Bluetooth PAN ネットワークのための DHCP クライアントを提供します。"
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth ネットワーク"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "インターフェース %(0)s は IP アドレス %(1)s に接続しています"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "%s の IP アドレスを取得できませんでした"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2069,7 +2426,7 @@ msgstr ""
 "%s の IP アドレスを取得中です。\n"
 "お待ちください…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2077,23 +2434,26 @@ msgstr ""
 "Bluetooth がアクティブになった際にステータスアイコンに通知し、ツールチップに"
 "接続しているデバイス数を表示します。"
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth 有効"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d 件のアクティブな接続</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth が無効"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "ステータスアイコンを表示するために libappindicator を使用します"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2101,35 +2461,36 @@ msgstr ""
 "デフォルトで非表示にされているデフォルトアダプターを一時的に表示するメニュー"
 "アイテムを提供します"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "デバイスの検出がタイムアウトしました"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "発見可能な状態を継続する秒数"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "発見可能にする(_M)"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "デフォルトアダプターを一時的に表示する"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "検出可能... %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "アプレットにメニューを、その他のプラグインに API を提供し、操作できるようにし"
 "ます"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2138,23 +2499,23 @@ msgstr ""
 "<b>%(0)s</b> 上の <b>DUN</b> サービスに接続しました。\n"
 "<b>%(1)s</b> を経由してネットワークを利用可能です"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "DUN プロファイルを用いてインターネットに接続するための基本的な機能を提供しま"
 "す。"
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "カスタムアクションを実行可能にする標準 SPP プロファイルコネクションハンドラー"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "接続時に実行するスクリプト"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2172,11 +2533,11 @@ msgstr ""
 "\n"
 "デバイスの接続解除時、スクリプトは HUP シグナルを送信します。</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "シリアルポートが接続されました"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2184,11 +2545,11 @@ msgstr ""
 "デバイス <b>%s</b> 上のシリアルポートサービスを <b>%s</b> 経由で利用可能にな"
 "りました"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "シリアルポート接続スクリプトの実行に失敗しました"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2197,37 +2558,37 @@ msgstr ""
 "スクリプト %s の実行に失敗しました\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Bluetooth アダプターの電源状態を設定します"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "自動的に電源をオンにする"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "自動的にアダプターの電源をオンにする"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Bluetooth をオフにする(_O)</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "全てのアダプターをオフにします"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Bluetooth をオンにする(_O)</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "全てのアダプターをオンする"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2235,21 +2596,20 @@ msgstr ""
 "Bluetooth ゲームコントローラーが接続されている間、スクリーンセーバーは一時的"
 "に動作しません。"
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "ネットワーク"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "不正な IP アドレス"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP アドレスが同じアドレスを持つインターフェース %s と衝突しています"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2260,8 +2620,8 @@ msgstr ""
 "います\n"
 "これにより、不正なネットワーク動作が発生する可能性があります"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "現在このセットアップではサポートされていません"
 
@@ -2275,40 +2635,26 @@ msgstr "アプレットの転送サービスプラグインは無効化されて
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth アダプター"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "アプレット"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman は GTK+ の Bluetooth マネージャーです"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth が有効"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth デバイス"
 
@@ -2344,6 +2690,31 @@ msgstr "RfKill ステートを設定する"
 msgid "Setting RfKill State requires privileges"
 msgstr "RfKill ステートの設定には権限が必要です"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "PIN コードを入力してください"
+
+#~ msgid "Enter passkey"
+#~ msgstr "パスキーの入力"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "%s に接続したシリアルポート"
+
+#~ msgid "palm"
+#~ msgstr "Palm"
+
+#~ msgid "isdn"
+#~ msgstr "ISDN"
+
+#~ msgid "headset"
+#~ msgstr "ヘッドセット"
+
+#~ msgid "handsfree"
+#~ msgstr "ハンドフリー"
+
+#~ msgid "unknown"
+#~ msgstr "不明"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth デバイス"
 
@@ -2362,11 +2733,6 @@ msgstr "RfKill ステートの設定には権限が必要です"
 
 #~ msgid "_Remove..."
 #~ msgstr "削除(_R)"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "接続"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/kk.po
+++ b/po/kk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Kazakh (http://www.transifex.com/mate/MATE/language/kk/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr ""
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Жасырын"
 
@@ -65,8 +65,8 @@ msgstr ""
 msgid "_View"
 msgstr "_Түрі"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Анықтама"
 
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Search"
 msgstr "Іздеу"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -88,17 +88,17 @@ msgstr ""
 msgid "Pair"
 msgstr ""
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Сенім арту"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "Setup..."
 msgstr "Баптау..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr ""
 
@@ -282,7 +282,12 @@ msgstr ""
 msgid "<b>Author:</b>"
 msgstr ""
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -344,7 +349,7 @@ msgstr "_Тастау"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -352,30 +357,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr ""
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Әрқашан"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -386,142 +391,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Іздеу"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr ""
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Қосылуда"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Өткізіп жіберу"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Қайталау"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr ""
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Құптау"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Бұғат"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Қызмет:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Қабылдау"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -552,244 +549,243 @@ msgstr "Иә"
 msgid "No"
 msgstr "Жоқ"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "І_здеу"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Нашар"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Төмен"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Жоғары"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Өте жоғары"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Жеткізу қатесі"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Қосылуда"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Байланысты үзу..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send File"
 msgid "Send a _File…"
 msgstr "Файл жіберу"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Өшіру"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr ""
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  arruah https://launchpad.net/~arruah"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -797,17 +793,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Плагиндер"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -815,7 +811,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -823,850 +819,1225 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Байланысты үзу..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Қабылдау"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "жұмыс үстелі"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
+msgstr "Қызмет:"
+
+#. translators: device class
+#: blueman/DeviceClass.py:35
+msgid "Laptop"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+msgid "Smart phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
+msgid "17-33 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
+msgid "50-67 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
+msgid "67-83 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "белгісіз"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:88
+msgid "Microphone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+msgid "Video camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+msgid "Video monitor"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+msgid "Video conferencing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+msgid "Keyboard"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "Қосылуда"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Байланысу"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 msgid "OBEX File Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr ""
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr ""
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr ""
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr ""
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr ""
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr ""
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr ""
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr ""
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Service:"
 msgid "Battery Service"
 msgstr "Қызмет:"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 #, fuzzy
-#| msgid "Service:"
 msgid "Primary Service"
 msgstr "Қызмет:"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr ""
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Device"
 msgid "Device Name"
 msgstr "Құрылғы"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Service:"
 msgid "Service Changed"
 msgstr "Қызмет:"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "иә"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "жоқ"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1691,34 +2062,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Байланысқан"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1781,141 +2153,136 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Бас тарту"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1929,27 +2296,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
@@ -1961,107 +2328,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2072,78 +2445,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Желі"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2151,8 +2523,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2168,21 +2540,12 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
-msgstr ""
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
 msgstr ""
 
 #: data/blueman-manager.desktop.in:3
@@ -2225,10 +2588,8 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "unknown"
+#~ msgstr "белгісіз"
+
 #~ msgid "_Remove..."
 #~ msgstr "Ө_шіру..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Байланысу"

--- a/po/ko.po
+++ b/po/ko.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-06-19 18:56+0000\n"
 "Last-Translator: 이정희 <daemul72@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -29,7 +29,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>노출 설정</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "숨겨짐"
 
@@ -73,8 +73,8 @@ msgstr "장치(_D)"
 msgid "_View"
 msgstr "보기(_V)"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "도움말(_H)"
 
@@ -87,7 +87,7 @@ msgstr "가까운 곳의 장치를 검색합니다"
 msgid "Search"
 msgstr "검색"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "장치와 페어링을 만듭니다"
 
@@ -96,17 +96,17 @@ msgstr "장치와 페어링을 만듭니다"
 msgid "Pair"
 msgstr "페어링"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "신뢰할 수 있는 장치로 설정/해제합니다"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "신뢰"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "이 장치에 대한 설치 도우미를 실행합니다"
 
@@ -115,7 +115,7 @@ msgstr "이 장치에 대한 설치 도우미를 실행합니다"
 msgid "Setup..."
 msgstr "설정..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "이 장치를 알려진 장치 목록에서 제거합니다"
 
@@ -294,7 +294,12 @@ msgstr "지정 안함"
 msgid "<b>Author:</b>"
 msgstr "<b>작성자:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -356,7 +361,7 @@ msgstr "리셋(_R)"
 msgid "Send note"
 msgstr "메모 보내기"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "어댑터 관리자를 동작하게 하려면 블루투스를 켜야 합니다"
 
@@ -364,31 +369,29 @@ msgstr "어댑터 관리자를 동작하게 하려면 블루투스를 켜야 합
 msgid "Bluetooth Adapters"
 msgstr "블루투스 어댑터"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "항상"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d분"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "어뎁터"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "장치 관리자를 동작하게 하려면 블루투스를 켜야 합니다"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "blueZ 연결에 실패했습니다"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -402,143 +405,135 @@ msgstr ""
 msgid "Searching"
 msgstr "검색중"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "블루투스 도우미"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "어댑터 기본 설정"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "파일 전송자"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "블루투스 파일 전송"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "연결 중"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd 사용 불가"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "obex 서비스를 자동으로 시작하지 못했습니다. obex 데몬이 실행 중인지 확인하십"
 "시오"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "취소 중"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "파일 전송 중"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "총 예상 시간:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "%s 파일을 보내는 중 오류가 발생했습니다"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "건너뛰기"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "다시 시도"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "오류가 발생했습니다"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "로컬 서비스"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "%s의 페어링 요청"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "블루투스 인증"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "인증 핀 코드 입력:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "핀 코드 입력"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "인증용 암호 입력:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "통과키 입력"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "페어링 확인 키 "
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "페어링 확인 PIN 코드"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "페어링 요청:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "인증용 확인 값:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "확인"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "거절"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "인증 요청:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "서비스:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "항상 허용"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "수락"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -573,243 +568,240 @@ msgstr "예"
 msgid "No"
 msgstr "아니요"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "문제 보고(_R)"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "장치 관리자"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "도구 모음 보이기(_T)"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "상태 표시줄 보이기(_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "정렬 순서(_O)"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "이름(_N)"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "추가(_A)"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "내림차순(_D)"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "플러그인(_P)"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "로컬 서비스(_L)"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "서비스 기본 설정"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "검색(_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "어댑터 기본 설정"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "끝내기"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "분류 안함"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>신뢰하며 페어링함</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>페어링함</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>신뢰함</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "나쁨"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "약간 최적"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "최적"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "많음"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "매우 많음"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "낮음"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "높음"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "매우 높음"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "성공!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "%s(으)로 직렬 포트 연결함"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "실패"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "연결 실패: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "연결 중"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "연결 끊기 실패:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "연결 끊는 중..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "<b>연결하기(_C)</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "자동 연결 프로파일 A2DP 소스, A2DP 싱크 및 HID에 연결합니다."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "<b>연결끊기(_D)</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "강제로 장치 연결 끊기"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>연결 대상:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>연결 취소:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "파일 보내기(_F)..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "페어링(_P)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "신뢰함(_T)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "신뢰하지 않음(_U)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "설정(_S)…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "장치 이름 바꾸기"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "제거"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "작업 취소"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "데이터 활동 표시"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "총 데이터 수신 및 전송 속도"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "총 데이터 전송 및 전송 속도"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "신뢰 중지"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "장치 선택"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "더 보기"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Elex https://launchpad.net/~mysticzizone\n"
@@ -821,7 +813,7 @@ msgstr ""
 "MATE Desktop Environment Team <https://www.transifex.com/mate/teams/13566/ko/"
 ">"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "블루맨은 GTK+ 블루투스 관리자입니다"
 
@@ -829,17 +821,17 @@ msgstr "블루맨은 GTK+ 블루투스 관리자입니다"
 msgid "GSM Settings"
 msgstr "GSM 설정"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "플러그인"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "의존성 문제"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -850,7 +842,7 @@ msgstr ""
 "를 취소하면 <b>\"%(0)s\"</b> 불러오기도 취소합니다.\n"
 "계속할까요?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -861,886 +853,1259 @@ msgstr ""
 "를 취소하면 <b>%(0)s</b> 불러오기도 취소합니다.\n"
 "계속할까요?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "어댑터 선택"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "탐색 가능… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "분류 안함"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "네트워크 접근 지역"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "데스크톱"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "서버"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "랩톱"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "휴대장비"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "Palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "휴대폰"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "무선"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "스마트폰"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "모뎀"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "ISDN"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd 사용 불가"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "헤드셋"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "핸즈프리"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "알 수 없음"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "마이크"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "오디오 소스"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "오디오 소스"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "오디오 소스"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "키보드"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "포인팅 장치"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "키보드"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "포인팅 장치"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "연결"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "연결"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "연결"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "연결"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "블루투스 파일 전송"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "연결"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "블루투스 파일 전송"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "블루투스 파일 전송"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "그룹 네트워크"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "블루투스 파일 전송"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "연결"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "연결"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "블루투스 파일 전송"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "연결"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "그룹 네트워크"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "시리얼 포트"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "전화 접속 네트워킹(DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "블루투스 파일 전송"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "헤드셋"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "오디오 소스"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "오디오 싱크"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "네트워크 접근 지역"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "그룹 네트워크"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "핸즈프리"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "네트워크 액세스 지점(NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "네트워크 액세스 지점(NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "그룹 네트워크"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "블루투스 파일 전송"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "오디오 소스"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "오디오 싱크"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "오디오 소스"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "장치 이름 바꾸기"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "장치 정보 보이기"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "로컬 서비스"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "전송"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "애플릿"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "장치 페어링하기"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "가까운 곳의 장치를 검색합니다"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "전송"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "애플릿"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "장치 페어링하기"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "가까운 곳의 장치를 검색합니다"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "장치 관리자"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "최근 연결(_C)"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "장치 관리자"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "어댑터 기본 설정"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "자동 연결 프로필"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "독점"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "예"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "아니오"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "정보(_I)"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "장치 정보 보이기"
 
@@ -1765,34 +2130,35 @@ msgstr "오디오 프로파일"
 msgid "Select audio profile for PulseAudio"
 msgstr "PulseAudio 오디오 프로파일을 선택"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "시리얼 포트 %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "IP 주소 새로 고침"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "전화 접속 설정"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "시리얼 포트"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "지정 안함"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "연결함"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "%(device)s의 %(service)s에 자동으로 연결됨"
@@ -1856,22 +2222,17 @@ msgstr "네트워크 사용(_U)"
 msgid "Shows network traffic usage"
 msgstr "네트워크 트래픽 표시"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "블루투스 켜짐"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "블루투스 꺼짐"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "NAP 브릿지 같은 로컬 네트워크 서비스를 관리합니다"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1879,84 +2240,84 @@ msgstr ""
 "모뎀 매니저(ModemManager)와 네트워크 매니저(NetworkManager)는 전화 접속 네트"
 "워킹(DUN)을 지원합니다"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 "빠른 접근을 위해 마지막으로 사용한 연결을 포함한 메뉴 항목을 제공합니다"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "최대 항목"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "최근 접속 메뉴의 최대 숫자가 곧 나타납니다."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "최근 연결(_C)"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "%s에 연결함"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "연결 실패"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(device)s의 %(service)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "이 연결에 대해 존재하는 어댑터가 없습니다."
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr "NetworkManager 0.8에서 도입한 PAN 지원을 제공합니다"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "블루투스 구성 요소를 위한 DBus API를 제공합니다"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "블루투스로 들어온 파일"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "파일 %(1)s에서 %(0)s(으)로 수신중"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "거절"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "파일 수신 중"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "파일 %(1)s에서 %(0)s(으)로 수신중"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "OBEX 파일 전송 기능 제공"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "받아오는 파일을 위해 설정한 디렉토리가 없습니다"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1965,41 +2326,37 @@ msgstr ""
 "\"<b>%s</b>\" 디렉터리가 있는지 확인하거나 blueman-서비스로 구성하십시오. 그"
 "때까지 기본 \"%s\"이(가) 사용됩니다."
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "파일 수신함"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "파일 %(1)s에서 %(0)s(으)로 정상적으로 수신됨"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "전송 실패"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "%(0)s 파일 전송 실패"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "파일 수신함"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "파일 %d개를 백그라운드에서 수신함"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "파일 %d개 이상을 백그라운드에서 수신함"
@@ -2011,27 +2368,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "상태 아이콘 메뉴에 표준 메뉴 항목을 추가합니다"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "새 장치 설정(_S)"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "장치에 파일 보내기(_F)"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "장치(_D)"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "어뎁터(_T)"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "애플릿"
 
@@ -2043,27 +2400,27 @@ msgstr "blueZ 데몬용 패스키, 인증 서비스를 제공합니다"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "애플릿을 끝낼 나가기 메뉴 항목을 추가합니다"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "블루투스 PAN 연결용 기본 DHCP 클라이언트를 제공합니다."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "블루투스 네트워크"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "%(0)s 인터페이스가 %(1)s IP 주소를 잡았습니다"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "%s에서 IP 주소를 가져오는데 실패했습니다"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2072,7 +2429,7 @@ msgstr ""
 "%s에서 IP주소를 가져오려고 합니다\n"
 "잠시만 기다려 주세요…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2080,23 +2437,26 @@ msgstr ""
 "블루투스가 활성중이고 도구 표시줄에 몇가지 연결이 나타날 때 상태 아이콘 표시"
 "를 추가합니다."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "블루투스 활성"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>활성 연결 %d개</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "블루투스 꺼짐"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "상태 아이콘을 표시할 때 libappindicator 활용"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2104,33 +2464,34 @@ msgstr ""
 "기본으로 숨김 설정했을때 기본 어댑터를 임시로 보이게 하는 메뉴 항목을 제공합"
 "니다"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "발견 제한 시간을 초과하였습니다"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "발견 가능 상태를 지속할 초 단위 시간입니다"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "발견 가능한 상태로 만들기(_M)"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "기본 어댑터를 임시로 보이게 합니다"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "탐색 가능… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "애플릿과 다른 플러그인을 다룬  API에서 메뉴를 제공합니다"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2139,20 +2500,20 @@ msgstr ""
 "<b>%(0)s</b>의 <b>DUN</b> 서비스 연결에 성공했습니다.\n"
 "이제 <b>%(1)s</b>(으)로 네트워크를 사용할 수 있습니다"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "DUN 프로파일을 통해 인터넷으로 연결하는 기본 지원을 제공합니다."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr "표준 SPP 프로파일 연결 처리자는 사용자 정의 동작 실행을 허용합니다"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "연결할 때 실행할 스크립트"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2170,22 +2531,22 @@ msgstr ""
 "\n"
 "장치 연결이 끊어지면 스크립트가 HUP 신호를 전송합니다.</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "시리얼 포트에 연결했습니다"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "<b>%s</b> 장치의 시리얼 포트 서비스는 이제 <b>%s</b>(으)로 사용할 수 있습니다"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "시리얼 포트 연결 스크립트 실행에 실패했습니다"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2194,58 +2555,57 @@ msgstr ""
 "%s 스크립트를 실행하는데 문제가 있습니다\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "블루투스 어댑터 전원 상태를 제어합니다"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "자동 전원 켜기"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "어댑터의 전원을 자동으로 켭니다"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>블루투스 끄기(_O)</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "모든 어댑터를 끕니다"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>블루투스 켜기(_O)</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "모든 어댑터 켜기"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "블루트스 게임 컨트롤러가 연결되어 있을 땐 스크린 세이버를 잠시 미룹니다."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "네트워크"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "잘못된 IP 주소 입니다"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "같은 주소를 가진 %s 인터페이스와 IP 주소가 충돌합니다"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2255,8 +2615,8 @@ msgstr ""
 "IP 주소는 다음과 같은 %s/%s 구성이 있는 %s 인터페이스의 서브넷과 겹칩니다.\n"
 "이로 인해 잘못된 네트워크 동작이 발생할 수 있습니다."
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "이 설정을 현재 지원하지 않습니다"
 
@@ -2272,10 +2632,6 @@ msgstr "애플릿 전송 서비스 플러그인을 비활성화했습니다"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "블루투스 어댑터 속성 지정하기"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-장치"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman 애플릿"
@@ -2284,19 +2640,12 @@ msgstr "Blueman 애플릿"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman 블루투스 관리자"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-#, fuzzy
-msgid "blueman"
-msgstr "blueman"
-
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
 msgstr "블루투스 관리자"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "블루투스 장치"
 
@@ -2332,6 +2681,38 @@ msgstr "RfKill 상태 설정"
 msgid "Setting RfKill State requires privileges"
 msgstr "RfKill을 설정하려면 관리자 권한이 있어야 합니다"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "핀 코드 입력"
+
+#~ msgid "Enter passkey"
+#~ msgstr "통과키 입력"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "%s(으)로 직렬 포트 연결함"
+
+#~ msgid "palm"
+#~ msgstr "Palm"
+
+#~ msgid "isdn"
+#~ msgstr "ISDN"
+
+#~ msgid "headset"
+#~ msgstr "헤드셋"
+
+#~ msgid "handsfree"
+#~ msgstr "핸즈프리"
+
+#~ msgid "unknown"
+#~ msgstr "알 수 없음"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-장치"
+
+#, fuzzy
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "블루투스 장치"
 
@@ -2350,11 +2731,6 @@ msgstr "RfKill을 설정하려면 관리자 권한이 있어야 합니다"
 
 #~ msgid "_Remove..."
 #~ msgstr "제거(_R)..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "연결"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-07 06:23+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <https://hosted.weblate.org/projects/blueman/"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Matomumo nustatymas</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Paslėptas"
 
@@ -72,8 +72,8 @@ msgstr "_Įrenginys"
 msgid "_View"
 msgstr "_Rodymas"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Pagalba"
 
@@ -86,7 +86,7 @@ msgstr "Ieškoti įrenginių"
 msgid "Search"
 msgstr "Ieškoti"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Sukurti porą su įrenginiu"
 
@@ -95,17 +95,17 @@ msgstr "Sukurti porą su įrenginiu"
 msgid "Pair"
 msgstr "Poruoti"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Pažymėti arba atžymėti įrenginį patikimu"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Pasitikėti"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Paleisti sąrankos pagelbiklį šiam įrenginiui"
 
@@ -114,7 +114,7 @@ msgstr "Paleisti sąrankos pagelbiklį šiam įrenginiui"
 msgid "Setup..."
 msgstr "Nustatymai..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Pašalinti įrenginį iš žinomų įrenginų sąrašo"
 
@@ -294,7 +294,12 @@ msgstr "Nenurodyta"
 msgid "<b>Author:</b>"
 msgstr "<b>Autorius:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -356,7 +361,7 @@ msgstr "_Atstatyti"
 msgid "Send note"
 msgstr "Siųsti raštelį"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "„Bluetooth“ turi būti įjungtas, kad adapterio nustatymai veiktų"
 
@@ -364,14 +369,12 @@ msgstr "„Bluetooth“ turi būti įjungtas, kad adapterio nustatymai veiktų"
 msgid "Bluetooth Adapters"
 msgstr "„Bluetooth“ adapteriai"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Visada"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minutė"
@@ -379,19 +382,19 @@ msgstr[1] "%d minutės"
 msgstr[2] "%d minučių"
 msgstr[3] "%d minučių"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapteris"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "„Bluetooth“ turi būti įjungtas, kad įrenginių tvarkytuvė veiktų"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Nepavyko prisijungti prie „BlueZ“"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -405,50 +408,50 @@ msgstr ""
 msgid "Searching"
 msgstr "Ieškoma"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth Pagalbininkas"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adapterio nustatymai"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Failų siuntėjas"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth failų siuntimas"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Jungiamasi"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd neprieinama"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Nepavyko automatiškai paleisti obex tarnybos. Įsitikinkite, kad obex tarnyba "
 "yra paleista"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Nutraukiama"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Siunčiamas failas"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Liko:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -457,94 +460,86 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Įvyko klaida siunčiant failą %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Praleisti"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Bandyti vėl"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Įvyko klaida"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Paslaugos"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Poravimo užklausa iš %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth atpažinimas"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Įveskite PIN kodą atpažinimui:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Įveskite PIN kodą"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Įveskite slaptą frazę atpažinimui:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Įveskite slaptą frazę"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Poruojamas raktas įrenginiui"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Poruojamas PIN kodas įrenginiui"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Poravimo užklausa įrenginiui:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Patvirtinkite reikšmę atpažinimui:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Patvirtinti"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Drausti"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Prieigos teisės užklausa įrenginiui:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Paslauga:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Visada leisti"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Priimti"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -579,244 +574,243 @@ msgstr "Taip"
 msgid "No"
 msgstr "Ne"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "Pranešti nesklandumus"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Įrenginių tvarkytuvė"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Rodyti į_rankių juostą"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Rodyti _būsenos juostą"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Rikiu_oti pagal"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Pavadinimas"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Pridėta"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Mažėjančiai"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "Į_skiepiai"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Paslaugos"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Paslaugų nustatymai"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "Pa_ieška"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "_Nuostatos"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "_Išeiti"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "nežinomas"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Patikimas ir suporuotas</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Suporuotas</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Patikimas</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Prastas"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Silpnas"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimalus"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Didelis"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Per didelis"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Žemas"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Aukštas"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Labai aukštas"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Sėkminga!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Nuoseklioji jungtis (port) prijungta prie %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Nepavyko"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Prisijungimas nepavyko: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Jungiamasi"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Atsijungimas nepavyko: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Atsijungiama..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Prisijungti</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Prijungia automatinio prijungimo profilius A2DP šaltinį, A2DP rinktuvą ir HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Atsijungti</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Priverstinai atsijungti"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Jungtis prie:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Atsijungti:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Siųsti _failą..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Pora"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Pasitikėti"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Nepasitikėti"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Nustatyti…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Pervadinti įrenginį"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Šalinti"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Nutraukti operaciją"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Duomenų aktyvumas"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Visi priimti duomenys ir priėmimo sparta"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Visi išsiųsti duomenys ir išsiuntimo sparta"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Nepasitikėti"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Parinkite įrenginį"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Daugiau"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr "vertėjų-sąrašas"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman yra GTK+ Bluetooth tvarkytuvė"
 
@@ -824,17 +818,17 @@ msgstr "Blueman yra GTK+ Bluetooth tvarkytuvė"
 msgid "GSM Settings"
 msgstr "GSM nustatymai"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Papildiniai"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Priklausomybių problema"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -845,7 +839,7 @@ msgstr ""
 "bus išjungtas ir <b>\"%(0)s\"</b>.\n"
 "Tęsti?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -856,884 +850,1260 @@ msgstr ""
 "b> bus iškrautas <b>%(0)s</b>.\n"
 "Tęsti?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Adapterio pasirinkimas"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Matomas… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "nežinomas"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Tinklo prieigos taškas"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "stalinis kompiuteris"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "serveris"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "nešiojamasis kompiuteris"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "delninukas"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm delninukas"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobilusis telefonas"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "belaidis telefonas"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "išmanusis telefonas"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modemas"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "visuminių paslaugų tinklo adapteris"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd neprieinama"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "ausinė(s)"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "laisvų rankų įranga"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "Nežinoma"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofonas"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
 msgstr "garsiakalbis"
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
 msgstr "ausinės"
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
 msgstr "vaizdo kamera"
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Garso šaltinis"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Garso šaltinis"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "klaviatūra"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "pelė"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+msgid "Combo"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+msgid "Display"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "klaviatūra"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "pelė"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Prisijungti"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Prisijungti"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Prisijungti"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Prisijungti"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth failų siuntimas"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Prisijungti"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth failų siuntimas"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth failų siuntimas"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Grupinis tinklas"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth failų siuntimas"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Prisijungti"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Prisijungti"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth failų siuntimas"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Prisijungti"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Grupinis tinklas"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr "UDP"
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr "RFCOMM"
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr "TCP"
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr "TCS-BIN"
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr "TCS-AT"
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr "OBEX"
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr "HTTP"
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr "WSP"
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr "BNEP"
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr "UPnP/ESDP"
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr "Nuoseklusis prievadas"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Telefoninio ryšio tinklas (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth failų siuntimas"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "ausinė(s)"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Garso šaltinis"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Garso Paslauga"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Tinklo prieigos taškas"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Grupinis tinklas"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "laisvų rankų įranga"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Tinklo prieigos taškas (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Tinklo prieigos taškas (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Grupinis tinklas"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth failų siuntimas"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Garso šaltinis"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Garso Paslauga"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Garso šaltinis"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Pervadinti įrenginį"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Rodyti įrenginio informaciją"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Paslaugos"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Siuntimas"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "įskiepis"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Suporuoti įrenginį"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Ieškoti įrenginių"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Siuntimas"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "įskiepis"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Suporuoti įrenginį"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Ieškoti įrenginių"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Įrenginių tvarkytuvė"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Vėliausi _ryšiai"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Įrenginių tvarkytuvė"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Adapterio nustatymai"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Automatinio prisijungimo profiliai"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Nuosavybinė"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "taip"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "ne"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Informacija"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Rodyti įrenginio informaciją"
 
@@ -1758,34 +2128,35 @@ msgstr "Garso profilis"
 msgid "Select audio profile for PulseAudio"
 msgstr "Nustatyti PulseAudio skirtą garso profilį"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Nuoseklioji jungtis %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Atnaujinti IP adresą"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Telefoninio ryšio nustatymai"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Nuoseklieji prievadai"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nenurodytas"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Prisijungta"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Automatiškai prisijungta prie %(service)s, įrenginyje %(device)s"
@@ -1858,65 +2229,60 @@ msgstr "Tinklo _vartojimas"
 msgid "Shows network traffic usage"
 msgstr "Parodo perduotų duomenų kiekį"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth įjungtas"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth išjungtas"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Leidžia keisti tinklo nustatymus kaip NAP jungtis"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 "Suteikia Dial Up tinklo (DUN) su ModemManager ir NetworkManager palaikymą"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "Prideda meniu punktą su paskutiniais prisijungimais greitam pasiekimui"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maksimalus elementų skaičius"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Maksimalus vėliausių ryšių meniu rodomų elementų skaičius."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Vėliausi _ryšiai"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Prisijungta prie %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Nepavyko prisijungti"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(device)s: %(service)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Šio prisijungimo adapteris neprijungtas"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1924,41 +2290,41 @@ msgstr ""
 "Suteikia palaikymą asmeniniam vietos tinklui (PAN), atsiradusiame "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Suteikia DBus API kitiems programos „Blueman“ komponentams"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Gaunamas failas"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Gaunamas failas %(0)s nuo %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Atmesti"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Priimamas failas"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Priimamas failas %(0)s iš %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Suteikia OBEX failų persiuntimo galimybes"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Nurodyto atsiunčiamų failų katalogo nėra"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1967,33 +2333,31 @@ msgstr ""
 "Įsitikinkite, kad katalogas \"<b>%s</b>\" yra arba sukonfigūruokite jį, "
 "naudodami blueman-services. Iki tol, bus naudojamas numatytasis \"%s\""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Failas priimtas"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Failas %(0)s iš %(1)s sėkmingai priimtas"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Siuntimas nepavyko"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Failo %(0)s siuntimas nepavyko"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Priimti failai"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Priimtas %d failas fone"
@@ -2001,10 +2365,8 @@ msgstr[1] "Priimti %d failai fone"
 msgstr[2] "Priimta %d failų fone"
 msgstr[3] "Priimta %d failų fone"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Priimtas dar %d failas fone"
@@ -2019,27 +2381,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Prideda įprastinius meniu elementus į būsenos ikonos meniu"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "Nu_statyti naują įrenginį"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Siųsti _failus į įrenginį"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "Į_renginiai"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_teriai"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "įskiepis"
 
@@ -2051,27 +2413,27 @@ msgstr "Suteikia atpažinimo priemones BlueZ tarnybai"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Prideda išėjimo iš programėlės punktą"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Pateikia paprastą DHCP klientą Bluetooth PAN ryšiams."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth tinklas"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Prievadas %(0)s gavo IP adresą %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Nepavyko gauti IP adreso per %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2080,7 +2442,7 @@ msgstr ""
 "Bandoma gauti IP adresą ties %s\n"
 "Prašome palaukti…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2088,14 +2450,12 @@ msgstr ""
 "Prideda Bluetooth aktyvumo indikatorių ir etiketėje rodo prisijungimų "
 "skaičių."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth aktyvus"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Aktyvus Prisijungimas</b>"
@@ -2103,11 +2463,16 @@ msgstr[1] "<b>%d Aktyvūs Prisijungimai</b>"
 msgstr[2] "<b>%d Aktyvių prisijungimų</b>"
 msgstr[3] "<b>%d Aktyvių prisijungimų</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth išjungtas"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Būsenos indikatoriui naudoja libappindicator"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2115,34 +2480,35 @@ msgstr ""
 "Suteikia meniu punktą, kurio pagalba galima padaryti numatytąjį Bluetooth "
 "adapterį laikinai matomu (jei jis nustatytas nematomu)"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Matomumo laikas"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Laikas (sekundėmis) per kurį adapteris bus matomas"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Padaryti M_atomu"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Padaryti numatytąjį adapterį laikinai matomu"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Matomas… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Sukuria meniu ir API, suteikiat kitiems papildiniams galimybę jį valdyti"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2151,22 +2517,22 @@ msgstr ""
 "Sėkmingai prisijungta prie <b>DUN</b> paslaugos per <b>%(0)s.</b>\n"
 "Tinkas dabar prieinamas per <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "Suteikia galimybę prisijungti prie interneto naudojantis DUN profilį."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Įprastinė SPP profilio ryšių doroklė, leidžia vykdyti individualizuotus "
 "veiksmus"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Ryšio metu vykdomas scenarijus"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2184,11 +2550,11 @@ msgstr ""
 "\n"
 "Įrenginiui atsijungus, scenarijui bus siunčiamas HUP signalas</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Nuoseklusis prievadas prijungtas"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2196,11 +2562,11 @@ msgstr ""
 "Nuoseklaus prievado (SPP) paslauga, įrenginyje <b>%s</b>, bus prieinama per "
 "<b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Nuosekliojo prievado ryšio scenarijus nepavyko"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2209,37 +2575,37 @@ msgstr ""
 "Iškilo problemų paleidžiant scenarijų %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Valdo „Bluetooth“ adapterio maitinimo būsenas"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatinis įjungimas"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automatiškai įjungti adapterius"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Išjungti Bluet_ooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Išjungti visus adapterius"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Į_jungti Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Įjungti visus adapterius"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2247,21 +2613,20 @@ msgstr ""
 "Laikinai pristabdo ekrano užsklandą, kai yra prijungiamas bluetooth žaidimų "
 "manipuliatorius."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Tinklas"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Neteisingas IP adresas"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP adresas nesutaria su sąsaja %s, kuri turi tą patį adresą"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2271,8 +2636,8 @@ msgstr ""
 "IP adresas persikloja su %s sąsajos potinkliu, kurio konfigūracija %s/%s\n"
 "Tai gali sukelti netinkamą tinklo elgseną"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Šiuo metu nepalaikoma"
 
@@ -2288,24 +2653,14 @@ msgstr "Programėlės failų persiuntimo įskiepis yra išjungtas"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Nustatyti „Bluetooth“ adapterio savybes"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "įskiepis"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman „Bluetooth“ tvarkytuvė"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2347,6 +2702,37 @@ msgstr "Nustatyti RfKill būseną"
 msgid "Setting RfKill State requires privileges"
 msgstr "RfKill būsenos nustatymas reikalauja privilegijų"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Įveskite PIN kodą"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Įveskite slaptą frazę"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Nuoseklioji jungtis (port) prijungta prie %s"
+
+#~ msgid "palm"
+#~ msgstr "palm delninukas"
+
+#~ msgid "isdn"
+#~ msgstr "visuminių paslaugų tinklo adapteris"
+
+#~ msgid "headset"
+#~ msgstr "ausinė(s)"
+
+#~ msgid "handsfree"
+#~ msgstr "laisvų rankų įranga"
+
+#~ msgid "unknown"
+#~ msgstr "Nežinoma"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "„Bluetooth“ įrenginiai"
 
@@ -2369,11 +2755,6 @@ msgstr "RfKill būsenos nustatymas reikalauja privilegijų"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Pašalinti..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Prisijungti"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/lv.po
+++ b/po/lv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Latvian (http://www.transifex.com/mate/MATE/language/lv/)\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Redzamība</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Paslēpts"
 
@@ -67,8 +67,8 @@ msgstr "_Ierīce"
 msgid "_View"
 msgstr "_Skats"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Palīdzība"
 
@@ -81,7 +81,7 @@ msgstr "Meklēt tuvējās iekārtas"
 msgid "Search"
 msgstr "Meklēt"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Izveidot pāri ar iekārtu"
 
@@ -90,17 +90,17 @@ msgstr "Izveidot pāri ar iekārtu"
 msgid "Pair"
 msgstr "Pārot"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Pievienot/Noņemt iekārtu kā uzticamu"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Uzticēties"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Palaist uzstādīšanas vedni šajai iekārtai"
 
@@ -109,7 +109,7 @@ msgstr "Palaist uzstādīšanas vedni šajai iekārtai"
 msgid "Setup..."
 msgstr "Uzstādīt..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Noņemt iekārtu no zināmo iekārtu saraksta"
 
@@ -284,7 +284,12 @@ msgstr "Nav norādīts"
 msgid "<b>Author:</b>"
 msgstr "<b>Autors:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -346,7 +351,7 @@ msgstr "_Pārstatīt"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth vajag būt ieslēgtam, lai adaptera pārvaldnieks spētu strādāt"
 
@@ -354,33 +359,31 @@ msgstr "Bluetooth vajag būt ieslēgtam, lai adaptera pārvaldnieks spētu strā
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth Adapteri"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Vienmēr"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minūtes"
 msgstr[1] "%d Minūte"
 msgstr[2] "%d Minūtes"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth vajag būt ieslēgtam, lai iekārtu pārvaldnieks spētu strādāt"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Pieslēgšanās BlueZ neizdevās"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -394,48 +397,48 @@ msgstr ""
 msgid "Searching"
 msgstr "Meklē"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth Asistents"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adaptera Iestatījumi"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Failu Sūtītājs"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth Failu Pārsūtīšana"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Savienojas"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obext nav pieejams"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Atceļ"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Sūta Failu"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -443,94 +446,86 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Faila %s sūtīšanas laikā notikusi kļūda"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Izlaist"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Mēģināt vēlreiz"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Radusies kļūda"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokālie Servisi"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Pārošanas pieprasījums priekš %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth Autentifikācija"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Ievadiet PIN kodu priekš autentifikācijas"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Ievadiet PIN kodu"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Ievadīt atslēgu priekš autentifikācijas"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Ievadīt atslēgu"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Pārošanas atslēga priekš"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Pārošanas PIN kods priekš"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Pārošanas pieprasījums priekš:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Apstiprināt vērtību priekš autentifikācijas"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Apstiprināt"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Noliegt"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Autorizācijas pieprasījums priekš:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Serviss:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Vienmēr pieņemt"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Pieņemt"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -561,247 +556,245 @@ msgstr "Jā"
 msgid "No"
 msgstr "Nē"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Paziņot par Problēmu"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Ierīcu Pārvaldnieks"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Parādīt _Rīkjoslu"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Parādīt _Statusa joslu"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "S_praudņi"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokālie Servisi"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Servisu Iestatījumi"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Meklēt"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Adaptera Iestatījumi"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "nekategorizēts"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Uzticams</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Vājš"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Zem-optimāls"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimāls"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Daudz"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Pārāk daudz"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Zems"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Augsts"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Ļoti Augsts"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Veiksmīgi!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Seriālais ports savienots ar %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Neizdevās"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Savienojums nav izdevies:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Savienojas"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Atvienojas..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Savienoties Ar:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Atvienoties:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Nosūtīt _Failu..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Pārot"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Uzticēties"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Neuzticēties"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Pārsaukt iekārtu"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Aizvākt"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Atcelt Darbību"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Datu aktivitātes indikācija"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Neuzticēties"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Izvēlēties Iekārtu"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Vairāk"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Kristaps https://launchpad.net/~retail"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -809,17 +802,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr "GSM Iestatījumi"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Spraudņi"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -827,7 +820,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -835,882 +828,1257 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Adapteru izvēle"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Atvienojas..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "nekategorizēts"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Tīkla Pieejas Punkts"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "darbvirsma"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "serveris"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "klēpjdators"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "rokas"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "plaukstas"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobīli"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "bezvadu"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "viedtālrunis"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modems"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obext nav pieejams"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "austiņas"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "nezināms"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofons"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Audio Avots"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Audio Avots"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Audio Avots"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tastatūra"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "rādīšanas"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tastatūra"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "rādīšanas"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Savienot"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Savienot"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Savienot"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Savienot"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth Failu Pārsūtīšana"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Savienot"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth Failu Pārsūtīšana"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth Failu Pārsūtīšana"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Grupas Tīkls"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth Failu Pārsūtīšana"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Savienot"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Savienot"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth Failu Pārsūtīšana"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Savienot"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Grupas Tīkls"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Serial Porti"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Iezvanpieejas Tīklošana (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth Failu Pārsūtīšana"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "austiņas"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Audio Avots"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Tīkla Pieejas Punkts"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Grupas Tīkls"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Tīkla Pieejas Punkts (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Tīkla Pieejas Punkts (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Grupas Tīkls"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth Failu Pārsūtīšana"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Audio Avots"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Audio Avots"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Pārsaukt iekārtu"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Lokālie Servisi"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Pārraide"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "sīklietotne"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Lokālie Servisi"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Meklēt tuvējās iekārtas"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Pārraide"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "sīklietotne"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Local Services"
-msgid "Primary Service"
-msgstr "Lokālie Servisi"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Meklēt tuvējās iekārtas"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Ierīcu Pārvaldnieks"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Pēdējie _Savienojumi"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Ierīcu Pārvaldnieks"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Adaptera Iestatījumi"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "jā"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nē"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1735,34 +2103,35 @@ msgstr "Audio Profils"
 msgid "Select audio profile for PulseAudio"
 msgstr "Izvēlēties audio profilui priekš PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Izvēlēties Portu %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Atjaunot IP Adresi"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Iezvanpieejas Iestatījumi"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Serial Porti"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nenorādīts"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Savienots"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1830,147 +2199,138 @@ msgstr "Tīkla _Lietojums"
 msgid "Shows network traffic usage"
 msgstr "Parāda tīkla trafika lietojumu"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Ieslēgts"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth Atslegts"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Menedžēt lokālos tīkla servisus, piemēram, NAP tiltus"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Pēdējie _Savienojumi"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Savienots ar %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Neizdevās savienot"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s uz %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adapteri priekš šī savienojuma nav pieejami"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Nodrošina DBus API priekš citām Blueman komponentēm"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Ienākošie Bluetooth faili"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Ienākošs fails %(0)s no %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Noraidīt"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Saņem failu"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Saņem failu %(0)s no %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Fails saņemts"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Fails %(0)s no %(1)s veiksmīgi saņemts"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Pārsūtīšana neizdevās"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Faila %(0)s pārsūtīšana neizdevas"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Faili saņemti"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Fonā saņemti %d faili"
 msgstr[1] "Fonā saņemts %d fails"
 msgstr[2] "Fonā saņemti %d faili"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Fonā saņemti vēl %d faili"
@@ -1984,27 +2344,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Nosūtīt _Failus uz Iekārtu"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Iekārtas"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adapt_teri"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "sīklietotne"
 
@@ -2016,110 +2376,114 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth Tīkls"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interfeiss %(0)s savienots ar IP adresi %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Nevarēja iegūt IP adresi uz %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth Aktīvs"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Aktīvi Savienojumi</b>"
 msgstr[1] "<b>%d Aktīvs Savienojums</b>"
 msgstr[2] "<b>%d Aktīvi Savienojumi</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth Atslegts"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Izmanto libappindicator, lai parādītu status ikonu"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Parādīt Redza_mu"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2130,21 +2494,21 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Seriālais ports savienots"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr "Seriālā porta serviss uz ierīces <b>%s</b> tagad ir pieejams <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Seriālā porta savienojuma skripts neizdevās"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2153,58 +2517,57 @@ msgstr ""
 "Radās problēma palaižot skriptu %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Kontrol Bluetooth adaptera jaudas stāvokļus"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automātiska ieslēgšana"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automātiski ieslēdz adapterus"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Izslēgt Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Izslēgt visus adapterus"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Ieslēgt Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Ieslēgt visus adapterus"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "Atslēdz ekrānsaudzētāju, kamēr ir pieslēgts bluetooth spēļu kontrolieris."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Tīkls"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Nepareiza IP adrese"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP adrese konfliktē ar interfeisu %s, kuram ir tāda paša adrese"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2212,8 +2575,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Nav atbalstīts ar pašreizējiem iestatījumiem"
 
@@ -2227,40 +2590,26 @@ msgstr "Sīkrīka pārsūtīšanas servisa spraudnis ir atslēgts"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Adapteri"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "sīklietotne"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Bluetooth Ieslēgts"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Ieslēgts"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth Iekārtas"
 
@@ -2296,6 +2645,31 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Ievadiet PIN kodu"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Ievadīt atslēgu"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Seriālais ports savienots ar %s"
+
+#~ msgid "palm"
+#~ msgstr "plaukstas"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "austiņas"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "nezināms"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth Iekārtas"
 
@@ -2318,11 +2692,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Noņemt..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Savienot"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Bluetooth vajag būt ieslēgtam, lai failu sūtīšana spētu strādāt"

--- a/po/mk.po
+++ b/po/mk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Macedonian (http://www.transifex.com/mate/MATE/language/mk/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Подесувања за видливост</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Сокриено"
 
@@ -65,8 +65,8 @@ msgstr "_Уред"
 msgid "_View"
 msgstr "_Поглед"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Помош"
 
@@ -79,7 +79,7 @@ msgstr "Пребарај уреди во близина"
 msgid "Search"
 msgstr "Пребарувај"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Креирај спојување со уредот"
 
@@ -88,17 +88,17 @@ msgstr "Креирај спојување со уредот"
 msgid "Pair"
 msgstr "Спојување"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Штиклрај/одштиклирај го овој уред како сигурен"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Сигурен"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Стартувај го помошникот за подесување за овој уред"
 
@@ -107,7 +107,7 @@ msgstr "Стартувај го помошникот за подесување �
 msgid "Setup..."
 msgstr "Подесување..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Отстрани го овој уред од листата на познати уреди"
 
@@ -288,7 +288,12 @@ msgstr "Не е назначено"
 msgid "<b>Author:</b>"
 msgstr "<b>Автор:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -350,7 +355,7 @@ msgstr "_Ресетирај"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Блутутот мора да биде вклучен за управувачот со адаптерот да работи"
 
@@ -358,32 +363,30 @@ msgstr "Блутутот мора да биде вклучен за управу
 msgid "Bluetooth Adapters"
 msgstr "Блутут адаптери"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Секогаш"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Минута"
 msgstr[1] "%d Минути"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Блутутот мора да биде вклучен за управувачот со уредот да работи"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Поврзувањето со BlueZ е неуспешно"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -397,142 +400,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Пребарување"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Блутут асистент"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Пренос на податоци преку блутут"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Поврзување"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Откажување"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Испраќање датотека"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Се појави грешка при испраќање на датотека %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Прескокни"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Обиди се повторно"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Се појави грешка"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Локални сервиси"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Барање за поврзување за %s "
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Блутут проверка"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Внеси го PIN кодот за проверка:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Внеси PIN код"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Внеси лозинка за проверка:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Внеси лозинка"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Барање за спојување за:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Потврди ја вредноста за проверка:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Потврди"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Одбиј"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Барање за проверка за:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Сервис:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Секогаш прифати"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Прифати"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -563,241 +558,241 @@ msgstr "Да"
 msgid "No"
 msgstr "Не"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Пријави проблем"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Управувач со уреди"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Додатоци"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Локални сервиси"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "Барај"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "Некатегоризирано"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Сигурно</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Слабо"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Под-оптимално"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Оптимално"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Повеќе"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Премногу"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Ниско"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Високо"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Многу високо"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Успешно!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Серискиот порт е поврзан со %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Неуспешно"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Врската е неуспешна:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Поврзување"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Одврзување..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Одврзи го уредот на сила"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Поврзи се со:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Одврзување:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Испрати _датотека..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Спојување"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Сигурно"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Несигурно"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Отстрани"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Откажи ја операцијата"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Приказ на активност на податоци"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Вкупно примени податоци и степен на пренос"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Вкупно испратени податоци и степен на пренос"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Несигурно"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Одбери уред"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Повеќе"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr "Арангел Ангов <ufo@linux.net.mk>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -805,17 +800,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr "GSM подесувања"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Додатоци"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "За меѓузависностите"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -826,7 +821,7 @@ msgstr ""
 "%(1)s</b> исто така ќе се исклучи <b>\"%(0)s\"</b>.\n"
 "Да продолжам?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -837,880 +832,1255 @@ msgstr ""
 "%(1)s</b> ќе го исклучи <b>%(0)s</b>.\n"
 "Да продолжам?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Одбирање на адаптер"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Одврзување..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "Некатегоризирано"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Точка за пристап на мрежата"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "Десктоп компјутер"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "сервер"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "лаптоп"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "Мобилен уред"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "палм уред"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "мобилен телефон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "безжичен уред"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "Паметен телефон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "модем"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "ИСДН"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+msgid "Not available"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "слушалки"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "интерфон слушалки"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "непознато"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "микрофон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Аудио извор"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Аудио извор"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Аудио извор"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "тастатура"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "уред за покажување"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "тастатура"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "уред за покажување"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Поврзи се"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Поврзи се"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Поврзи се"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Поврзи се"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Пренос на податоци преку блутут"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Поврзи се"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Пренос на податоци преку блутут"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Пренос на податоци преку блутут"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Групна мрежа"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Пренос на податоци преку блутут"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Поврзи се"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Поврзи се"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Пренос на податоци преку блутут"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Поврзи се"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Групна мрежа"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Сериски портови"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Dialup мрежа (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Пренос на податоци преку блутут"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "слушалки"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Аудио извор"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Аудио Sink"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Точка за пристап на мрежата"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Групна мрежа"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "интерфон слушалки"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Точка за пристап на мрежата (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Точка за пристап на мрежата (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Групна мрежа"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Пренос на податоци преку блутут"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Аудио извор"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Аудио Sink"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Аудио извор"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr ""
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Локални сервиси"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Пренос"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "аплет"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Локални сервиси"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Пребарај уреди во близина"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Пренос"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "аплет"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Local Services"
-msgid "Primary Service"
-msgstr "Локални сервиси"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Пребарај уреди во близина"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Управувач со уреди"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Скорешни _врски"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Управувач со уреди"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "да"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "не"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1735,34 +2105,35 @@ msgstr "Аудио профил"
 msgid "Select audio profile for PulseAudio"
 msgstr "Одбери аудио профил за PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Сериски порт %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Обнови ја IP адресата"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Dialup подесувања"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Сериски портови"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Неназначено"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Поврзано"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1830,28 +2201,23 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr "Прикажува искористеност на мрежниот сообраќај"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Блутутот е овозможен"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Блутутот е оневозможен"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Управува со локалните мрежни сервиси, како NAP мостовите"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1859,38 +2225,38 @@ msgstr ""
 "пристап"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Максимум ставки"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Ќе биде прикажано максималниот број на ставки на менито за скорешни врски."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Скорешни _врски"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Поврзано со %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Неуспешно поврзување"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s на %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Адаптерот за оваа врска е недостапен"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1898,83 +2264,79 @@ msgstr ""
 "Обезбедува подршка за Лична област за мрежно работење (PAN) претставена во "
 "Управувачот со мрежа 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Обезбедува DBus API за други Blueman компоненти"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Дојдовна датотека преку блутут"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Дојдовна датотека %(0)s од %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Одбиј"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Примање датотека"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Примање датотека %(0)s од %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Обезбедува OBEX датотеки за способност за пренос"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Датотеката е примена"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Датотеката %(0)s од %(1)s е успешно примена"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Преносот е неуспешен"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Преносот на датотеката %(0)s е неуспешен"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Датотеките се примени"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Датотеката %d е примена во позадина"
 msgstr[1] "Датотеките %d се примени во позадина"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Примена %d повеќе датотека во позадина"
@@ -1987,27 +2349,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Додава стандардни мени ставки на статусната мени икона"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Испрати _датотеки на уредот"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Уреди"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Адаптери"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "аплет"
 
@@ -2019,34 +2381,34 @@ msgstr "Обезбедува лозинка и сервиси за провер�
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Додава мени ставка за излез за прекин на аплетот"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Обезбедува основен dhcp клиент за блутут PAN врски."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Блутут мрежа"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Интерфејс %(0)s поврзи со IP адресата %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Неуспешно добивање на IP адреса на %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2054,24 +2416,27 @@ msgstr ""
 "Додава индикација на статусната икона кога блутутот е активен и го покажува "
 "бројот на врски во алатката со објаснување."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Блутутот е активен"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Активна врска</b>"
 msgstr[1] "<b>%d Активни врски</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Блутутот е оневозможен"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Го користи libappindicator за да ја прикаже статусната икона"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2079,33 +2444,34 @@ msgstr ""
 "Обезбедува мени ставка за да се направи стандардниот адаптер привремено "
 "видлив кога стандардно е подесен во невидлив"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Време за пронаоѓање"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Време во секунди колку ќе трае модот на пронаоѓање"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Направи го видлив"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Направи го стандардниот адаптер привремено видлив"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "Обезбедува мени за аплетот и API за другите плагини да го манипулираат"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2114,22 +2480,22 @@ msgstr ""
 "Успешно поврзано на <b>DUN</b> сервисот на <b>%(0)s.</b>\n"
 "Мрежата е сега достапна преку <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "Обезбедува основна подршка за поврзување на интернет преку DUN профил."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Стандарден ракувач за SPP профил врска, дозволува извршување сопствени "
 "наредби."
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Скрипта која се извршува при врска"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2146,11 +2512,11 @@ msgstr ""
 "uuid16 се вратени како листи раздвоени со заприки\n"
 "При исклучување на уредот скриптата ќе прати HUP сигнал</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Серискиот порт е поврзан"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2158,11 +2524,11 @@ msgstr ""
 "Сервисот на серискиот порт на уредот <b>%s</b> сега ќе биде достапен преку "
 "<b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Скриптата на конекцијата на серискиот порт е неуспешна"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2171,57 +2537,56 @@ msgstr ""
 "Проблем при стартување на скриптата %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Ја контролира енергетската состојба на блутут адаптерот"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Исклучи ги сите адаптери"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Вклучи ги сите адаптери"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Мрежа"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Неважечка IP адреса"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP адресата е во конфликт со интерфејсот %s кој ја има истата адреса"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2229,8 +2594,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr " Не е подржано со ова подесување"
 
@@ -2244,40 +2609,26 @@ msgstr "Плагинот на аплетот за пренос сервис е �
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Блутут адаптери"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "аплет"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "Блутутот е овозможен"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Блутутот е овозможен"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Блутут уреди"
 
@@ -2313,6 +2664,31 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Внеси PIN код"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Внеси лозинка"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Серискиот порт е поврзан со %s"
+
+#~ msgid "palm"
+#~ msgstr "палм уред"
+
+#~ msgid "isdn"
+#~ msgstr "ИСДН"
+
+#~ msgid "headset"
+#~ msgstr "слушалки"
+
+#~ msgid "handsfree"
+#~ msgstr "интерфон слушалки"
+
+#~ msgid "unknown"
+#~ msgstr "непознато"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Блутут уреди"
 
@@ -2328,11 +2704,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Отстрани..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Поврзи се"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr "Блутутот мора да биде вклучен за испраќањето на датотеки да работи"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Marathi (http://www.transifex.com/mate/MATE/language/mr/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>दृश्यता सेटिंग</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "अदृश्य "
 
@@ -65,8 +65,8 @@ msgstr "साधन (_D)"
 msgid "_View"
 msgstr "दृश्य(_V)"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "मदत(_H)"
 
@@ -79,7 +79,7 @@ msgstr "नजीकचे साधन शोधत आहे..."
 msgid "Search"
 msgstr "शोधा"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "साधनाबरोबर जोडणी तयार करा"
 
@@ -88,17 +88,17 @@ msgstr "साधनाबरोबर जोडणी तयार करा"
 msgid "Pair"
 msgstr "जोडी"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "साधनाची विश्वासू अशी नोंद करा/ नोंद खोडा"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "विश्वासर्ह"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "साधनाचा प्रस्थापना सहकारी सुरु करा"
 
@@ -107,7 +107,7 @@ msgstr "साधनाचा प्रस्थापना सहकारी 
 msgid "Setup..."
 msgstr "प्रस्थापना..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "या साधनाला माहितीतल्या साधनांच्या यादीतून काढून टाका"
 
@@ -286,7 +286,12 @@ msgstr "दर्शवले नाही"
 msgid "<b>Author:</b>"
 msgstr "<b>लेखक:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -348,7 +353,7 @@ msgstr "स्वच्छ करा (_R)"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -356,32 +361,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth अडॅप्टर"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "नेहमी"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d मिनिट"
 msgstr[1] " %d मिनिटे"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "ब्लुझशी जुळवणी झाली नाही"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -392,142 +395,134 @@ msgstr ""
 msgid "Searching"
 msgstr "शोधत आहे"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth फाइल स्थानांतरण"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "जुळवत आहे"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "रद्द करत आहे"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "फाइल पाठवित आहे"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "फाइल '%s' पाठवताना त्रुटी आढळली."
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr ""
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr ""
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "चूक उद्भवली"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "स्थानिक सेवा"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "%s करीता जोडी बनवण्याची विनंती"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "ब्लूटूथ अधिप्रमाणन"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "अधिप्रमानासाठी पिन कोड टाका:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "PIN द्या"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "अधिप्रमानासाठी पासकी टाका:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "पासकी टाका"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "जोडी बनवण्याची विनंती:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "अधिप्रमानासाठी मूल्याची पुष्टी करा"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "पुष्टी करा"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "अमान्य"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "ओळख पटवण्याची विनंती यांच्यासाठी:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "सेवा:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "नेहमी स्वीकारा"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "स्वीकार"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -558,243 +553,243 @@ msgstr "होय"
 msgid "No"
 msgstr "नाही"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "अडचणीची माहिती द्या (_R)"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "साधन व्यवस्थापक"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "प्लगइन (_P)"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "स्थानिक सेवा(_L)"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "शोधा (_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "अवर्गीकृत"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>विश्वासू</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "निकृष्ट"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "कमी-इष्टतम"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "इष्टतम"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "खूप"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "खूप जास्त"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "कमी"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "जास्त"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "खूपच जास्त"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "सफलता!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "सीरिअल पोर्ट ला %s जोडलेले आहे"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "अपयशी"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "जुळणी अयशस्वी:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "जुळवत आहे"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "जुळवणी मोडत आहे..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "साधन जबरदस्तीने काढून टाका"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>जोडणी करा:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>जोडणी तोडा:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "एक फाईल पाठवा (_F)..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "जोडी (_P)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "विश्वासू बनवा (_T)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "विश्वासू यादीतून काढा (_U)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "काढून टाका"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "कार्यपद्धती रद्द करा "
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "डेटा हालचाल निर्देशन"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "एकूण डेटा मिळाला आणि किती वेगाने मिळाला"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "एकूण डेटा पाठवला आणि किती वेगाने पाठवला"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "अविश्वासू बनवा"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "साधन निवडा"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "अजून"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "translator-credits\n"
 "वैभव दळवी (vaibhav.dlv@gmail.com)"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -802,17 +797,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr "GSM सेटिंग"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "प्लगईन"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "आश्रितता वाद"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -823,7 +818,7 @@ msgstr ""
 "<b>\"%(0)s\"</b> पण अनलोड होईल.\n"
 "करायचे?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -834,880 +829,1255 @@ msgstr ""
 "%(0)s</b> अनलोड होईल.\n"
 "करायचे?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "अडॅप्टर निवड"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "जुळवणी मोडत आहे..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "अवर्गीकृत"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Network Access Point"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "डेस्कटॉप"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "सर्व्हर"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "लॅपटॉप"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "हातात मावणारे"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "पाम"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "सेलुलर "
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "कॉर्डलेस"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "स्मार्ट फोन "
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "मोडेम"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+msgid "Not available"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "हेडसेट"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "अपरिचीत"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "ध्वनीविस्तारक"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "ध्वनी स्त्रोत"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "ध्वनी स्त्रोत"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "ध्वनी स्त्रोत"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "कळफलक"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "कडे केंद्रित"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "कळफलक"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "कडे केंद्रित"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "जुळवणी करा"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "जुळवणी करा"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "जुळवणी करा"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "जुळवणी करा"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth फाइल स्थानांतरण"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "जुळवणी करा"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth फाइल स्थानांतरण"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth फाइल स्थानांतरण"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "गट संजाळ"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth फाइल स्थानांतरण"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "जुळवणी करा"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "जुळवणी करा"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth फाइल स्थानांतरण"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "जुळवणी करा"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "गट संजाळ"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "सीरिअल पोर्ट"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Dialup Networking (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth फाइल स्थानांतरण"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "हेडसेट"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "ध्वनी स्त्रोत"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "ऑडियो सिंक"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Network Access Point"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "गट संजाळ"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Network Access Point (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "गट संजाळ"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth फाइल स्थानांतरण"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "ध्वनी स्त्रोत"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "ऑडियो सिंक"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "ध्वनी स्त्रोत"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr ""
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "स्थानिक सेवा"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "स्थानांतरन"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr " एप्लेट"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "स्थानिक सेवा"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "नजीकचे साधन शोधत आहे..."
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "स्थानांतरन"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr " एप्लेट"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Local Services"
-msgid "Primary Service"
-msgstr "स्थानिक सेवा"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "नजीकचे साधन शोधत आहे..."
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "साधन व्यवस्थापक"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "अलीकडच्या जोडण्या (_C)"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "साधन व्यवस्थापक"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "योय"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "नाही"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1732,34 +2102,35 @@ msgstr "ऑडियो प्रोफाइल"
 msgid "Select audio profile for PulseAudio"
 msgstr "पल्सऑडियो साठी प्रोफाइल निवडा"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "सीरिअल पोर्ट %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "IP पत्ता नुतनीकरण करा"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "डायलअप संयोजना"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "सीरिअल पोर्ट"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "अनिर्दिष्ट "
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "जुळले"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1824,64 +2195,59 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr "संजाळ वाहतूक वापर दाखवते "
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "ब्लूटूथ कार्यान्वीत आहे"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "ब्लूटूथ अकार्यान्वीत आहे"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "NAP bridges सारख्या स्थानिक संजाळ सेवा सांभाळा "
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "एका मेनू घटकामध्ये शेवटच्या वापरलेल्या जोडण्या झटपट वापरासाठी पुरवतो"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "सर्वाधिक घटक "
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "शेवटच्या जोडण्यांची कमाल संख्या जे मेनू दाखवेल."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "अलीकडच्या जोडण्या (_C)"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "%s ला जुळणी झाली"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "जुळणी होऊ शकली नाही"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s, %(device)s वर "
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "या जोडणीसाठी अडॅप्टर उपलब्ध नाही"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1889,83 +2255,79 @@ msgstr ""
 "NetworkManager 0.8 मध्ये परिचय केलेल्या Personal Area Networking (PAN) ला उपलब्ध "
 "करतो"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "ब्लुमॅन घटकांसाठी DBus API देतो "
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "ब्लूटूथने फाईल येत आहे"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "फाईल %(0)s, %(1)s कडून येत आहे"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "नकार"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "फाईल प्राप्त करीत आहे"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "फाईल %(0)s, %(1)s कडून प्राप्त करीत आहे"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "OBEX फ़ाइल अदलाबदली क्षमता उपलब्ध करून देतो"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "फाईल पूर्णपणे प्राप्त झाली"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "फाईल %(0)s, %(1)s कडून यशस्वीरीत्या प्राप्त झाली"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "फाईल बदलीमध्ये त्रुटी आली"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "फाईल %(0)s च्या बदलीमध्ये त्रुटी आली"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "फाईल्स प्राप्त झाल्या"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "%d फाईल पार्श्वभूमीमध्ये प्राप्त झाली"
 msgstr[1] "%d फाईल्स पार्श्वभूमीमध्ये प्राप्त झाल्या"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "अजून %d फाईल पार्श्वभूमीमध्ये प्राप्त झाली"
@@ -1978,27 +2340,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "साधनाला फाईल पाठवा (_F)"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "साधने(_D)"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "अॅङॅप्टर (_T)"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr " एप्लेट"
 
@@ -2010,109 +2372,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "ब्लूटूथ संजाळ"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "ब्लूटूथ कार्यक्षम"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d कार्यक्षम जुळणी </b>"
 msgstr[1] "<b>%d कार्यक्षम जुळण्या </b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "ब्लूटूथ अकार्यान्वीत आहे"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "दृश्य रीत चालण्याचा कालावधी (सेकंदात)"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "दृश्य बनवा (_M)"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "मुलभूत अडॅप्टर तात्पुरता दृश्य करा"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "जुळणी झाल्यावर अमलात आणायची स्क्रिप्ट "
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2123,78 +2489,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "सीरिअल पोर्ट जोडलेले आहे"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "सीरिअल पोर्ट जुळणी स्क्रिप्ट चालली नाही"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "सर्व अडॅप्टर बंद करा"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "सर्व अडॅप्टर सुरु करा"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "संजाळ"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "अवैध IP पत्ता"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2202,8 +2567,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2217,40 +2582,26 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth अडॅप्टर"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr " एप्लेट"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Blueman Bluetooth Manager"
 msgstr "ब्लूटूथ कार्यान्वीत आहे"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "ब्लूटूथ कार्यान्वीत आहे"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Bluetooth साधन"
 
@@ -2286,6 +2637,31 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "PIN द्या"
+
+#~ msgid "Enter passkey"
+#~ msgstr "पासकी टाका"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "सीरिअल पोर्ट ला %s जोडलेले आहे"
+
+#~ msgid "palm"
+#~ msgstr "पाम"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "हेडसेट"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "अपरिचीत"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth साधन"
 
@@ -2301,11 +2677,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "काढून टाका (_R)..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "जुळवणी करा"
 
 #~ msgid "Send files to this device"
 #~ msgstr "साधन करीता फाइल पाठवा"

--- a/po/ms.po
+++ b/po/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Malay (http://www.transifex.com/mate/MATE/language/ms/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Tetapan Ketampakan</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Tersembunyi"
 
@@ -65,8 +65,8 @@ msgstr "Pe_ranti"
 msgid "_View"
 msgstr "_Lihat"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Bantuan"
 
@@ -79,7 +79,7 @@ msgstr "Gelintar peranti berhampiran"
 msgid "Search"
 msgstr "Gelintar"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Cipta perpasangan dengan peranti ini"
 
@@ -88,17 +88,17 @@ msgstr "Cipta perpasangan dengan peranti ini"
 msgid "Pair"
 msgstr "Pasang"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Tanda/Buang tanda peranti ini sebagai dipercayai"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Percaya"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Jalankan pembantu persediaan untuk peranti ini"
 
@@ -107,7 +107,7 @@ msgstr "Jalankan pembantu persediaan untuk peranti ini"
 msgid "Setup..."
 msgstr "Persediaan..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Buang peranti ini dari senarai peranti diketahui"
 
@@ -288,7 +288,12 @@ msgstr "Tidak dinyatakan"
 msgid "<b>Author:</b>"
 msgstr "<b>Pengarang:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -350,7 +355,7 @@ msgstr "T_etap Semula"
 msgid "Send note"
 msgstr "Hantar nota"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth perlu dihidupkan supaya pengurus penyesuai berfungsi"
 
@@ -358,31 +363,29 @@ msgstr "Bluetooth perlu dihidupkan supaya pengurus penyesuai berfungsi"
 msgid "Bluetooth Adapters"
 msgstr "Penyesuai Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Sentiasa"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minit"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Penyesuai"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth perlu dihidupkan supaya pengurus peranti dapat berfungsi"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Sambungan ke BlueZ gagal"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -396,142 +399,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Menggelintar"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Pembantu Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Keutamaan Penyesuai"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Pengirim Fail"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Pemindah Fail Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Menyambung"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd tidak tersedia"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Gagal automulakan perkhidmatan obex. Pastikan daemon obex berjalan dahulu"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Membatalkan"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Menghantar Fail"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Ralat berlaku ketika menghantar fail %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Langkau"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Cuba lagi"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Ralat berlaku"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Perkhidmatan Setempat"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Permintaan perpasangan untuk %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Pengesahihan Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Masukkan kod PIN untuk pengesahihan:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Masukkan kod PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Masukkan kunci laluan untuk pengesahihan:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Masukkan kunci laluan"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Perpasangan untuk:"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Kod PIN perpasangan untuk"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Permintaan perpasangan untuk:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Sahkan nilai untuk pengesahihan:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Sahkan"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Nafi"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Permintaan kebenaran untuk:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Perkhidmatan:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Sentiasa terima"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Terima"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -566,247 +561,244 @@ msgstr "Ya"
 msgid "No"
 msgstr "Tidak"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "La_porkan Masalah"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Pengurus Peranti"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Tunjuk Pa_lang Alat"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Tunjuk Palang _Status"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Isih Mengikut"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nama"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Ditambah"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Menurun"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Pemalam"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Perkhidmatan _Setempat"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Keutamaan Perkhidmatan"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Gelintar"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Keutamaan Penyesuai"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Keluar"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "tiada kategori"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Dipercayai dan Berpasangan</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Berpasangan</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Dipercayai</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Lemah"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Sub-optimum"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimum"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Memadai"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Terlalu Memadai"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Rendah"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Tinggi"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Sangat Tinggi"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Berjaya!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Port Serial bersambung dengan %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Gagal"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Sambungan Gagal:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Menyambung"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Pemutusan Gagal:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Memutuskan..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Sambung auto sambung profil sumber A2DP, sinki A2DP, dan HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Putus dari peranti secara paksa"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Sambung Ke:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Terputus:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Hantar satu _Fail..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Pasang"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "Per_cayai"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "T_idak Percayai"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Nama semula peranti"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Buang"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Batal Operasi"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Petunjuk aktiviti data"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Jumlah data diterima dan kadar pemindahan"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Jumlah data dihantar dan kadar pemindahan"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Tidak Dipercayai"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Pilih Peranti"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Lagi"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr "Abuyop <abuyop@gmail.com>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman merupakan pengurus Bluetooth GTK+"
 
@@ -814,17 +806,17 @@ msgstr "Blueman merupakan pengurus Bluetooth GTK+"
 msgid "GSM Settings"
 msgstr "Tetapan GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Pemalam"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Isu dependensi"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -835,7 +827,7 @@ msgstr ""
 "b> juga akan nyahmuatkan <b>\"%(0)s\"</b>.\n"
 "Teruskan?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -846,886 +838,1259 @@ msgstr ""
 "b> juga akan nyahmuatkan <b>\"%(0)s\"</b>.\n"
 "Teruskan?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Pemilihan penyesuai"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Boleh ditemui... %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "tiada kategori"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Titik Capaian Rangkaian"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "dekstop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "pelayan"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "komputer riba"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "peranti bimbit"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "selular"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "tanpa wayar"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "telefon pintar"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd tidak tersedia"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "set kepala"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "bebas tangan"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "tidak diketahui"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Sumber Audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Sumber Audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Sumber Audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "papan kekunci"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "penuding"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "papan kekunci"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "penuding"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Pemindah Fail Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Pemindah Fail Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Pemindah Fail Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Rangkaian Kumpulan"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Pemindah Fail Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Pemindah Fail Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Sambung"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Rangkaian Kumpulan"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Port Serial"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Perangkaian Dailan (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Pemindah Fail Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "set kepala"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Sumber Audio"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Sinki Audio"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Titik Capaian Rangkaian"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Rangkaian Kumpulan"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "bebas tangan"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Titik Capaian Rangkaian (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Titik Capaian Rangkaian (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Rangkaian Kumpulan"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Pemindah Fail Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Sumber Audio"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Sinki Audio"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Sumber Audio"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Nama semula peranti"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Tunjuk maklumat peranti"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Perkhidmatan Setempat"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Pemindahan"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "aplet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Pasangkan Peranti"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Gelintar peranti berhampiran"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Pemindahan"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "aplet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Pasangkan Peranti"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Gelintar peranti berhampiran"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Pengurus Peranti"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "_Sambungan Baru-Baru Ini"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Pengurus Peranti"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Keutamaan Penyesuai"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Profil berauto-sambung"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietari"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ya"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "tidak"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Maklumat"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Tunjuk maklumat peranti"
 
@@ -1750,34 +2115,35 @@ msgstr "Profil Audio"
 msgid "Select audio profile for PulseAudio"
 msgstr "Pilih profil audio untuk PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Port Serial %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Baharu Semula Alamat IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Tetapan Dailan"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Port Serial"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Tidak dinyatakan"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Bersambung"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Bersambung secara automatik ke %(service)s pada %(device)s"
@@ -1842,22 +2208,17 @@ msgstr "Pengg_unaan Rangkaian"
 msgid "Shows network traffic usage"
 msgstr "Tunjuk penggunaan trafik rangkaian"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Dibenarkan"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth Dilumpuhkan"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Urus perkhidmatan rangkaian setempat, seperti jambatan NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1865,7 +2226,7 @@ msgstr ""
 "Menyediakan sokongan untuk Perangkaian Dailan (DUN) dengan Pengurus Modem "
 "dan Pengurus Rangkaian"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1873,38 +2234,38 @@ msgstr ""
 "capaian pantas"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Item maksimum"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Bilangan maksimum bagi menu sambungan item baru-baru ini yang akan dipapar."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Sambungan Baru-Baru Ini"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Bersambung dengan %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Gagal sambung"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s pada %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Penyesuai untuk sambungan ini tidak tersedia"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1912,41 +2273,41 @@ msgstr ""
 "Menyediakan sokongan untuk Perangkaian Kawasan Peribadi (PAN) yang "
 "diperkenalkan di dalam Pengurus Rangkaian 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Menyediakan API DBus untuk lain-lain komponen Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Fail masuk melalui Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Fail masuk %(0)s daripada %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Tolak"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Menerima fail"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Menerima fail %(0)s daripada %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Menyediakan keupayaan pemindahan fail OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Direktori terkonfigur untuk fail masuk tidak wujud"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1955,41 +2316,37 @@ msgstr ""
 "Sila pastikan direktori \"<b>%s</b>\" wujud atau konfigur ia dengan blueman-"
 "services. Sehinggalah lalai \"%s\" akan digunakan"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Fail diterima"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Fail %(0)s daripada %(1)s berjaya diterima"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Pemindahan gagal"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Pemindahan fail %(0)s gagal"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Fail diterima"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Terima %d fail di belakang"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Terima %d lagi fail dibelakang"
@@ -2001,27 +2358,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Tambah item menu piawai ke menu ikon status"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "P_ersediaan Peranti Baharu"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Hantar _Fail ke Peranti"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "Pe_ranti"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Pen_yesuai"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "aplet"
 
@@ -2033,27 +2390,27 @@ msgstr "Menyediakan kunci laluan, perkhidmatan pengesahihan untuk daemon BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Tambah item menu keluar untuk keluar dari aplet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Menyediakan klien dhcp asas untuk sambungan PAN Bluetooth."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Rangkaian Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Antaramuka %(0)s terikat dengan alamat IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Gagal dapatkan alamat IP pada %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2062,7 +2419,7 @@ msgstr ""
 "Cuba dapatkan alamat IP pada %s\n"
 "Tunggu sebentar..."
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2070,23 +2427,26 @@ msgstr ""
 "Tambah pertunjuk pada ikon status bila Bluetooth aktif dan tunjuk bilangan "
 "sambungan dalam tip alat."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth Aktif"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Sambungan Aktif</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth Dilumpuhkan"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Guna libappindicator untuk tunjukkan ikon status"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2094,35 +2454,36 @@ msgstr ""
 "Menyediakan item menu untuk membuat penyesuai lalai tampak buat sementara "
 "bila ia ditetapkan tersembunyi secara lalai"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Had masa tamat boleh ditemui"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Amaun masa dalam saat mod boleh ditemui akan bertahan"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Jadikan Boleh Ditemui"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Jadikan penyesuai lalai kelihatan buat sementara"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Boleh ditemui... %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Sediakan menu untuk aplet dan API untuk lain-lain pemalam untuk "
 "dimanipulasikan"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2131,22 +2492,22 @@ msgstr ""
 "Berjaya sambung ke perkhidmatan <b>DUN</b> pada  <b>%(0)s.</b>\n"
 "Rangkaian kini tersedia melalui <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Menyediakan sokongan asas untuk menyambung ke internet melalui profil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Pengendali sambungan profil SPP piawai, membolehkan pelakuan tindakan suai"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skrip untuk dilakukan dalam sambungan"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2164,11 +2525,11 @@ msgstr ""
 "\n"
 "Bila peranti terputus skrip akan menghantar isyarat HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Port Serial bersambung"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2176,11 +2537,11 @@ msgstr ""
 "Perkhidmatan port serial pada peranti <b>%s</b> kini tersedia melalui <b>%s</"
 "b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Skrip sambungan port serial gagal"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2189,37 +2550,37 @@ msgstr ""
 "Terdapat masalah melancarkan skrip %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Kawal keadaan kuasa penyesuai Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Auto hidup"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Hidupkan penyesuai secara automatik"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Matikan Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Matikan semua penyesuai"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Hi_dupkan Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Hidupkan semua penyesuai"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2227,22 +2588,21 @@ msgstr ""
 "Tangguh penyelamat skrin buat sementara bila pengawal permainan bluetooth "
 "bersambung."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Rangkaian"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Alamat IP tidak sah"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "Alamat IP berkonflik dengan antaramuka %s yang mempunyai alamat yang sama"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2253,8 +2613,8 @@ msgstr ""
 "%s/%s berikut\n"
 "Ia menyebabkan kelakuan rangkaian yang bermasalah"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Buat masa ini tidak disokong dengan persediaan ini"
 
@@ -2268,40 +2628,26 @@ msgstr "Pemalam perkhidmatan pemindahan aplet dilumpuhkan"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Penyesuai Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "aplet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman merupakan pengurus Bluetooth GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Dibenarkan"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Peranti Bluetooth"
 
@@ -2337,6 +2683,31 @@ msgstr "Tetapkan Keadaan RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Penetapan Keadaan RfKill memerlukan kelayakan"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Masukkan kod PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Masukkan kunci laluan"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Port Serial bersambung dengan %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "set kepala"
+
+#~ msgid "handsfree"
+#~ msgstr "bebas tangan"
+
+#~ msgid "unknown"
+#~ msgstr "tidak diketahui"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Peranti Bluetooth"
 
@@ -2355,11 +2726,6 @@ msgstr "Penetapan Keadaan RfKill memerlukan kelayakan"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Buang..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Sambung"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/nb.po
+++ b/po/nb.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-31 21:43+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/blueman/"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Synlighetsinnstilling</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Skjult"
 
@@ -75,8 +75,8 @@ msgstr "_Enhet"
 msgid "_View"
 msgstr "_Vis"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Hjelp"
 
@@ -89,7 +89,7 @@ msgstr "Søk etter enheter i nærheten"
 msgid "Search"
 msgstr "Søk"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Opprett en sammenkobling med enheten"
 
@@ -98,17 +98,17 @@ msgstr "Opprett en sammenkobling med enheten"
 msgid "Pair"
 msgstr "Koble sammen"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Angi/fjern enhet som tiltrodd"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Tiltro"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Start veiledet oppsett av denne enheten"
 
@@ -117,7 +117,7 @@ msgstr "Start veiledet oppsett av denne enheten"
 msgid "Setup..."
 msgstr "Oppsett …"
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Fjern denne enheten fra listen over kjente enheter"
 
@@ -300,7 +300,12 @@ msgstr "Ikke angitt"
 msgid "<b>Author:</b>"
 msgstr "<b>Forfatter:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -362,7 +367,7 @@ msgstr "_Nullstill"
 msgid "Send note"
 msgstr "Send notat"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Blåtann må være påslått for at adapterbehandleren skal virke."
 
@@ -370,30 +375,30 @@ msgstr "Blåtann må være påslått for at adapterbehandleren skal virke."
 msgid "Bluetooth Adapters"
 msgstr "Blåtannsadaptere"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Alltid"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minutt"
 msgstr[1] "%d minutter"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Blåtann må være påskrudd for at enhetshåndteringen skal fungere"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Forbindelse til BlueZ mislyktes"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 #, fuzzy
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
@@ -408,153 +413,144 @@ msgstr ""
 msgid "Searching"
 msgstr "Søker"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Blåtannsassistent"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adapterinnstillinger"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Filavsender"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Filoverføring via Blåtann"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 #, fuzzy
 msgid "Connecting"
 msgstr "Kobler til"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd er ikke tilgjengelig"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 #, fuzzy
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Klarte ikke å starte OBEX-tjeneste automatisk. Forsikre deg om at OBEX-"
 "nissen kjører."
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 #, fuzzy
 msgid "Cancelling"
 msgstr "Avbryter"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 #, fuzzy
 msgid "Sending File"
 msgstr "Sender fil"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Estimert tid til ankomst:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] "%(seconds)d sekund"
 msgstr[1] "%(seconds)d sekunder"
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, fuzzy, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Det oppsto en feil under forsendelse av filen %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Hopp over"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Prøv igjen"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 #, fuzzy
 msgid "Error occurred"
 msgstr "Det oppsto en feil"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokale tjenester"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Sammenkoblingsforespørsel fra %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Tilgangskontroll for Blåtann"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Skriv inn PIN-koden for å godkjenne:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Skriv inn PIN-kode"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 #, fuzzy
 msgid "Enter passkey for authentication:"
 msgstr "Skriv inn passord for tilgangskontroll:"
 
-#: blueman/main/applet/BluezAgent.py:232
-#, fuzzy
-msgid "Enter passkey"
-msgstr "Oppgi adgangskode"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 #, fuzzy
 msgid "Pairing passkey for"
 msgstr "Sammenkobler adgangsnøkkel for"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 #, fuzzy
 msgid "Pairing PIN code for"
 msgstr "Sammenkobler PIN-kode for"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Sammenkoblingsforespørsel for:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Bekreft verdi for godkjennelse:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Bekreft"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Avvis"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Godkjennelsesforespørsel for:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Tjeneste:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Godkjenn hver gang"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Godta"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 #, fuzzy
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
@@ -592,242 +588,242 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nei"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Rapporter et problem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Enhetshåndtering"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Vis _verktøyslinje"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Vis _statuslinje"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "S_orter etter"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Navn"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Lagt til"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Synkende"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Programtillegg"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokale tjenester"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Tjenesteinnstillinger"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Søk"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Adapterinnstillinger"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Avslutt"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "ukategorisert"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Tiltrodd og parret</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Parret</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Tiltrodd</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Svak"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Suboptimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Best mulig"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Mye"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "For mye"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Lav"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Høy"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Veldig høy"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Suksess!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Seriellport tilkoblet %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Mislyktes"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Tilkobling mislyktes: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
 msgid "Connecting…"
 msgstr "Kobler til"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Frakobling mislyktes: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
 msgid "Disconnecting…"
 msgstr "Kobler fra …"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Koble til</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 #, fuzzy
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Kobler til auto-tilkoblingsprofilene A2DP-kilde, A2DP-sink og HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Koble fra</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 #, fuzzy
 msgid "Forcefully disconnect the device"
 msgstr "Tvangsfrakoble enheten"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Koble til::</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Avbryt:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
 msgid "Send a _File…"
 msgstr "Send en _fil …"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Sammenkoble"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Tiltro"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Mistro"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Sett opp…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Gi enheten nytt navn"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Fjern"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Avbryt handlingen"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Dataaktivitetsindikator"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Totalt data mottatt og forsendelseshastighet"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Totalt data sendt og forsendelseshastighet"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Mistro"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Velg enhet"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mer"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Allan Nordhøy <epost@anotheragency.no>\n"
@@ -840,7 +836,7 @@ msgstr ""
 "Valmantas Palikša\n"
 "Øyvind Øritsland"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman er en GTK+basert Blåtannsbehandler"
 
@@ -848,17 +844,17 @@ msgstr "Blueman er en GTK+basert Blåtannsbehandler"
 msgid "GSM Settings"
 msgstr "GSM-innstillinger"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Programtillegg"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Avhengighetsproblem"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, fuzzy, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -869,7 +865,7 @@ msgstr ""
 "b> vil også fjerne <b>»%(0)s«</b>.\n"
 "Fortsett?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, fuzzy, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -880,887 +876,1278 @@ msgstr ""
 "%(1)s</b> vil fjerne <b>%(0)s</b>.\n"
 "Fortsett?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Valg av adapter"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Synlig … %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "ukategorisert"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Nettverkstilgangspunkt"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "skrivebord"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "tjener"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "bærbar"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "håndholdt"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-#, fuzzy
-msgid "palm"
-msgstr "PDA"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "trådløs"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smarttelefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "ISDN"
+msgid "83-99 percent"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "hodesett"
-
-#. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "håndfri"
-
-#. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "ukjent"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
-msgstr "mikrofon"
-
-#. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
-msgstr "høyttaler"
-
-#. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
-msgstr "hodetelefoner"
-
-#. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
-msgstr "bærbar lyd"
-
-#. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr "bilstereo"
-
-#. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
-msgstr "TV-mottager"
-
-#. translators: device class
-#: blueman/DeviceClass.py:129
+#: blueman/DeviceClass.py:75
 #, fuzzy
-msgid "hifi audio"
-msgstr "Hi-Fi -lyd"
+msgid "Not available"
+msgstr "obexd er ikke tilgjengelig"
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
-msgstr "videospiller-opptaker"
-
-#. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
-msgstr "videokamera"
-
-#. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
-msgstr "digital-videokamera"
-
-#. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr "videomonitor"
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr "videoskjerm og høyttaler"
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
-msgstr "videokonferanseutstyr"
-
-#. translators: device class
-#: blueman/DeviceClass.py:145
-msgid "gaming/toy"
-msgstr "videospill/leke"
-
-#. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tastatur"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "pekeenhet"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
-msgstr "kombo"
-
-#: blueman/Sdp.py:93
-msgid "SDP"
-msgstr "SDP"
-
-#: blueman/Sdp.py:94
-msgid "UDP"
-msgstr "UDP"
-
-#: blueman/Sdp.py:95
-msgid "RFCOMM"
-msgstr "RFCOMM"
-
-#: blueman/Sdp.py:96
-msgid "TCP"
-msgstr "TCP"
-
-#: blueman/Sdp.py:97
-msgid "TCS-BIN"
-msgstr ""
-
-#: blueman/Sdp.py:98
-msgid "TCS-AT"
-msgstr ""
-
-#: blueman/Sdp.py:99
-msgid "ATT"
-msgstr ""
-
-#: blueman/Sdp.py:100
-msgid "OBEX"
-msgstr ""
-
-#: blueman/Sdp.py:101
-msgid "IP"
-msgstr "IP"
-
-#: blueman/Sdp.py:102
-msgid "FTP"
-msgstr "FTP"
-
-#: blueman/Sdp.py:103
-msgid "HTTP"
-msgstr "HTTP"
-
-#: blueman/Sdp.py:104
-msgid "WSP"
-msgstr ""
-
-#: blueman/Sdp.py:105
-msgid "BNEP"
-msgstr ""
-
-#: blueman/Sdp.py:106
-msgid "UPnP/ESDP"
-msgstr ""
-
-#: blueman/Sdp.py:107
-msgid "HIDP"
-msgstr ""
-
-#: blueman/Sdp.py:108
-msgid "Hardcopy Control Channel"
-msgstr ""
-
-#: blueman/Sdp.py:109
-msgid "Hardcopy Data Channel"
-msgstr ""
-
-#: blueman/Sdp.py:110
-msgid "Hardcopy Notification"
-msgstr ""
-
-#: blueman/Sdp.py:111
-msgid "AVCTP"
-msgstr ""
-
-#: blueman/Sdp.py:112
-msgid "AVDTP"
-msgstr ""
-
-#: blueman/Sdp.py:113
-msgid "CMTP"
-msgstr ""
-
-#: blueman/Sdp.py:114
-msgid "UDI_C-Plane"
-msgstr ""
-
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
-msgid "Multi-Channel Adaptation Protocol (MCAP)"
-msgstr ""
-
-#: blueman/Sdp.py:117
-msgid "L2CAP"
-msgstr ""
-
-#: blueman/Sdp.py:118
-msgid "ServiceDiscoveryServerServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:119
-msgid "BrowseGroupDescriptorServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:120
-msgid "Public Browse Group"
-msgstr ""
-
-#: blueman/Sdp.py:121
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
 #, fuzzy
-#| msgid "Serial Ports"
-msgid "Serial Port"
-msgstr "Seriellporter"
-
-#: blueman/Sdp.py:122
-msgid "LAN Access Using PPP"
-msgstr ""
-
-#: blueman/Sdp.py:123
-msgid "Dialup Networking (DUN)"
-msgstr "Modemoppringingsnettverk (DUN)"
-
-#: blueman/Sdp.py:124
-msgid "IrMC Sync"
-msgstr ""
-
-#: blueman/Sdp.py:125
-msgid "OBEX Object Push"
-msgstr ""
-
-#: blueman/Sdp.py:126
-#, fuzzy
-#| msgid "Bluetooth File Transfer"
-msgid "OBEX File Transfer"
-msgstr "Filoverføring via Blåtann"
-
-#: blueman/Sdp.py:127
-msgid "IrMC Sync Command"
-msgstr ""
-
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
 msgid "Headset"
 msgstr "hodesett"
 
-#: blueman/Sdp.py:129
-msgid "Cordless Telephony"
-msgstr "Trådløs telefoni"
-
-#: blueman/Sdp.py:130
-msgid "Audio Source"
-msgstr "Lydkilde"
-
-#: blueman/Sdp.py:131
-msgid "Audio Sink"
-msgstr "Lyd-sink"
-
-#: blueman/Sdp.py:132
-msgid "Remote Control Target"
-msgstr "Fjernkontrollmål"
-
-#: blueman/Sdp.py:133
-msgid "Advanced Audio"
-msgstr "Avansert lyd"
-
-#: blueman/Sdp.py:134
-msgid "Remote Control"
-msgstr "Fjernkontroll"
-
-#: blueman/Sdp.py:135
-msgid "Video Conferencing"
-msgstr "Videokonferanse"
-
-#: blueman/Sdp.py:136
-msgid "Intercom"
-msgstr ""
-
-#: blueman/Sdp.py:137
-msgid "Fax"
-msgstr ""
-
-#: blueman/Sdp.py:138
-msgid "Headset Audio Gateway"
-msgstr ""
-
-#: blueman/Sdp.py:139
-msgid "WAP"
-msgstr ""
-
-#: blueman/Sdp.py:140
-msgid "WAP Client"
-msgstr ""
-
-#: blueman/Sdp.py:141
-msgid "PANU"
-msgstr ""
-
-#: blueman/Sdp.py:142
-msgid "Network Access Point"
-msgstr "Nettverkstilgangspunkt"
-
-#: blueman/Sdp.py:143
-msgid "Group Network"
-msgstr "Gruppenettverk"
-
-#: blueman/Sdp.py:144
-msgid "DirectPrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:145
-msgid "ReferencePrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:146
-msgid "Imaging (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:147
-msgid "ImagingResponder (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:148
-msgid "ImagingAutomaticArchive (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:149
-msgid "ImagingReferencedObjects (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:150
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
 #, fuzzy
-#| msgid "handsfree"
 msgid "Handsfree"
 msgstr "håndfri"
 
-#: blueman/Sdp.py:151
+#. translators: device class
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
+msgstr "mikrofon"
+
+#. translators: device class
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
+msgstr "høyttaler"
+
+#. translators: device class
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
+msgstr "hodetelefoner"
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
+msgstr "bærbar lyd"
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
+msgstr "bilstereo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
+msgstr "TV-mottager"
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
+msgstr "Hi-Fi -lyd"
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
+msgstr "videospiller-opptaker"
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "videokamera"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
+msgstr "digital-videokamera"
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "videomonitor"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
+msgstr "videoskjerm og høyttaler"
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "videokonferanseutstyr"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+#, fuzzy
+msgid "Gaming/Toy"
+msgstr "videospill/leke"
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tastatur"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "pekeenhet"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+#, fuzzy
+msgid "Combo"
+msgstr "kombo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+msgid "Display"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Koble til"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Koble til"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Generisk tilgang"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Koble til"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Generisk lyd"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Fjernkontroll"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Generisk tilgang"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Generisk lyd"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Gruppenettverk"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Filoverføring via Blåtann"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Koble til"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Helsetermometer"
+
+#: blueman/DeviceClass.py:182
+#, fuzzy
+msgid "Thermometer: Ear"
+msgstr "Helsetermometer"
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Filoverføring via Blåtann"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+#, fuzzy
+msgid "Generic Blood Pressure"
+msgstr "Blodtrykk"
+
+#: blueman/DeviceClass.py:186
+#, fuzzy
+msgid "Blood Pressure: Arm"
+msgstr "Blodtrykk"
+
+#: blueman/DeviceClass.py:187
+#, fuzzy
+msgid "Blood Pressure: Wrist"
+msgstr "Blodtrykk"
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Koble til"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Gruppenettverk"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+#, fuzzy
+msgid "Cycling: Power Sensor"
+msgstr "Sykkel-effektmåler"
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+#, fuzzy
+msgid "Generic: Weight Scale"
+msgstr "Vekt"
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+#, fuzzy
+msgid "Generic Continuous Glucose Monitor"
+msgstr "Blodsukkermåling"
+
+#: blueman/DeviceClass.py:217
+#, fuzzy
+msgid "Generic Insulin Pump"
+msgstr "Generisk lyd"
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
+msgid "SDP"
+msgstr "SDP"
+
+#: blueman/Sdp.py:88
+msgid "UDP"
+msgstr "UDP"
+
+#: blueman/Sdp.py:89
+msgid "RFCOMM"
+msgstr "RFCOMM"
+
+#: blueman/Sdp.py:90
+msgid "TCP"
+msgstr "TCP"
+
+#: blueman/Sdp.py:91
+msgid "TCS-BIN"
+msgstr ""
+
+#: blueman/Sdp.py:92
+msgid "TCS-AT"
+msgstr ""
+
+#: blueman/Sdp.py:93
+msgid "ATT"
+msgstr ""
+
+#: blueman/Sdp.py:94
+msgid "OBEX"
+msgstr ""
+
+#: blueman/Sdp.py:95
+msgid "IP"
+msgstr "IP"
+
+#: blueman/Sdp.py:96
+msgid "FTP"
+msgstr "FTP"
+
+#: blueman/Sdp.py:97
+msgid "HTTP"
+msgstr "HTTP"
+
+#: blueman/Sdp.py:98
+msgid "WSP"
+msgstr ""
+
+#: blueman/Sdp.py:99
+msgid "BNEP"
+msgstr ""
+
+#: blueman/Sdp.py:100
+msgid "UPnP/ESDP"
+msgstr ""
+
+#: blueman/Sdp.py:101
+msgid "HIDP"
+msgstr ""
+
+#: blueman/Sdp.py:102
+msgid "Hardcopy Control Channel"
+msgstr ""
+
+#: blueman/Sdp.py:103
+msgid "Hardcopy Data Channel"
+msgstr ""
+
+#: blueman/Sdp.py:104
+msgid "Hardcopy Notification"
+msgstr ""
+
+#: blueman/Sdp.py:105
+msgid "AVCTP"
+msgstr ""
+
+#: blueman/Sdp.py:106
+msgid "AVDTP"
+msgstr ""
+
+#: blueman/Sdp.py:107
+msgid "CMTP"
+msgstr ""
+
+#: blueman/Sdp.py:108
+msgid "UDI_C-Plane"
+msgstr ""
+
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
+msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgstr ""
+
+#: blueman/Sdp.py:111
+msgid "L2CAP"
+msgstr ""
+
+#: blueman/Sdp.py:112
+msgid "ServiceDiscoveryServerServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:113
+msgid "BrowseGroupDescriptorServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:114
+msgid "Public Browse Group"
+msgstr ""
+
+#: blueman/Sdp.py:115
+#, fuzzy
+msgid "Serial Port"
+msgstr "Seriellporter"
+
+#: blueman/Sdp.py:116
+msgid "LAN Access Using PPP"
+msgstr ""
+
+#: blueman/Sdp.py:117
+msgid "Dialup Networking (DUN)"
+msgstr "Modemoppringingsnettverk (DUN)"
+
+#: blueman/Sdp.py:118
+msgid "IrMC Sync"
+msgstr ""
+
+#: blueman/Sdp.py:119
+msgid "OBEX Object Push"
+msgstr ""
+
+#: blueman/Sdp.py:120
+#, fuzzy
+msgid "OBEX File Transfer"
+msgstr "Filoverføring via Blåtann"
+
+#: blueman/Sdp.py:121
+msgid "IrMC Sync Command"
+msgstr ""
+
+#: blueman/Sdp.py:123
+msgid "Cordless Telephony"
+msgstr "Trådløs telefoni"
+
+#: blueman/Sdp.py:124
+msgid "Audio Source"
+msgstr "Lydkilde"
+
+#: blueman/Sdp.py:125
+msgid "Audio Sink"
+msgstr "Lyd-sink"
+
+#: blueman/Sdp.py:126
+msgid "Remote Control Target"
+msgstr "Fjernkontrollmål"
+
+#: blueman/Sdp.py:127
+msgid "Advanced Audio"
+msgstr "Avansert lyd"
+
+#: blueman/Sdp.py:128
+msgid "Remote Control"
+msgstr "Fjernkontroll"
+
+#: blueman/Sdp.py:129
+msgid "Video Conferencing"
+msgstr "Videokonferanse"
+
+#: blueman/Sdp.py:130
+msgid "Intercom"
+msgstr ""
+
+#: blueman/Sdp.py:131
+msgid "Fax"
+msgstr ""
+
+#: blueman/Sdp.py:132
+msgid "Headset Audio Gateway"
+msgstr ""
+
+#: blueman/Sdp.py:133
+msgid "WAP"
+msgstr ""
+
+#: blueman/Sdp.py:134
+msgid "WAP Client"
+msgstr ""
+
+#: blueman/Sdp.py:135
+msgid "PANU"
+msgstr ""
+
+#: blueman/Sdp.py:136
+msgid "Network Access Point"
+msgstr "Nettverkstilgangspunkt"
+
+#: blueman/Sdp.py:137
+msgid "Group Network"
+msgstr "Gruppenettverk"
+
+#: blueman/Sdp.py:138
+msgid "DirectPrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:139
+msgid "ReferencePrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:140
+msgid "Imaging (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:141
+msgid "ImagingResponder (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:142
+msgid "ImagingAutomaticArchive (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:143
+msgid "ImagingReferencedObjects (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Nettverkstillgangspunkt (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Nettverkstillgangspunkt (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr "PnP-informasjon"
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Gruppenettverk"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Filoverføring via Blåtann"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr "Generisk lyd"
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr "Generisk telefoni"
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Lydkilde"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Lyd-sink"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr "Videodistribusjon"
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Lydkilde"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr "Generisk tilgang"
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr "Umiddelbar varsling"
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr "Sendingseffekt"
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Gi enheten nytt navn"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr "Helsetermometer"
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
 msgid "Device Information"
 msgstr "Vis enhetsinfo"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr "Puls"
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Lokale tjenester"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr "Blodtrykk"
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr "Sykkel-effektmåler"
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr "Miljømåling"
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr "Brukerdata"
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr "Vekt"
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr "Blodsukkermåling"
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr "Internettprotokollstøtte"
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr "HTTP-mellomtjener"
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Overfør"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "panelprogram"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Koble sammen enhet"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Søk etter enheter i nærheten"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Overfør"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "panelprogram"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Koble sammen enhet"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Søk etter enheter i nærheten"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Enhetshåndtering"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr "Utseende"
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Siste _tilkoblinger"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Enhetshåndtering"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr "System-ID"
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr "Modellnummer-streng"
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr "Serienummer-streng"
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr "PnP-ID"
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr "Gyldig tallfølge"
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Adapterinnstillinger"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Koble sammen profiler automatisk"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietært"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ja"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nei"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 #, fuzzy
 msgid "Show device information"
 msgstr "Vis enhetsinfo"
@@ -1786,34 +2173,35 @@ msgstr "Lydprofil"
 msgid "Select audio profile for PulseAudio"
 msgstr "Velg lydprofil for PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Seriellport %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Forny IP-adresse"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Modemoppringingsinnstillinger"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Seriellporter"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Uspesifisert"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Tilkoblet"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Koblet automatisk til %(service)s på %(device)s"
@@ -1882,29 +2270,24 @@ msgstr "_Nettverksbruk"
 msgid "Shows network traffic usage"
 msgstr "Viser nettverksforbruk"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Blåtann påslått"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Blåtann avskrudd"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Håndter lokale nettverkstjenester, som NAP-broer"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 "Gir støtte for oppringningsnettverk (DUN) med ModemManager og NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1912,38 +2295,38 @@ msgstr ""
 "tilgang"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maks. antall elementer"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Maksimalt antall punkter menyen for siste tilkoblinger vil vise."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Siste _tilkoblinger"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, fuzzy, python-format
 msgid "Connected to %s"
 msgstr "Tilkoblet %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 #, fuzzy
 msgid "Failed to connect"
 msgstr "Kunne ikke koble til"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s på %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "En adapter for denne tilkoblingen er ikke tilgjengelig"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1951,41 +2334,41 @@ msgstr ""
 "Tilbyr støtte for Personlig områdesnettverk (PAN) introdusert i "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Muliggjør DBus API for andre Blueman-komponenter"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Innkommende fil via Blåtann"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Innkommende fil %(0)s fra %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Avvis"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Mottar fil"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Mottar fil %(0)s fra %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Tilbyr OBEX-filoverføringsfunksjoner"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Oppsatt mappe for innkommende filer finnes ikke"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, fuzzy, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1994,42 +2377,38 @@ msgstr ""
 "Forsikre deg om at mappen \"<b>%s</b>\" finnes, eller sett den opp med "
 "blueman-services. Inntil da vil \"%s\" bli brukt."
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Fil mottatt"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Fil %(0)s fra %(1)s ble mottatt med hell"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Overføring mislyktes"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Overføring av fila %(0)s mislyktes"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Filer mottatt"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Mottok %d fil i bakgrunnen"
 msgstr[1] "Mottok %d filer i bakgrunnen"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Mottok %d fil til i bakgrunnen"
@@ -2042,27 +2421,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Legg til forvalgte menyelementer til statusikonsmenyen."
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Sett opp ny enhet"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Send _filer til enhet"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Enheter"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "_Adaptere"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "panelprogram"
 
@@ -2074,28 +2453,28 @@ msgstr "Tilbyr adgangsnøkkel, godkjennelsestjenester for BlueZ-nissen"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Tilføyer et punkt i menyen til å avslutte panelprogrammet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 #, fuzzy
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Tilbyr en grunnleggende DHCP-klient for Blåtanns-PAN-tilkoblinger."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Blåtannsnettverk"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Grensesnitt %(0)s knyttet til IP-adressen %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Kunne ikke innhente en IP-adresse på %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2104,7 +2483,7 @@ msgstr ""
 "Prøver å innhente en IP-adresse på %s\n"
 "Vent …"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2112,24 +2491,27 @@ msgstr ""
 "Tilfører en indikasjon på statusikonet når Blåtann er aktiv og viser "
 "antallet tilkoblinger i verktøystipset."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Blåtann er påslått"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d aktiv tilknytning</b>"
 msgstr[1] "<b>%d aktive tilknytninger</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Blåtann avskrudd"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Bruker libappindikator for å vise et statusikon"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2137,35 +2519,36 @@ msgstr ""
 "Tilbyr et menypunkt som gjør den forvalgte adapteren synlig midlertidig, når "
 "den som forvalg er satt usynlig"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Tidsutløp for synlighet"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Tid i sekunder tilstanden synlighet skal være aktivert"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Gjør synlig"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Gjør de forvalgte adapterne synlig midlertidig"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Synlig … %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Tilbyr meny for panelprogrammet og et API slik at andre programtillegg kan "
 "manipulere det"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2174,23 +2557,23 @@ msgstr ""
 "Tilkoblet <b>DUN</b>-tjenesten på <b>%(0)s.</b>\n"
 "Nettverket er nå tilgjengelig via <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Tilbyr grunnleggende støtte for forbindelse til Internett via DUN-profil."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Forvalgt håndtering av SPP-profiltilkobling, gir mulighet til å kjøre "
 "egentilpassede handlinger"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skript som skal kjøres ved tilknytning"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2208,11 +2591,11 @@ msgstr ""
 "\n"
 "Ved frakobling av enheten vil skriptet få tilsendt et HUP-signal</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Seriellport tilkoblet"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2220,11 +2603,11 @@ msgstr ""
 "Seriellporttjeneste på enheten <b>%s</b> vil nå være tilgjengelig via <b>%s</"
 "b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Forbindelsesskript for seriellporten mislyktes"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2233,58 +2616,57 @@ msgstr ""
 "Det oppsto et problem under igangsetting av skriptet %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Kontroller driftstilstander for Blåtannsadaptere"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatisk påslag"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automatisk påslag av adaptere"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Skru av Blåtann</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Skru av alle adaptere"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Skru på Blåtann</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Skru på alle adaptere"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "Avfei pauseskjerm midlertidig når Blåtanns-spillkontrollere er tilkoblet."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Nettverk"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Ugyldig IP-adresse"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP-adressen er i konflikt med grensesnittet %s som har samme adresse"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, fuzzy, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2295,8 +2677,8 @@ msgstr ""
 "følgende oppsett  %s/%s\n"
 "Dette kan forårsake nettverkskrøll"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "For øyeblikket ikke støttet med dette oppsettet"
 
@@ -2313,10 +2695,6 @@ msgstr "Panelprogrammet utvidelsesprogramtillegg for overføring er avskrudd"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Velg egenskaper for Blåtannsadaptere"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman-panelprogram"
@@ -2324,11 +2702,6 @@ msgstr "Blueman-panelprogram"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Blåtannsbehandler"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2372,6 +2745,39 @@ msgstr "Sett RfKill-tilstand"
 msgid "Setting RfKill State requires privileges"
 msgstr "Setting av RfKill-tilstand krever rettigheter"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Skriv inn PIN-kode"
+
+#, fuzzy
+#~ msgid "Enter passkey"
+#~ msgstr "Oppgi adgangskode"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Seriellport tilkoblet %s"
+
+#, fuzzy
+#~ msgid "palm"
+#~ msgstr "PDA"
+
+#~ msgid "isdn"
+#~ msgstr "ISDN"
+
+#~ msgid "headset"
+#~ msgstr "hodesett"
+
+#~ msgid "handsfree"
+#~ msgstr "håndfri"
+
+#~ msgid "unknown"
+#~ msgstr "ukjent"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Blåtannsenheter"
 
@@ -2394,11 +2800,6 @@ msgstr "Setting av RfKill-tilstand krever rettigheter"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Fjern …"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Koble til"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/nds.po
+++ b/po/nds.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Low German (http://www.transifex.com/mate/MATE/language/"
@@ -22,7 +22,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr ""
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr ""
 
@@ -66,8 +66,8 @@ msgstr ""
 msgid "_View"
 msgstr "_Ansicht"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Hölp"
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Search"
 msgstr "Sök"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -89,17 +89,17 @@ msgstr ""
 msgid "Pair"
 msgstr ""
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr ""
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr ""
 
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Setup..."
 msgstr ""
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr ""
 
@@ -283,7 +283,12 @@ msgstr ""
 msgid "<b>Author:</b>"
 msgstr ""
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -345,7 +350,7 @@ msgstr "_Torüggsetten"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -353,30 +358,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr ""
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Jümmers"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -387,142 +392,134 @@ msgstr ""
 msgid "Searching"
 msgstr ""
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr ""
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr ""
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr ""
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr ""
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Jau"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr ""
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -553,238 +550,240 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nee"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Sök"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Minn"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Hoch"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Bannig hoog"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Gaht nich"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 msgid "Connecting…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 msgid "Disconnecting…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 msgid "Send a _File…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Entfernen"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr ""
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Skullmaster https://launchpad.net/~koeritz-jonas\n"
 "  Valmantas Palikša https://launchpad.net/~walmis"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -792,17 +791,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Plugins"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -810,7 +809,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -818,842 +817,1206 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:10
+msgid "Phone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:12
+msgid "Access point"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+msgid "Desktop"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:33
+msgid "Server"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:35
+msgid "Laptop"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+msgid "Smart phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
+msgid "17-33 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
+msgid "50-67 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
+msgid "67-83 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "unbekannt"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:88
+msgid "Microphone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+msgid "Video camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+msgid "Video monitor"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+msgid "Video conferencing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+msgid "Keyboard"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
+msgid "Pointing"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+msgid "Generic Phone"
+msgstr ""
+
+#: blueman/DeviceClass.py:170
+msgid "Generic Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:171
+msgid "Generic Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+msgid "Generic Clock"
+msgstr ""
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+msgid "Generic Remote Control"
+msgstr ""
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+msgid "Generic Tag"
+msgstr ""
+
+#: blueman/DeviceClass.py:178
+msgid "Generic Keyring"
+msgstr ""
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+msgid "Generic Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:181
+msgid "Generic Thermometer"
+msgstr ""
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+msgid "Generic Glucose Meter"
+msgstr ""
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+msgid "Generic: Cycling"
+msgstr ""
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 msgid "OBEX File Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr ""
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr ""
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr ""
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr ""
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr ""
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr ""
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr ""
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr ""
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr ""
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr ""
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr ""
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Device"
 msgid "Device Name"
 msgstr "Lööpwark"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr ""
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ja"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nee"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1678,34 +2041,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nich angeven"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1768,141 +2132,136 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1916,27 +2275,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
@@ -1948,107 +2307,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2059,78 +2424,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Netzwerk"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2138,8 +2502,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2155,21 +2519,12 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
-msgstr ""
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
 msgstr ""
 
 #: data/blueman-manager.desktop.in:3
@@ -2211,6 +2566,9 @@ msgstr ""
 #: data/configs/org.blueman.policy.in:38
 msgid "Setting RfKill State requires privileges"
 msgstr ""
+
+#~ msgid "unknown"
+#~ msgstr "unbekannt"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Löschen..."

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-06-09 12:59+0000\n"
 "Last-Translator: simonborgithub <mail@simonbor.nl>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/blueman/blueman/nl/"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Zichtbaarheidinstelling</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Verborgen"
 
@@ -72,8 +72,8 @@ msgstr "A_pparaat"
 msgid "_View"
 msgstr "Beel_d"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Hulp"
 
@@ -86,7 +86,7 @@ msgstr "Zoek naar apparaten in de buurt"
 msgid "Search"
 msgstr "Zoeken"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Het apparaat koppelen"
 
@@ -95,17 +95,17 @@ msgstr "Het apparaat koppelen"
 msgid "Pair"
 msgstr "Koppelen"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Markeer/demarkeer dit apparaat als vertrouwd"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Vertrouwen"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Start de instelhulp voor dit apparaat"
 
@@ -114,7 +114,7 @@ msgstr "Start de instelhulp voor dit apparaat"
 msgid "Setup..."
 msgstr "Instellen..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Verwijder dit apparaat uit de lijst met bekende apparaten"
 
@@ -296,7 +296,12 @@ msgstr "Niet gespecificeerd"
 msgid "<b>Author:</b>"
 msgstr "<b>Auteur:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -358,7 +363,7 @@ msgstr "_Terugzetten"
 msgid "Send note"
 msgstr "Notitie verzenden"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth moet zijn ingeschakeld, anders werkt het adapterbeheer niet"
 
@@ -366,33 +371,31 @@ msgstr "Bluetooth moet zijn ingeschakeld, anders werkt het adapterbeheer niet"
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth-adapters"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Altijd"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minuut"
 msgstr[1] "%d minuten"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "Bluetooth moet ingeschakeld worden om het apparaatbeheer te kunnen gebruiken"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Verbinding met BlueZ mislukt"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -406,144 +409,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Bezig met zoeken"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth-assistent"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adaptervoorkeuren"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Bestandverzender"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth-bestandoverdracht"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Bezig met verbinden"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd is niet beschikbaar"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Kon de obex-dienst niet automatisch starten. Zorg ervoor dat de obex-"
 "achtergronddienst draait"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Bezig met annuleren"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Bezig met verzenden van bestand"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Geschatte aankomsttijd:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Er is een fout opgetreden bij het verzenden van bestand %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Overslaan"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Opnieuw proberen"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Er is een fout opgetreden"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokale diensten"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Koppelingsverzoek voor %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth-authenticatie"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Voer pincode in voor authenticatie:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Voer pincode in"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Voer wachtwoordsleutel in voor authenticatie:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Voer wachtwoordsleutel in"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Koppelingsverzoek voor"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "PIN-code koppelen voor"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Koppelingsverzoek voor:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Bevestig waarde voor authenticatie:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Bevestigen"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Weigeren"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Machtigingsverzoek voor:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Dienst:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Altijd aanvaarden"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Aanvaarden"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -577,245 +572,242 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nee"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Rapporteer een probleem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Apparaatbeheer"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Toon _Werkbalk"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Toon _Statusbalk"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "S_orteer op"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Naam"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Toegevoegd"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Aflopend"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "Invoegtoe_passingen"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokale diensten"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Dienstvoorkeuren"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Zoeken"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Adaptervoorkeuren"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Afsluiten"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "geen classificatie"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Vertrouwd en gepaard</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Gepaard</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Vertrouwd></b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Matig"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Sub-optimaal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimaal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Veel"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Te veel"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Laag"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Hoog"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Zeer hoog"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Gelukt!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Seriële poort verbonden met %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Mislukt"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Verbinding mislukt: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Bezig met verbinden"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Verbinding verbreken mislukt: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Bezig met verbreken van verbinding..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Verbinden</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Hiermee verbindt u automatisch verbindingsprofielen A2DP bron, A2DP zink en "
 "HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Verbinding verbreken</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Verbinding met apparaat met kracht verbreken"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Verbinden met:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Verbinding verbreken:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Verstuur een _bestand..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Koppel"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Vertrouwen"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Niet vertrouwen"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Instellen…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Hernoem apparaat"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Verwijderen"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Actie annuleren"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indicatie van gegevensactiviteit"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Totaal van ontvangen gegevens en verbindingssnelheid"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Totaal van verstuurde gegevens en verbindingssnelheid"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Vertrouwen beëindigen"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Selecteer apparaat"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Meer"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -833,7 +825,7 @@ msgstr ""
 "  rob https://launchpad.net/~rvdb\n"
 "  ubby https://launchpad.net/~kostas-sytske"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman is een GTK+ Bluetooth-beheerder"
 
@@ -841,17 +833,17 @@ msgstr "Blueman is een GTK+ Bluetooth-beheerder"
 msgid "GSM Settings"
 msgstr "GSM-instellingen"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Invoegtoepassingen"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Afhankelijkheidsprobleem"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -862,7 +854,7 @@ msgstr ""
 "b> uitschakelen zal ook <b>\"%(0)s\"</b> uitschakelen.\n"
 "Verdergaan?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -873,886 +865,1259 @@ msgstr ""
 "<b>%(1)s</b> zal <b>%(0)s</b> uitschakelen.\n"
 "Verdergaan?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Adapterkeuze"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Ontdekbaar... %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "geen classificatie"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Netwerktoegangspunt"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "bureaucomputer"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "pda"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "gsm"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "draadloos"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smartphone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd is niet beschikbaar"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "koptelefoon/microfoon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handenvrij"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "onbekend"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "microfoon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Audiobron"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Audiobron"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Audiobron"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "toetsenbord"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "aanwijsapparaat"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "toetsenbord"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "aanwijsapparaat"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth-bestandoverdracht"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth-bestandoverdracht"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth-bestandoverdracht"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Netwerk groeperen"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth-bestandoverdracht"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth-bestandoverdracht"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Verbinden"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Netwerk groeperen"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Seriële poorten"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Inbelnetwerk (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth-bestandoverdracht"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "koptelefoon/microfoon"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Audiobron"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Audio-ontvanger"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Netwerktoegangspunt"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Netwerk groeperen"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handenvrij"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Netwerktoegangspunt (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Netwerktoegangspunt (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Netwerk groeperen"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth-bestandoverdracht"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Audiobron"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Audio-ontvanger"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Audiobron"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Hernoem apparaat"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Apparaatinformatie tonen"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Lokale diensten"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Overdragen"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "applet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Koppel apparaat"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Zoek naar apparaten in de buurt"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Overdragen"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "applet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Koppel apparaat"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Zoek naar apparaten in de buurt"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Apparaatbeheer"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Recente _verbindingen"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Apparaatbeheer"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Adaptervoorkeuren"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Profielen automatisch verbinden"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Niet-vrij"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ja"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nee"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Apparaatinformatie tonen"
 
@@ -1777,34 +2142,35 @@ msgstr "Audioprofiel"
 msgid "Select audio profile for PulseAudio"
 msgstr "Selecteer audioprofiel voor PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Seriële poort %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "IP-adres vernieuwen"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Inbelinstellingen"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Seriële poorten"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Niet gespecificeerd"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Verbonden"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Automatisch verbonden met %(service)s op %(device)s"
@@ -1872,22 +2238,17 @@ msgstr "Netwerk _gebruik"
 msgid "Shows network traffic usage"
 msgstr "Laat netwerkverkeergebruik zien"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth ingeschakeld"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth uitgeschakeld"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Beheert lokale netwerkdiensten, zoals NAP bridges"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1895,7 +2256,7 @@ msgstr ""
 "Biedt ondersteuning voor inbelnetwerk (DUN) met ModemManager en "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1903,39 +2264,39 @@ msgstr ""
 "verbindingen"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maximaal aantal onderdelen"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Het maximaal aantal onderdelen dat getoond zal worden in het recente "
 "verbindingenmenu."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Recente _verbindingen"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Verbonden met %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Kon niet verbinden"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s op %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adapter voor deze verbinding is niet beschikbaar"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1943,41 +2304,41 @@ msgstr ""
 "Biedt ondersteuning voor Personal Area Netwerken (PAN) geïntroduceerd in "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Biedt een DBus-API aan voor andere Blueman-componenten"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Binnenkomend bestand via Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Binnenkomend bestand %(0)s van %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Weigeren"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Bestand wordt ontvangen"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Bestand %(0)s van %(1)s wordt ontvangen"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Biedt mogelijkheden voor OBEX-bestandsoverdracht"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Ingestelde map voor binnenkomende bestanden bestaat niet"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1986,42 +2347,38 @@ msgstr ""
 "Zorg er a.u.b. voor dat de map '<b>%s</b>' bestaat of stel hem in met "
 "blueman-diensten. Tot dat ogenblik zal de standaard '%s' worden gebruikt"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Bestand ontvangen"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Bestand %(0)s van %(1)s succesvol ontvangen"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Overdracht mislukt"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Overdracht van bestand %(0)s mislukt"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Bestanden ontvangen"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "%d bestand op de achtergrond ontvangen"
 msgstr[1] "%d bestanden op de achtergrond ontvangen"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "nog %d ander bestand op de achtergrond ontvangen"
@@ -2034,27 +2391,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Voegt standaardmenu-onderdelen toe aan het statuspictogrammenu"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "Nieuw apparaat in_stellen"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "_Bestanden verzenden naar apparaat"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Apparaten"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adapters"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2066,27 +2423,27 @@ msgstr "Biedt sleutel- en authenticatiediensten voor BlueZ-achtergronddienst"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Voegt een menu-onderdeel 'Afsluiten' toe om het applet af te sluiten"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Biedt een basis dhcp-client voor Bluetooth-PAN-verbindingen."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth-netwerk"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Apparaat %(0)s gekoppeld aan IP-adres %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Kon geen IP-adres verkrijgen op %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2095,7 +2452,7 @@ msgstr ""
 "Aan het proberen om een IP-adres te verkrijgen op %s\n"
 "Een ogenblik geduld a.u.b…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2103,24 +2460,27 @@ msgstr ""
 "Voegt een indicator toe aan het statuspictogram wanneer Bluetooth "
 "ingeschakeld is en toont het aantal verbindingen in de gereedschaptip."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth actief"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d actieve verbinding</b>"
 msgstr[1] "<b>%d actieve verbindingen</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth uitgeschakeld"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Gebruik libappindicator voor statusikoon"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2128,35 +2488,36 @@ msgstr ""
 "Levert een menu-onderdeel om de standaardadapter tijdelijk zichtbaar te "
 "maken wanneer deze standaard op verborgen is ingesteld"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Zichtbaarheidsperiode"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Aantal seconden dat de zichtbaarheidsmodus zal duren"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Zichtbaar _maken"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Maak de standaardadapter tijdelijk zichtbaar"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Ontdekbaar... %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Biedt een menu aan voor het applet en een API zodat andere "
 "invoegtoepassingen dit kunnen wijzigen"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2165,23 +2526,23 @@ msgstr ""
 "Succesvol verbonden met <b>DUN-dienst</b> op <b>%(0)s.</b>\n"
 "Netwerk is nu beschikbaar via <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Biedt basisondersteuning voor verbinding met het internet via DUN-profiel."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standaard SPP-profielverbindingsuitvoerder, maakt het mogelijk om aangepaste "
 "acties uit te voeren"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script om uit te voeren na verbinding"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2200,11 +2561,11 @@ msgstr ""
 "Bij het afkoppelen van een apparaat zal het script een HUP-signaal krijgen</"
 "span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Seriële poort verbonden"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2212,11 +2573,11 @@ msgstr ""
 "Dienst seriële poort op apparaat <b>%s</b> zal nu beschikbaar zijn via <b>"
 "%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Verbindingsscript seriële poort mislukt"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2225,37 +2586,37 @@ msgstr ""
 "Er was een probleem met het uitvoeren van script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Beheert de stroomstatus van de Bluetooth-adapter"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatisch inschakelen"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Adapters automatisch inschakelen"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Bluetooth _uitschakelen</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Alle adapters uitschakelen"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Bluetooth _aan</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Alle adapters inschakelen"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2263,21 +2624,20 @@ msgstr ""
 "Stelt tijdelijk de schermbeveiliging uit wanneer een Bluetooth-"
 "spelcontroller verbonden is."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Netwerk"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Ongeldig IP-adres"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP-adres conflicteert met apparaat %s dat hetzelfde adres heeft"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2288,8 +2648,8 @@ msgstr ""
 "heeft  %s/%s\n"
 "Dit kan onjuist netwerkgedrag veroorzaken"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Wordt momenteel niet ondersteund met deze instelling"
 
@@ -2305,10 +2665,6 @@ msgstr "Applets invoegtoepassing voor overdrachtfunctie is uitgeschakeld"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Zet Bluetooth-adapters eigenschappen"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman Applet"
@@ -2316,11 +2672,6 @@ msgstr "Blueman Applet"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman is een Bluetooth-beheerder"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2362,6 +2713,37 @@ msgstr "RfKill status instellen"
 msgid "Setting RfKill State requires privileges"
 msgstr "U heeft rechten nodig om de status van RfKill in te stellen"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Voer pincode in"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Voer wachtwoordsleutel in"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Seriële poort verbonden met %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "koptelefoon/microfoon"
+
+#~ msgid "handsfree"
+#~ msgstr "handenvrij"
+
+#~ msgid "unknown"
+#~ msgstr "onbekend"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth-apparaten"
 
@@ -2382,11 +2764,6 @@ msgstr "U heeft rechten nodig om de status van RfKill in te stellen"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Verwijderen…"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Verbinden"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/pl.po
+++ b/po/pl.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-16 21:29+0000\n"
 "Last-Translator: kakiremora <piotrek.pastuszak2003@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -36,7 +36,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Ustawienia widoczności</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Ukryty"
 
@@ -80,8 +80,8 @@ msgstr "_Urządzenie"
 msgid "_View"
 msgstr "_Widok"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Pomoc"
 
@@ -94,7 +94,7 @@ msgstr "Szukaj urządzeń w pobliżu"
 msgid "Search"
 msgstr "Szukaj"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Paruj z urządzeniem"
 
@@ -103,17 +103,17 @@ msgstr "Paruj z urządzeniem"
 msgid "Pair"
 msgstr "Paruj"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Zaznacz/Odznacz urządzenie jako zaufane"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Zaufane"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Uruchom asystenta konfiguracji dla tego urządzenia"
 
@@ -122,7 +122,7 @@ msgstr "Uruchom asystenta konfiguracji dla tego urządzenia"
 msgid "Setup..."
 msgstr "Ustawienia..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Usuń to urządzenie z listy znanych"
 
@@ -303,7 +303,12 @@ msgstr "Nieokreślony"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -365,7 +370,7 @@ msgstr "Z_resetuj"
 msgid "Send note"
 msgstr "Wyślij notatkę"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth musi być włączone na menedżerze adaptera, aby działało"
 
@@ -373,14 +378,12 @@ msgstr "Bluetooth musi być włączone na menedżerze adaptera, aby działało"
 msgid "Bluetooth Adapters"
 msgstr "Adaptery Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Zawsze"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minuta"
@@ -388,19 +391,19 @@ msgstr[1] "%d minuty"
 msgstr[2] "%d minut"
 msgstr[3] "%d minut"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth musi być włączony, aby menedżer urządzeń mógł działać"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Połączenie z BlueZ się nie powiodło"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -414,50 +417,50 @@ msgstr ""
 msgid "Searching"
 msgstr "Wyszukiwanie"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Asystent Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Ustawienia adaptera"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Wysyłanie plików"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transfer plików za pomocą Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Łączenie"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd nie dostępny"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Nie można automatycznie uruchomić usługi obex. Upewnij się, że obex daemon "
 "jest uruchomiony"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Anulowanie"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Przesyłanie pliku"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -466,94 +469,86 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Wystąpił błąd podczas przesyłania pliku %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Pomiń"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Spróbuj ponownie"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Wystąpił błąd"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Usługi lokalne"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Żądanie sparowania dla %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autoryzacja Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Wprowadź kod PIN do uwierzytelnienia:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Wprowadź kod PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Wprowadź hasło do uwierzytelnienia:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Wprowadź hasło"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Parowanie hasła dla"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Parownie kod PIN dla"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Żądanie parowania dla:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Potwierdź wartość do uwierzytelnienia:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Potwierdź"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Odrzuć"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Żądanie autoryzacji dla:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Usługa:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Zawsze akceptuj"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Akceptuj"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -587,239 +582,238 @@ msgstr "Tak"
 msgid "No"
 msgstr "Nie"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Zgłoś problem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Menedżer urządzeń"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Wyświetl pasek _narzędziowy"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Wyświetl _pasek stanu"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "S_ortuj według"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nazwy"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Dodania"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Malejąco"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Wtyczki"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Usługi lokalne"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferencje usługi"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Szukaj"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "Ustawienia"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "_Wyjście"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "nieskategoryzowany"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Zaufane i sparowane</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Sparowane</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Zaufany</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Słaby"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Niemal optymalny"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optymalny"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Dużo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Zbyt dużo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Niski"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Wysoki"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Bardzo wysoki"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Zakończono z powodzeniem!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Port szeregowy podłączony do %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Nieudane"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Połączenie nie powiodło się: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Łączenie"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Rozłączenie nie powiodło się: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Rozłączanie..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Połącz</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Łączy automatyczne profile źródła A2DP, złącza A2DP i HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Rozłącz</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Wymuś rozłącznie z urządzniem"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Połącz z:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Rozłącz:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Wyślij _plik..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Paruj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Ufaj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "P_rzestań ufać"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Ustaw…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Zmień nazwę urządzenia"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Usuń"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Anuluj operację"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Wskaźnik przesyłania danych"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Całkowita ilość odebranych danych oraz szybkość trasmisji"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Całkowita ilość wysłanych danych oraz szybkość transmisji"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Niezaufane"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Wybierz urządzenie"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Więcej"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Tłumacze środowiska MATE, 2014-2015, 2017-2018\n"
@@ -850,7 +844,7 @@ msgstr ""
 "  roffik https://launchpad.net/~roffik\n"
 "  spitfire https://launchpad.net/~mieszkoslusarczyk"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman jest zarządcą Bluetooth napisanym w GTK+"
 
@@ -858,17 +852,17 @@ msgstr "Blueman jest zarządcą Bluetooth napisanym w GTK+"
 msgid "GSM Settings"
 msgstr "Ustawienia GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Wtyczki"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problem z zależnościami"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -879,7 +873,7 @@ msgstr ""
 "spowoduje wyłącznie również <b>\"%(0)s\"</b>.\n"
 "Kontynuować?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -890,886 +884,1259 @@ msgstr ""
 "spowoduje wyłączenie <b>%(0)s</b>.\n"
 "Kontynuować?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Wybór adaptera"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Widoczne… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "nieskategoryzowany"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Punkt dostępu do sieci"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "pulpit"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "serwer"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "palmtop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "Palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "komórkowy"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "bezprzewodowy"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smartfon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd nie dostępny"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "zestaw słuchawkowy"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "nieznany"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Źródło sygnału dźwiękowego"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Źródło sygnału dźwiękowego"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Źródło sygnału dźwiękowego"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "klawiatura"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "urządzenie wskazujące"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "klawiatura"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "urządzenie wskazujące"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Połącz"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Połącz"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Połącz"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Połącz"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Transfer plików za pomocą Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Połącz"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Transfer plików za pomocą Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Transfer plików za pomocą Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Sieć grupowa"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transfer plików za pomocą Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Połącz"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Połącz"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transfer plików za pomocą Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Połącz"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Sieć grupowa"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Porty szeregowe"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Sieci wdzwaniane (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Transfer plików za pomocą Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "zestaw słuchawkowy"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Źródło sygnału dźwiękowego"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Wyjście dźwiękowe"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Punkt dostępu do sieci"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Sieć grupowa"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Punkt wejścia sieci (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Punkt wejścia sieci (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Sieć grupowa"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Transfer plików za pomocą Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Źródło sygnału dźwiękowego"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Wyjście dźwiękowe"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Źródło sygnału dźwiękowego"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Zmień nazwę urządzenia"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Wyświetl informacje o urządzeniu"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Usługi lokalne"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Prześlij"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "aplet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Paruj urządzenia"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Szukaj urządzeń w pobliżu"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Prześlij"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "aplet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Paruj urządzenia"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Szukaj urządzeń w pobliżu"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Menedżer urządzeń"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Ostatnie _połączenia"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Menedżer urządzeń"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Ustawienia adaptera"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Profile automatycznego łączenia"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Własnościowy"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "tak"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nie"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Informacje"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Wyświetl informacje o urządzeniu"
 
@@ -1794,34 +2161,35 @@ msgstr "Profil dźwiękowy"
 msgid "Select audio profile for PulseAudio"
 msgstr "Wybierz profil dźwiękowy dla PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Port szeregowy %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Odnów adres IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Ustawienia DialUp"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Porty szeregowe"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nieokreślony"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Połączono"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Automatycznie połączony z %(service)s na %(device)s"
@@ -1895,22 +2263,17 @@ msgstr "_Użycie sieci"
 msgid "Shows network traffic usage"
 msgstr "Pokazuje liczbę przesłanych danych"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth włączony"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth wyłączony"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Zarządz usługami sieci lokalnej, jak mosty NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1918,43 +2281,43 @@ msgstr ""
 "Zapewnia wsparcie dla Dial Up Networking (DUN) z programami ModemManager i "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "Dostarcza element menu zawierający ostatnio używane połączenia"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maksymalna ilość połączeń"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Maksymalna liczba ostatnich połączeń wyświetlana w menu."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Ostatnie _połączenia"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Połączono z %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Nie udało się połączyć"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s na %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adapter dla tego połączenia jest niedostępny"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1962,41 +2325,41 @@ msgstr ""
 "Dostarcza wsparcie dla Personal Area Networking (PAN) wprowadzonego w "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Zapewnia API DBus dla innych komponentów Bluemana"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Plik przychodzący przez Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Plik przychodzący %(0)s od %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Odrzuć"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Odbieranie pliku"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Odbieranie pliku %(0)s od %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Dostarcza możliwości transferu plików przez protokołu OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Folder na odebrane dane nie istnieje"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -2005,33 +2368,31 @@ msgstr ""
 "Upewnij się, że katalog „<b>%s</b>” istnieje lub skonfiguruj go za pomocą "
 "blueman-services. Do tego czasu będzie używany domyślny „%s”"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Odebrano plik"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Plik %(0)s z %(1)s odebrany z powodzeniem"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Transfer nieudany"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Transfer pliku %(0)s nieudany"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Odebrane pliki"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Odebrany %d plik w tle"
@@ -2039,10 +2400,8 @@ msgstr[1] "Odebrane %d pliki w tle"
 msgstr[2] "Odebrane %d plików w tle"
 msgstr[3] "Odebrane %d plików w tle"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Odebrany %d plik więcej w tle"
@@ -2057,27 +2416,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Dodaje standardowe elementy menu do menu ikony statusu"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "U_staw nowe urządzenie"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Wyślij plik do urządzenia"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Urządzenia"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adaptery"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "aplet"
 
@@ -2089,27 +2448,27 @@ msgstr "Zapewnia hasło, usługi uwierzytelniania dla daemona BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Dodaje element menu wyjścia do wyjścia z apletu"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Dostarcza podstawowego klienta DHCP dla połączeń PAN Bluetooth."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Sieć Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interfejs %(0)s przypisany do adresu %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Nie udało się otrzymać adresu IP na %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2118,7 +2477,7 @@ msgstr ""
 "Próba uzyskania adresu IP od %s\n"
 "Proszę czekać…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2126,14 +2485,12 @@ msgstr ""
 "Dodaje wskazówkę na ikonie statusu kiedy Bluetooth jest aktywny i pokazuje "
 "liczbę połączeń w etykiecie."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth jest aktywny"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d aktywne połączenie</b>"
@@ -2141,11 +2498,16 @@ msgstr[1] "<b>%d aktywne połączenia</b>"
 msgstr[2] "<b>%d aktywnych połączeń</b>"
 msgstr[3] "<b>%d aktywnych połączeń</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth wyłączony"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Używa libappindicator aby pokazać ikonę statusu"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2153,34 +2515,35 @@ msgstr ""
 "Udostępnia element menu służący do tymczasowego wyświetlania domyślnego "
 "adaptera, gdy jest domyślnie ustawiony jako ukryty"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Czas wykrywalności"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Ilość czasu w sekundach kiedy tryb wykrywalności się wyłączy"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Włącz wykrywalność"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Ustaw domyślny adapter tymczasowo widoczny"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Widoczne… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Dostarcza menu dla apletu i API dla innych wtyczek do manipulowania nim"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2189,23 +2552,23 @@ msgstr ""
 "Pomyślnie połączono do usługi <b>DUN</b> na <b>%(0)s.</b>\n"
 "Połączenie jest teraz dostępne przez <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Dostarcza podstawowe wsparcie dla połączenia do internetu przez profil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standardowa obsługa połączenia profilu SPP, pozwalającego na wykonywanie "
 "niestandardowych czynności"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skrypt do wykonania podczas połączenia"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2223,11 +2586,11 @@ msgstr ""
 "\n"
 "Podczas rozłączenia urządzenia skrypt wyśle sygnał HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Port szeregowy połączony"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2235,11 +2598,11 @@ msgstr ""
 "Usługa portu szeregowe na urządzeniu <b>%s</b> będzie teraz dostępna przez "
 "<b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Skrypt połączenia portu szeregowego nie powiódł się"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2248,59 +2611,58 @@ msgstr ""
 "Nastąpił problem uruchomienia skryptu %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Kontroluje stany zasilania adapteru Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatyczne włączanie"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automatyczne włączanie adapterów"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>W_yłącz Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Wyłącz wszystkie adaptery Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Włącz Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Włącz wszystkie adaptery"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "Tymczasowo wyłącza wygaszacz ekranu gdy podłączony jest kontroler bluetooth."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Sieć"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Nieprawidłowy adres IP"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "Adres IP jest w konflikcie z interfejsem %s, który posiada taki sam adres"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2311,8 +2673,8 @@ msgstr ""
 "konfigurację %s/%s\n"
 "Może to spowodować nieprawidłowe zachowanie sieci"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Obecnie nie obsługiwany z taką konfiguracją"
 
@@ -2326,40 +2688,26 @@ msgstr "Wtyczka usługi transferu apletu jest wyłączona"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptery Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "aplet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman jest zarządcą Bluetooth napisanym w GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth włączony"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Urządzenia Bluetooth"
 
@@ -2395,6 +2743,31 @@ msgstr "Ustaw stan RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Ustawienie stanu RfKill wymaga uprawnień"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Wprowadź kod PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Wprowadź hasło"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Port szeregowy podłączony do %s"
+
+#~ msgid "palm"
+#~ msgstr "Palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "zestaw słuchawkowy"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "nieznany"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Urządzenia Bluetooth"
 
@@ -2417,11 +2790,6 @@ msgstr "Ustawienie stanu RfKill wymaga uprawnień"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Usuń..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Połącz"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/pt.po
+++ b/po/pt.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Portuguese (http://www.transifex.com/mate/MATE/language/pt/)\n"
@@ -30,7 +30,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Definição de Visibilidade</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Oculto"
 
@@ -74,8 +74,8 @@ msgstr "_Dispositivo"
 msgid "_View"
 msgstr "_Vista"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Ajuda"
 
@@ -88,7 +88,7 @@ msgstr "Procurar dispositivos próximos"
 msgid "Search"
 msgstr "Pesquisar"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Criar emparelhamento com o dispositivo"
 
@@ -97,17 +97,17 @@ msgstr "Criar emparelhamento com o dispositivo"
 msgid "Pair"
 msgstr "Emparelhar"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Marcar/Desmarcar este dispositivo como fiável"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Confiar"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Correr o assistente de configuração para este dispositivo"
 
@@ -116,7 +116,7 @@ msgstr "Correr o assistente de configuração para este dispositivo"
 msgid "Setup..."
 msgstr "Configurar..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Remover este dispositivo da lista de dispositivos conhecidos"
 
@@ -298,7 +298,12 @@ msgstr "Não específicado"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -360,7 +365,7 @@ msgstr "_Repor"
 msgid "Send note"
 msgstr "Enviar nota"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "O Bluetooth necessita de ser ligado para que o gerente do adaptador possa "
@@ -370,33 +375,31 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Adaptadores Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Sempre"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minuto"
 msgstr[1] "%d Minutos"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptador"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "O Bluetooth tem que ser desligado para o gestor de dispositivos funcionar"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Ligação a BlueZ falhou"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -411,144 +414,136 @@ msgstr ""
 msgid "Searching"
 msgstr "A pesquisar"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Assistente de Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Preferências de adaptadores"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Envio de Ficheiro"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transferência de Ficheiros por Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "A ligar"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd não disponível"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Falha ao iniciar automaticamente o serviço obex. Certifique-se que o daemon "
 "obex está a ser executado"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "A cancelar"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "A enviar ficheiro"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Ocorreu um erro ao enviar o ficheiro %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Ignorar"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Tentar novamente"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Ocorreu um erro"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Serviços Locais"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Pedido de emparelhamento para %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autenticação Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Introduza código PIN para autenticação:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Introduza código PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Introduza a palavra-passe para autenticação"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Introduza a palavra-passe"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Palavra-passe de emparelhamento para"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Código PIN de emparelhamento para"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Pedido de emparelhamento para:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirme valor para autenticação:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Negar"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Pedido de autorização para:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Serviço:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Aceitar sempre"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Aceitar"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -582,243 +577,240 @@ msgstr "Sim"
 msgid "No"
 msgstr "Não"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Relatar um Problema"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Gestor de Dispositivos"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Mostrar barra de _ferramentas"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Mostrar barra de _estado"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Ord_enar Por"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nome"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Adicionado"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Descendente"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Suplementos"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Serviços _Locais"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferências de Serviço"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Procurar"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Preferências de adaptadores"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Sair"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "sem categoria"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>De confiança e emparelhado</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Emparelhado</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Fiável</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Fraca"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Subotimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Muito"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Demasiado"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Baixo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Alto"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Muito Alto"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Sucesso!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Porta de série ligada a %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Falhou"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Ligação Falhada:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "A ligar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Emparelhamento sem sucesso:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "A desligar..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Liga os perfis de autoligação A2DP source, A2DP sink, e HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Desligar à força o dispositivo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Ligar a:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Desligar:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Enviar um _Ficheiro..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Emparelhar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Confiar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Desconfiar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Renomear dispositivo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Remover"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Cancelar Operação"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indicação da atividade de dados"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Dados totais recebidos e taxa de transferência"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Dados totais enviados e taxa de transferência"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Desconfiar"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Selecione Dispositivo"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mais"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -830,7 +822,7 @@ msgstr ""
 "  mestrini https://launchpad.net/~mestrini\n"
 "  Carlos Manuel https://launchpad.net/~crolidge"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman é um Gestor de Bluetooth GTK+"
 
@@ -838,17 +830,17 @@ msgstr "Blueman é um Gestor de Bluetooth GTK+"
 msgid "GSM Settings"
 msgstr "Definições de GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Suplementos"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problema de dependência"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -859,7 +851,7 @@ msgstr ""
 "%(1)s</b> também desligará o <b>\"%(0)s\"</b>.\n"
 "Continuar?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -870,886 +862,1259 @@ msgstr ""
 "b> irá descarregar <b>%(0)s</b>.\n"
 "Continuar?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Seleção de adaptador"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Detetável… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "sem categoria"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Ponto de Acesso de Rede"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "computador"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "servidor"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "portátil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "dispositivo móvel"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "PDA"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "telemóvel"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "sem-fios"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smartphone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd não disponível"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "auscultadores"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "auricular"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "desconhecido"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "microfone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Fonte Áudio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Fonte Áudio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Fonte Áudio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "teclado"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "apontador"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "teclado"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "apontador"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Ligar"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Ligar"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Ligar"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Ligar"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Transferência de Ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Ligar"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Transferência de Ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Transferência de Ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Rede de Grupo"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transferência de Ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Ligar"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Ligar"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transferência de Ficheiros por Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Ligar"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Rede de Grupo"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Portas Série"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Dialup Networking (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Transferência de Ficheiros por Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "auscultadores"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Fonte Áudio"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Tema Áudio"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Ponto de Acesso de Rede"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Rede de Grupo"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "auricular"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Ponto de Acesso de Rede (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Ponto de Acesso de Rede (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Rede de Grupo"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Transferência de Ficheiros por Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Fonte Áudio"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Tema Áudio"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Fonte Áudio"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Renomear dispositivo"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Mostrar informação do dispositivo"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Serviços Locais"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Transferir"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "applet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Emparelhar dispositivo"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Procurar dispositivos próximos"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Transferir"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "applet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Emparelhar dispositivo"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Procurar dispositivos próximos"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Gestor de Dispositivos"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "_Ligações Recentes"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Gestor de Dispositivos"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Preferências de adaptadores"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Perfies de ligação automática"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietário"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "sim"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "não"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Informação"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Mostrar informação do dispositivo"
 
@@ -1774,34 +2139,35 @@ msgstr "Perfil Áudio"
 msgid "Select audio profile for PulseAudio"
 msgstr "Selecionar perfil áudio para PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Porta de Série %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Renovar Endereço IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Definições de Ligação telefónica"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Portas Série"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Não especificado"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Ligado"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1869,22 +2235,17 @@ msgstr "_Utilização da Rede"
 msgid "Shows network traffic usage"
 msgstr "Mostra a utilização do tráfego de rede"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Ativado"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth Desativado"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Gere os serviços de redes locais, como as pontes NAIP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1892,7 +2253,7 @@ msgstr ""
 "Fornece suporte para Dial Up Networking (DUN) com o ModemManager e com o "
 "Network Manager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1900,78 +2261,78 @@ msgstr ""
 "ligações utilizadas"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Numero máximo de itens"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "O número máximo de itens que o menu de ligações recentes irá mostrar."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Ligações Recentes"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Ligado a %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Ligação falhou"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s em %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "O adaptador para esta ligação não está disponível"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 "Fornece apoio à Rede de Área Pessoal (PAN) apresentada no NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Fornece API DBus para outros componentes do Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Ficheiro a entrar por Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "A receber ficheiro %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Rejeitar"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "A receber ficheiro"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "A receber ficheiro %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Fornece a capacidade de transferir ficheiros OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Não existe o directório configurado para ficheiros de entrada"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1980,42 +2341,38 @@ msgstr ""
 "Por favor, certifique-se de que o diretório \"<b>%s</b>\" existe, ou "
 "configure-o com serviços blueman. Até lá, será usado o padrão \"%s\""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Ficheiro recebido"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Ficheiro %(0)s de %(1)s recebido com sucesso"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Transferência falhou"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Transferência do ficheiro %(0)s falhou"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Ficheiros recebidos"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Recebido %d ficheiro em processo de fundo"
 msgstr[1] "Recebidos %d ficheiros em processo de fundo"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Recebido mais %d ficheiro em processo de fundo"
@@ -2028,27 +2385,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Adiciona itens de menu padrão ao menu do ícone de status"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Configurar Novo Dispositivo"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Enviar _Ficheiros para Dispositivo"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Dispositivos"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_tadores"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2060,27 +2417,27 @@ msgstr "Fornece palavras-chave e serviços de autenticação ao servidor BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Adiciona um item de menu para sair do applet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Fornece um cliente básico de dhcp para ligações Bluetooth PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Rede Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interface %(0)s atribuída ao endereço IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Falhou ao obter um endereço IP de %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2089,7 +2446,7 @@ msgstr ""
 "A tentar obter um endereço IP em %s\n"
 "Aguardar..."
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2097,24 +2454,27 @@ msgstr ""
 "Coloca uma indicação no ícone de estado quando o Bluetooth está ativo e "
 "mostra o número de ligações na dica de ferramenta."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth Ativo"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Ligação Ativa</b>"
 msgstr[1] "<b>%d Ligações Ativas</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth Desativado"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Utilizada libappindicator para mostrar um ícone de estado"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2122,35 +2482,36 @@ msgstr ""
 "Fornece um item de menu para tornar o adaptador padrão temporariamente "
 "visível quando está definido como oculto por defeito"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Tempo para deteção"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Duração de tempo em segundos que irá demorar o modo de descoberta"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Tornar Detetável"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Tornar o adaptador padrão temporariamente visivel"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Detetável… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Fornece um menu ao applet e um API para que outros suplementos o possam "
 "manipular"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2159,22 +2520,22 @@ msgstr ""
 "Ligou com sucesso ao serviço <b>DUN</b> em <b>%(0)s.</b>\n"
 "A rede está agora disponível através de <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "Fornece suporte básico para ligar à Internet através do perfil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Gestor de ligações do perfil padrão SPP; permite executar ações "
 "personalizadas"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script a executar na ligação"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2192,11 +2553,11 @@ msgstr ""
 "\n"
 "Ao desligar o dispositivo, o script irá enviar um sinal HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Porta de série ligada"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2204,11 +2565,11 @@ msgstr ""
 "O serviço da porta de séria no dispositivo <b>%s</b> estará agora disponível "
 "via <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Falhou o script da ligação da porta de série"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2217,37 +2578,37 @@ msgstr ""
 "Ocorreu um problema ao lançar o script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Controla o estado do adaptador de corrente Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Ligar automatico"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Ligar automaticamente adaptadores"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Desligar Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Desligar todos os adaptadores"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Ligar Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Ligar todos os adaptadores"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2255,22 +2616,21 @@ msgstr ""
 "Suspende temporariamente o protetor de ecrã quando está ligado um "
 "controlador de jogo Bluetooth."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Rede"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Endereço IP inválido"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 "O endereço IP está em conflito com a interface %s que tem o mesmo endereço"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2281,8 +2641,8 @@ msgstr ""
 "configuração  %s/%s\n"
 "Isto pode causar o comportamento incorreto da rede"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Não está suportado nesta configuração"
 
@@ -2296,40 +2656,26 @@ msgstr "Suplemento do serviço de transferência do applet está desativado"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptadores Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman é um Gestor de Bluetooth GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth Ativado"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Dispositivos Bluetooth"
 
@@ -2365,6 +2711,31 @@ msgstr "Configurar RfKill State"
 msgid "Setting RfKill State requires privileges"
 msgstr "Configurar o RfKill State requer privilégios"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Introduza código PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Introduza a palavra-passe"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Porta de série ligada a %s"
+
+#~ msgid "palm"
+#~ msgstr "PDA"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "auscultadores"
+
+#~ msgid "handsfree"
+#~ msgstr "auricular"
+
+#~ msgid "unknown"
+#~ msgstr "desconhecido"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Dispositivos Bluetooth"
 
@@ -2385,11 +2756,6 @@ msgstr "Configurar o RfKill State requer privilégios"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Remover..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Ligar"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-08-01 08:55+0000\n"
 "Last-Translator: Wellington Terumi Uemura <wellingtonuemura@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -38,7 +38,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Configuração de Visibilidade</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Oculto"
 
@@ -82,8 +82,8 @@ msgstr "_Dispositivo"
 msgid "_View"
 msgstr "_Exibir"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Ajuda"
 
@@ -96,7 +96,7 @@ msgstr "Pesquisar por dispositivos próximos"
 msgid "Search"
 msgstr "Pesquisar"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Criar emparelhamento com o dispositivo"
 
@@ -105,17 +105,17 @@ msgstr "Criar emparelhamento com o dispositivo"
 msgid "Pair"
 msgstr "Emparelhar"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Marcar/Desmarcar este dispositivo como confiável"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Confiável"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Executar o assistente de configuração para este dispositivo"
 
@@ -124,7 +124,7 @@ msgstr "Executar o assistente de configuração para este dispositivo"
 msgid "Setup..."
 msgstr "Configurar..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Remover este dispositivo da lista de dispositivos conhecidos"
 
@@ -305,7 +305,12 @@ msgstr "Não especificado"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -367,7 +372,7 @@ msgstr "_Redefinir"
 msgid "Send note"
 msgstr "Enviar nota"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "O Bluetooth precisa ser ligado para que o gerenciador de adaptador funcione"
@@ -376,31 +381,31 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Adaptadores de Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Sempre"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%(minutes)d Minuto"
 msgstr[1] "%(minutes)d Minutos"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptador"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "Bluetooth precisa estar ligado para o gerenciador de dispositivos funcionar"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Falha de conexão com o BlueZ"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -415,144 +420,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Pesquisando"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Assistente de Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Preferências do Adaptador"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Transmissor de Arquivos"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transferencia de Arquivo Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Conectando"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd não disponível"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Falha ao iniciar automaticamente o serviço obex. Verifique se o obex daemon "
 "está em execução"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Cancelando"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Enviando Arquivo"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] "%(seconds)d Segundo"
 msgstr[1] "%(seconds)d Segundos"
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Houve erro ao enviar arquivo %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Pular"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Tentar novamente"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Ocorreu um erro"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Serviços Locais"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Requisição de pareamento para %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autenticação de Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Digitar o código PIN para autenticação:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Digitar código PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Informe a chave de acesso para autenticação:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Informe a chave de acesso"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Chave de acesso de emparelhamento"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Código PIN de emparelhamento"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Pareamento requisitado para:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirmar valor para autenticação:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Negar"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Pedido de autorização para:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Serviço:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Sempre aceitar"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Aceitar"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -586,234 +583,238 @@ msgstr "Sim"
 msgid "No"
 msgstr "Não"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Reportar um problema"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Gerenciador de Dispositivos"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Mostrar _Barra de Ferramentas"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Mostrar _Barra de ferramentas"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "_Ordenar por"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nome"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Adicionado"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Decrescente"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Plugins"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Serviços _Locais"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferências dos Serviços"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Pesquisar"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "_Preferências"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "_Sair"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "sem categoria"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Confiável e emparelhado</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Emparelhado</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Confiável</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Pobre"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Não ideal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Ideal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Muito"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Demais"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Baixo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Alto"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Muito Alto"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Sucesso!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Porta serial conectada a %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Falhou"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Falha de Conexão: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 msgid "Connecting…"
 msgstr "Conectando…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Falha ao desconectar: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 msgid "Disconnecting…"
 msgstr "Desconectando…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Conectar</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Conecta perfis de conexão automática de fonte A2DP, coletor A2DP, e HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Desconectar</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Forçar desconexão com dispositivo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Conectar a:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Desconectar:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 msgid "Send a _File…"
 msgstr "Enviar um _Arquivo…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "Em_parelhar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Confiar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Não confiar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_configuração…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr "R_enomear dispositivo…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 msgid "_Remove…"
 msgstr "_Remover…"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Cancelar Operação"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indicação de atividade de dados"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Total de dados recebido e taxa de transmissão"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Total de dados enviados e taxa de transmissão"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Não confiar"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Selecionar Dispositivo"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mais"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr "Tradutor- créditos"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman é um gerenciador de bluetooth do GTK+"
 
@@ -821,17 +822,17 @@ msgstr "Blueman é um gerenciador de bluetooth do GTK+"
 msgid "GSM Settings"
 msgstr "Configurações de GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problemas de dependência"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -842,7 +843,7 @@ msgstr ""
 "vai descarregar também <b>\"%(0)s\"</b>.\n"
 "Continuar?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -853,840 +854,1267 @@ msgstr ""
 "b> vai descarregar <b>%(0)s</b>\n"
 "Continuar?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Seleção de adaptador"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr "Procurando…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "sem categoria"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Ponto de Acesso à Rede"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+#, fuzzy
+msgid "Audio/video"
+msgstr "Áudio/Vídeo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+#, fuzzy
+msgid "Peripheral"
+msgstr "Sinalizador da privacidade periférica"
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+#, fuzzy
+msgid "Imaging"
+msgstr "Imagem (BIP)"
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "área de trabalho"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "servidor"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "computador portátil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "portátil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "celular"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "sem fio"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smartphone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+msgid "83-99 percent"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "Fone de ouvido com microfone"
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd não disponível"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "handsfree (adaptador auricular)"
-
-#. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "desconhecido"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
-msgstr "microfone"
-
-#. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
-msgstr "alto-falante"
-
-#. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
-msgstr "fones de ouvido"
-
-#. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
-msgstr "aparelho de som portátil"
-
-#. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr "som do veículo"
-
-#. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
-msgstr "set-top box"
-
-#. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
-msgstr "aparelho de som de alta fidelidade"
-
-#. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
-msgstr "vcr"
-
-#. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
-msgstr "câmera de vídeo"
-
-#. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
-msgstr "filmadora"
-
-#. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr "monitor de vídeo"
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr "monitor de vídeo com altofalantes"
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
-msgstr "sistema de videoconferência"
-
-#. translators: device class
-#: blueman/DeviceClass.py:145
-msgid "gaming/toy"
-msgstr "videogame ou brinquedo"
-
-#. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "teclado"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "apontador"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
-msgstr "combo"
-
-#: blueman/Sdp.py:93
-msgid "SDP"
-msgstr "SDP"
-
-#: blueman/Sdp.py:94
-msgid "UDP"
-msgstr "UDP"
-
-#: blueman/Sdp.py:95
-msgid "RFCOMM"
-msgstr "RFCOMM"
-
-#: blueman/Sdp.py:96
-msgid "TCP"
-msgstr "TCP"
-
-#: blueman/Sdp.py:97
-msgid "TCS-BIN"
-msgstr "TCS-BIN"
-
-#: blueman/Sdp.py:98
-msgid "TCS-AT"
-msgstr "TCS-AT"
-
-#: blueman/Sdp.py:99
-msgid "ATT"
-msgstr "ATT"
-
-#: blueman/Sdp.py:100
-msgid "OBEX"
-msgstr "OBEX"
-
-#: blueman/Sdp.py:101
-msgid "IP"
-msgstr "IP"
-
-#: blueman/Sdp.py:102
-msgid "FTP"
-msgstr "FTP"
-
-#: blueman/Sdp.py:103
-msgid "HTTP"
-msgstr "HTTP"
-
-#: blueman/Sdp.py:104
-msgid "WSP"
-msgstr "WSP"
-
-#: blueman/Sdp.py:105
-msgid "BNEP"
-msgstr "BNEP"
-
-#: blueman/Sdp.py:106
-msgid "UPnP/ESDP"
-msgstr "UPnP/ESDP"
-
-#: blueman/Sdp.py:107
-msgid "HIDP"
-msgstr "HIDP"
-
-#: blueman/Sdp.py:108
-msgid "Hardcopy Control Channel"
-msgstr "Canal de controle das cópias impressas"
-
-#: blueman/Sdp.py:109
-msgid "Hardcopy Data Channel"
-msgstr "Canal dos dados das cópias impressas"
-
-#: blueman/Sdp.py:110
-msgid "Hardcopy Notification"
-msgstr "Notificação da cópia impressa"
-
-#: blueman/Sdp.py:111
-msgid "AVCTP"
-msgstr "AVCTP"
-
-#: blueman/Sdp.py:112
-msgid "AVDTP"
-msgstr "AVDTP"
-
-#: blueman/Sdp.py:113
-msgid "CMTP"
-msgstr "CMTP"
-
-#: blueman/Sdp.py:114
-msgid "UDI_C-Plane"
-msgstr "UDI_C-Plane"
-
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
-msgid "Multi-Channel Adaptation Protocol (MCAP)"
-msgstr "Protocolo de Adaptação Multicanal (MCAP)"
-
-#: blueman/Sdp.py:117
-msgid "L2CAP"
-msgstr "L2CAP"
-
-#: blueman/Sdp.py:118
-msgid "ServiceDiscoveryServerServiceClassID"
-msgstr "ServiceDiscoveryServerServiceClassID"
-
-#: blueman/Sdp.py:119
-msgid "BrowseGroupDescriptorServiceClassID"
-msgstr "BrowseGroupDescriptorServiceClassID"
-
-#: blueman/Sdp.py:120
-msgid "Public Browse Group"
-msgstr "Grupo de Navegação Pública"
-
-#: blueman/Sdp.py:121
-msgid "Serial Port"
-msgstr "Portas seriais"
-
-#: blueman/Sdp.py:122
-msgid "LAN Access Using PPP"
-msgstr "Acesso LAN usando o PPP"
-
-#: blueman/Sdp.py:123
-msgid "Dialup Networking (DUN)"
-msgstr "Rede Discada (DUN)"
-
-#: blueman/Sdp.py:124
-msgid "IrMC Sync"
-msgstr "Sincronização IrMC"
-
-#: blueman/Sdp.py:125
-msgid "OBEX Object Push"
-msgstr "Envio do Objeto OBEX"
-
-#: blueman/Sdp.py:126
-msgid "OBEX File Transfer"
-msgstr "Transferência de Arquivo OBEX"
-
-#: blueman/Sdp.py:127
-msgid "IrMC Sync Command"
-msgstr "Comando de Sincronização IrMC"
-
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
 msgid "Headset"
 msgstr "Fones de ouvido com microfone"
 
-#: blueman/Sdp.py:129
-msgid "Cordless Telephony"
-msgstr "Telefonia sem fio"
-
-#: blueman/Sdp.py:130
-msgid "Audio Source"
-msgstr "Fonte de Áudio"
-
-#: blueman/Sdp.py:131
-msgid "Audio Sink"
-msgstr "Saída de áudio"
-
-#: blueman/Sdp.py:132
-msgid "Remote Control Target"
-msgstr "Alvo do controle remoto"
-
-#: blueman/Sdp.py:133
-msgid "Advanced Audio"
-msgstr "Áudio avançado"
-
-#: blueman/Sdp.py:134
-msgid "Remote Control"
-msgstr "Controle Remoto"
-
-#: blueman/Sdp.py:135
-msgid "Video Conferencing"
-msgstr "Videoconferência"
-
-#: blueman/Sdp.py:136
-msgid "Intercom"
-msgstr "Intercomunicador"
-
-#: blueman/Sdp.py:137
-msgid "Fax"
-msgstr "Fax"
-
-#: blueman/Sdp.py:138
-msgid "Headset Audio Gateway"
-msgstr "Gateway de áudio do fone de ouvido"
-
-#: blueman/Sdp.py:139
-msgid "WAP"
-msgstr "WAP"
-
-#: blueman/Sdp.py:140
-msgid "WAP Client"
-msgstr "Cliente WAP"
-
-#: blueman/Sdp.py:141
-msgid "PANU"
-msgstr "PANU"
-
-#: blueman/Sdp.py:142
-msgid "Network Access Point"
-msgstr "Ponto de Acesso à Rede"
-
-#: blueman/Sdp.py:143
-msgid "Group Network"
-msgstr "Grupo de Rede"
-
-#: blueman/Sdp.py:144
-msgid "DirectPrinting (BPP)"
-msgstr "Impressão Directa (BPP)"
-
-#: blueman/Sdp.py:145
-msgid "ReferencePrinting (BPP)"
-msgstr "Impressão de Referência (BPP)"
-
-#: blueman/Sdp.py:146
-msgid "Imaging (BIP)"
-msgstr "Imagem (BIP)"
-
-#: blueman/Sdp.py:147
-msgid "ImagingResponder (BIP)"
-msgstr "ImagingResponder (BIP)"
-
-#: blueman/Sdp.py:148
-msgid "ImagingAutomaticArchive (BIP)"
-msgstr "Arquivamento Automático da Imagem (BIP)"
-
-#: blueman/Sdp.py:149
-msgid "ImagingReferencedObjects (BIP)"
-msgstr "ImagingReferencedObjects (BIP)"
-
-#: blueman/Sdp.py:150
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
 msgid "Handsfree"
 msgstr "Handsfree (adaptador auricular)"
 
-#: blueman/Sdp.py:151
+#. translators: device class
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
+msgstr "microfone"
+
+#. translators: device class
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
+msgstr "alto-falante"
+
+#. translators: device class
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
+msgstr "fones de ouvido"
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
+msgstr "aparelho de som portátil"
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
+msgstr "som do veículo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
+msgstr "set-top box"
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
+msgstr "aparelho de som de alta fidelidade"
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
+msgstr "vcr"
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "câmera de vídeo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
+msgstr "filmadora"
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "monitor de vídeo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
+msgstr "monitor de vídeo com altofalantes"
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "sistema de videoconferência"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+#, fuzzy
+msgid "Gaming/Toy"
+msgstr "videogame ou brinquedo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "teclado"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "apontador"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+#, fuzzy
+msgid "Combo"
+msgstr "combo"
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+#, fuzzy
+msgid "Display"
+msgstr "Display 3D"
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+#, fuzzy
+msgid "Glasses"
+msgstr "Óculos 3D"
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Conexão genérica"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Conexão genérica"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Acesso genérico"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Conexão genérica"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Áudio Genérico"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Controle Remoto"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Acesso genérico"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Áudio Genérico"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Rede Genérica"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transferência de Arquivo Genérica"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Conexão genérica"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Termômetro de saúde"
+
+#: blueman/DeviceClass.py:182
+#, fuzzy
+msgid "Thermometer: Ear"
+msgstr "Termômetro de saúde"
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transferência de Arquivo Genérica"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+#, fuzzy
+msgid "Generic Blood Pressure"
+msgstr "Pressão Arterial"
+
+#: blueman/DeviceClass.py:186
+#, fuzzy
+msgid "Blood Pressure: Arm"
+msgstr "Pressão Arterial"
+
+#: blueman/DeviceClass.py:187
+#, fuzzy
+msgid "Blood Pressure: Wrist"
+msgstr "Pressão Arterial"
+
+#: blueman/DeviceClass.py:188
+#, fuzzy
+msgid "Human Interface Device (HID)"
+msgstr "Dispositivo da Interface Humana"
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Conexão genérica"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Rede Genérica"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+#, fuzzy
+msgid "Cycling: Speed Sensor"
+msgstr "Velocidade do ciclismo e da cadência"
+
+#: blueman/DeviceClass.py:205
+#, fuzzy
+msgid "Cycling: Cadence Sensor"
+msgstr "Velocidade do ciclismo e da cadência"
+
+#: blueman/DeviceClass.py:206
+#, fuzzy
+msgid "Cycling: Power Sensor"
+msgstr "Ciclo da alimentação"
+
+#: blueman/DeviceClass.py:207
+#, fuzzy
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr "Velocidade do ciclismo e da cadência"
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+#, fuzzy
+msgid "Generic: Pulse Oximeter"
+msgstr "Oxímetro de pulso"
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+#, fuzzy
+msgid "Generic: Weight Scale"
+msgstr "Escala do peso"
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+#, fuzzy
+msgid "Generic Continuous Glucose Monitor"
+msgstr "Monitoramento contínuo da glicose"
+
+#: blueman/DeviceClass.py:217
+#, fuzzy
+msgid "Generic Insulin Pump"
+msgstr "Áudio Genérico"
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+#, fuzzy
+msgid "Location and Navigation Display Device"
+msgstr "Localização e Navegação"
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+#, fuzzy
+msgid "Location and Navigation Pod"
+msgstr "Localização e Navegação"
+
+#: blueman/Sdp.py:87
+msgid "SDP"
+msgstr "SDP"
+
+#: blueman/Sdp.py:88
+msgid "UDP"
+msgstr "UDP"
+
+#: blueman/Sdp.py:89
+msgid "RFCOMM"
+msgstr "RFCOMM"
+
+#: blueman/Sdp.py:90
+msgid "TCP"
+msgstr "TCP"
+
+#: blueman/Sdp.py:91
+msgid "TCS-BIN"
+msgstr "TCS-BIN"
+
+#: blueman/Sdp.py:92
+msgid "TCS-AT"
+msgstr "TCS-AT"
+
+#: blueman/Sdp.py:93
+msgid "ATT"
+msgstr "ATT"
+
+#: blueman/Sdp.py:94
+msgid "OBEX"
+msgstr "OBEX"
+
+#: blueman/Sdp.py:95
+msgid "IP"
+msgstr "IP"
+
+#: blueman/Sdp.py:96
+msgid "FTP"
+msgstr "FTP"
+
+#: blueman/Sdp.py:97
+msgid "HTTP"
+msgstr "HTTP"
+
+#: blueman/Sdp.py:98
+msgid "WSP"
+msgstr "WSP"
+
+#: blueman/Sdp.py:99
+msgid "BNEP"
+msgstr "BNEP"
+
+#: blueman/Sdp.py:100
+msgid "UPnP/ESDP"
+msgstr "UPnP/ESDP"
+
+#: blueman/Sdp.py:101
+msgid "HIDP"
+msgstr "HIDP"
+
+#: blueman/Sdp.py:102
+msgid "Hardcopy Control Channel"
+msgstr "Canal de controle das cópias impressas"
+
+#: blueman/Sdp.py:103
+msgid "Hardcopy Data Channel"
+msgstr "Canal dos dados das cópias impressas"
+
+#: blueman/Sdp.py:104
+msgid "Hardcopy Notification"
+msgstr "Notificação da cópia impressa"
+
+#: blueman/Sdp.py:105
+msgid "AVCTP"
+msgstr "AVCTP"
+
+#: blueman/Sdp.py:106
+msgid "AVDTP"
+msgstr "AVDTP"
+
+#: blueman/Sdp.py:107
+msgid "CMTP"
+msgstr "CMTP"
+
+#: blueman/Sdp.py:108
+msgid "UDI_C-Plane"
+msgstr "UDI_C-Plane"
+
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
+msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgstr "Protocolo de Adaptação Multicanal (MCAP)"
+
+#: blueman/Sdp.py:111
+msgid "L2CAP"
+msgstr "L2CAP"
+
+#: blueman/Sdp.py:112
+msgid "ServiceDiscoveryServerServiceClassID"
+msgstr "ServiceDiscoveryServerServiceClassID"
+
+#: blueman/Sdp.py:113
+msgid "BrowseGroupDescriptorServiceClassID"
+msgstr "BrowseGroupDescriptorServiceClassID"
+
+#: blueman/Sdp.py:114
+msgid "Public Browse Group"
+msgstr "Grupo de Navegação Pública"
+
+#: blueman/Sdp.py:115
+msgid "Serial Port"
+msgstr "Portas seriais"
+
+#: blueman/Sdp.py:116
+msgid "LAN Access Using PPP"
+msgstr "Acesso LAN usando o PPP"
+
+#: blueman/Sdp.py:117
+msgid "Dialup Networking (DUN)"
+msgstr "Rede Discada (DUN)"
+
+#: blueman/Sdp.py:118
+msgid "IrMC Sync"
+msgstr "Sincronização IrMC"
+
+#: blueman/Sdp.py:119
+msgid "OBEX Object Push"
+msgstr "Envio do Objeto OBEX"
+
+#: blueman/Sdp.py:120
+msgid "OBEX File Transfer"
+msgstr "Transferência de Arquivo OBEX"
+
+#: blueman/Sdp.py:121
+msgid "IrMC Sync Command"
+msgstr "Comando de Sincronização IrMC"
+
+#: blueman/Sdp.py:123
+msgid "Cordless Telephony"
+msgstr "Telefonia sem fio"
+
+#: blueman/Sdp.py:124
+msgid "Audio Source"
+msgstr "Fonte de Áudio"
+
+#: blueman/Sdp.py:125
+msgid "Audio Sink"
+msgstr "Saída de áudio"
+
+#: blueman/Sdp.py:126
+msgid "Remote Control Target"
+msgstr "Alvo do controle remoto"
+
+#: blueman/Sdp.py:127
+msgid "Advanced Audio"
+msgstr "Áudio avançado"
+
+#: blueman/Sdp.py:128
+msgid "Remote Control"
+msgstr "Controle Remoto"
+
+#: blueman/Sdp.py:129
+msgid "Video Conferencing"
+msgstr "Videoconferência"
+
+#: blueman/Sdp.py:130
+msgid "Intercom"
+msgstr "Intercomunicador"
+
+#: blueman/Sdp.py:131
+msgid "Fax"
+msgstr "Fax"
+
+#: blueman/Sdp.py:132
+msgid "Headset Audio Gateway"
+msgstr "Gateway de áudio do fone de ouvido"
+
+#: blueman/Sdp.py:133
+msgid "WAP"
+msgstr "WAP"
+
+#: blueman/Sdp.py:134
+msgid "WAP Client"
+msgstr "Cliente WAP"
+
+#: blueman/Sdp.py:135
+msgid "PANU"
+msgstr "PANU"
+
+#: blueman/Sdp.py:136
+msgid "Network Access Point"
+msgstr "Ponto de Acesso à Rede"
+
+#: blueman/Sdp.py:137
+msgid "Group Network"
+msgstr "Grupo de Rede"
+
+#: blueman/Sdp.py:138
+msgid "DirectPrinting (BPP)"
+msgstr "Impressão Directa (BPP)"
+
+#: blueman/Sdp.py:139
+msgid "ReferencePrinting (BPP)"
+msgstr "Impressão de Referência (BPP)"
+
+#: blueman/Sdp.py:140
+msgid "Imaging (BIP)"
+msgstr "Imagem (BIP)"
+
+#: blueman/Sdp.py:141
+msgid "ImagingResponder (BIP)"
+msgstr "ImagingResponder (BIP)"
+
+#: blueman/Sdp.py:142
+msgid "ImagingAutomaticArchive (BIP)"
+msgstr "Arquivamento Automático da Imagem (BIP)"
+
+#: blueman/Sdp.py:143
+msgid "ImagingReferencedObjects (BIP)"
+msgstr "ImagingReferencedObjects (BIP)"
+
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr "Gateway do áudio mãos livres"
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr "DirectPrintingReferenceObjectsService (BPP)"
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr "ReflectedUI (BPP)"
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr "Impressão Básica (BPP)"
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr "Condição geral da impressão (BPP)"
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr "Serviço do Dispositivo da Interface Humana (HID)"
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr "HardcopyCableReplacement (HCR)"
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr "HCR_Print (HCR)"
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr "HCR_Scan (HCR)"
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr "Acesso ISDN Comum (CIP)"
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr "VideoConferencingGW (VCP)"
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr "UDI-MT"
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr "UDI-TA"
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr "Áudio/Vídeo"
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr "Acesso SIM (SAP)"
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr "Acesso à lista telefônica (PBAP) - PCE"
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr "Acesso à lista telefônica (PBAP) - PSE"
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr "Acesso à lista telefônica (PBAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr "Servidor do acesso à mensagem"
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr "Servidor de notificação das mensagens"
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr "Perfil de Acesso de Mensagem (MAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr "GNSS"
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr "Servidor GNSS"
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr "Display 3D"
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr "Óculos 3D"
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr "Sincronização 3D (3DSP)"
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr "Perfil da especificação multi-perfil (MPS)"
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr "Serviço da especificação dos vários perfis (MPS)"
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr "Calendário, Tarefa e Notas (CTN) Serviço de Acesso"
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr "Calendário, Tarefa e Notas (CTN) Serviço de Notificação"
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr "Calendário, Tarefas e Notas (CTN) Perfil"
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr "Informação PnP"
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr "Rede Genérica"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr "Transferência de Arquivo Genérica"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr "Áudio Genérico"
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr "Telefonia Genérica"
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr "Fonte de Vídeo"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr "Saída de Vídeo"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr "Distribuição de vídeo"
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr "HDP"
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr "Fonte HDP"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr "HDP Sink"
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr "Acesso genérico"
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr "Atributo genérico"
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr "Alerta imediato"
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr "Perda do link"
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr "Tx Power"
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr "Tempo do serviço atual"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr "Serviço de Referência para a Atualização do Tempo"
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr "Próximo serviço de alteração DST"
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr "Glicose"
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr "Termômetro de saúde"
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr "Informações do dispositivo"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr "Batimento cardíaco"
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr "Serviço da condição geral do alerta telefônico"
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr "Serviço de Bateria"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr "Pressão Arterial"
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr "Serviço de notificação do alerta"
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr "Dispositivo da Interface Humana"
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr "Parâmetros de varredura"
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr "Velocidade da execução e da cadência"
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr "Automação ES"
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr "Velocidade do ciclismo e da cadência"
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr "Ciclo da alimentação"
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr "Localização e Navegação"
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr "Sensoriamento Ambiental"
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr "Composição corporal"
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr "Dados do usuário"
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr "Escala do peso"
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr "Gestão do vínculo"
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr "Monitoramento contínuo da glicose"
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr "Suporte ao Protocolo da Internet"
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr "Posicionamento nos interiores"
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr "Oxímetro de pulso"
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr "Proxy HTTP"
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr "Descoberta do transporte"
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr "Transferir Objeto"
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr "AppleAgent"
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr "Serviço Principal"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr "Serviço Secundário"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr "Inclui"
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr "Declaração da característica"
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 msgid "Device Name"
 msgstr "Nome do Dispositivo"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr "Aparência"
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr "Sinalizador da privacidade periférica"
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr "Endereço de Reconexão"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr "Parâmetros da conexão dos periféricos preferidos"
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr "Serviço Modificado"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr "Identificação do sistema"
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr "Número do modelo"
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr "Número de série"
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr "Revisão do Firmware"
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr "Revisão do hardware"
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr "Revisão do software"
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr "Nome do fabricante"
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr "PnP ID"
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr "Propriedades estendidas da característica"
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr "Descritivo da característica do usuário"
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr "Configuração característica do cliente"
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr "Configuração da característica do servidor"
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr "Característica do formato da apresentação"
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr "Característica do formato agregado"
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr "Intervalo válido"
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr "Referência do relatório externo"
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr "Referências de Relatório"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Perfis de conexão automática"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietário"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "sim"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "não"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Exibir informações do dispositivo"
 
@@ -1711,34 +2139,35 @@ msgstr "Perfil de Áudio"
 msgid "Select audio profile for PulseAudio"
 msgstr "Selecione o perfil de áudio para o PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Porta serial %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Renovar Endereço IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Configurações de Dialup"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Portas seriais"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Não especificado"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Conectado"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Conexão automática de %(service)s em %(device)s"
@@ -1806,22 +2235,17 @@ msgstr "_Uso de Rede"
 msgid "Shows network traffic usage"
 msgstr "Apresenta o uso do tráfego de rede"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Habilitado"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth Desabilitado"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Gerencia serviços de redes locais, tais como pontes NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1829,44 +2253,44 @@ msgstr ""
 "Oferece suporte à Dial Up Networking (DUN) com o ModemManager e o "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 "Oferece um item de menu que contém a última conexão usada para acesso rápido"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Máximo de itens"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "O número máximo de itens que o menu de conexões recentes vai mostrar."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Conexões Recentes"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Conectado à %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Falha de conexão"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s em %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "O adaptador para esta conexão não está disponível"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1874,41 +2298,41 @@ msgstr ""
 "Oferece suporte para Área de Rede Pessoal (PAN) introduzido no "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Oferece API DBus para outros componentes Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Chegando arquivo via Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Chegando arquivo %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Rejeitar"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Recebendo arquivo"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Recebendo arquivo %(0)s de %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Oferece capacidade de transferência de arquivo OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Não há um diretório configurado para os arquivos de entrada"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1917,37 +2341,37 @@ msgstr ""
 "por favor, tenha certeza de que o diretório \"<b>%s</b>\" existe ou "
 "configure-o com os serviços blueman. Até lá, o padrão \"%s\" será usado"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Arquivo recebido"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Arquivo %(0)s de %(1)s recbido com sucesso"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Falha na transferência"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Transferência de arquivo %(0)s falhou"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Arquivos recebidos"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Recebeu %(files)d arquivo no segundo plano"
 msgstr[1] "Recebeu %(files)d arquivos no segundo plano"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1965,27 +2389,27 @@ msgstr ""
 "ícone que mostra a sua condição; desde que não esteja desligado pelo sistema "
 "ou fisicamente."
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Adiciona itens de menu padrão ao menu do ícone de status"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Configurar Novo Dispositivo"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Enviar _Arquivos para o Dispositivo"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Dispositivos"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_tadores"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "miniaplicativo"
 
@@ -1997,27 +2421,27 @@ msgstr "Oferece chave de acesso e serviços de autenticação para o deamon Blue
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Adiciona um menu de saída para finalizar o applet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Oferece um cliente dhcp básico para conexões PAN Bluetooth."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Rede Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interface %(0)s vinculada ao endereço IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Falha na obtenção de um endereço IP em %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2026,7 +2450,7 @@ msgstr ""
 "Tentando obter um endereço IP em %s\n"
 "Aguarde…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2034,22 +2458,27 @@ msgstr ""
 "Adiciona uma indicação no ícone de status quando o Bluetooth está ativo e "
 "mostra o número de conexões na janela de dica."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth ativo"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%(connections)d Conexão Ativa</b>"
 msgstr[1] "<b>%(connections)d Conexões Ativas</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth Desabilitado"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Usa a libappindicator para mostrar um ícone de status"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2057,34 +2486,35 @@ msgstr ""
 "Fornece um item de menu para tornar o adaptador padrão temporariamente "
 "visível quando este é definido como oculto por padrão"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Tempo limite visível"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Quantidade de tempo em segundos que o modo visível vai durar"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Tornar Visível"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Tornar o adaptador padrão temporariamente visível"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Visível... %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Oferece um menu para o applet e uma API para outros plugins o manipularem"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2093,22 +2523,22 @@ msgstr ""
 "Conectado com sucesso ao serviço <b>DUN</b> em <b>%(0)s.</b>\n"
 "Rede disponível agora através do <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "Oferece suporte básico para conexão com a internet via perfil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Manipulador padrão de conexões de perfil SPP, permite executar ações "
 "personalizadas"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script a executar quando conectar"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2126,11 +2556,11 @@ msgstr ""
 "\n"
 "Quando o dispositivo desconecta, o script recebe um sinal HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Porta serial conectada"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2138,11 +2568,11 @@ msgstr ""
 "Serviço de porta serial no dispositivo <b>%s</b> agora estará disponível via "
 "<b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Script de conexão com porta serial falhou"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2151,37 +2581,37 @@ msgstr ""
 "Houve um problema ao lançar o script %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Controla estados de energia do adaptador Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Ligar automaticamente"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Ligar automaticamente os adaptadores"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Desligar Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Desligar todos os adaptadores"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Ligar Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Ligar todos os adaptadores"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2189,21 +2619,20 @@ msgstr ""
 "Temporariamente suspende o protetor de tela quando um joystick bluetooth "
 "está conectado."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Rede"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Endereço de IP inválido"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "Endereço IP em conflito com a interface %s que tem o mesmo endereço"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2214,8 +2643,8 @@ msgstr ""
 "configuração %s/%s\n"
 "Isso causará um comportamento incorreto na rede"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Atualmente não suportado com esta configuração"
 
@@ -2231,10 +2660,6 @@ msgstr "Plugin de serviço de transferência do applet está desabilitado"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Definir propriedades do adaptador de Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-dispositivo"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Applet Blueman"
@@ -2242,11 +2667,6 @@ msgstr "Applet Blueman"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Gerenciador de Bluetooth Blueman"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2288,6 +2708,37 @@ msgstr "Definir Estado do RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Definir Estado do RfKill requer privilégios"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Digitar código PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Informe a chave de acesso"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Porta serial conectada a %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "Fone de ouvido com microfone"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree (adaptador auricular)"
+
+#~ msgid "unknown"
+#~ msgstr "desconhecido"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-dispositivo"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Dispositivos Bluetooth"
 
@@ -2306,9 +2757,6 @@ msgstr "Definir Estado do RfKill requer privilégios"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Remover..."
-
-#~ msgid "Generic Connect"
-#~ msgstr "Conexão genérica"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/ro.po
+++ b/po/ro.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Romanian (http://www.transifex.com/mate/MATE/language/ro/)\n"
@@ -27,7 +27,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Configurări vizibilitate</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Ascuns"
 
@@ -71,8 +71,8 @@ msgstr "_Dispozitiv"
 msgid "_View"
 msgstr "_Vizualizare"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Ajutor"
 
@@ -85,7 +85,7 @@ msgstr "Caută dispozitive în apropiere"
 msgid "Search"
 msgstr "Caută"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Creează asociere cu dispozitivul"
 
@@ -94,17 +94,17 @@ msgstr "Creează asociere cu dispozitivul"
 msgid "Pair"
 msgstr "Asociază"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Marchează / Demarchează acest dispozitiv ca fiind de încredere"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "De încredere"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Rulează asistentul de instalare pentru acest dispozitiv"
 
@@ -113,7 +113,7 @@ msgstr "Rulează asistentul de instalare pentru acest dispozitiv"
 msgid "Setup..."
 msgstr "Instalare..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Elimină acest dispozitiv din lista de dispozitive cunoscute"
 
@@ -295,7 +295,12 @@ msgstr "Nespecificat"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -357,7 +362,7 @@ msgstr "_Restabilește"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "Serviciul Bluetooth trebuie să fie pornit pentru ca administratorul de "
@@ -367,35 +372,33 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Adaptoare bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Întotdeauna"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minut"
 msgstr[1] "%d minute"
 msgstr[2] "%d de minute"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptor"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "Serviciul Bluetooth trebuie să fie pornit pentru ca administratorul de "
 "dispozitive să funcționeze"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Conectarea la BlueZ a eșuat"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -409,48 +412,48 @@ msgstr ""
 msgid "Searching"
 msgstr "Se caută"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Asistent Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Preferințe adaptor"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Expeditor fișier"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transfer de fișiere prin Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Se conectează"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd nu este disponibil"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Se renunță"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Se trimite un fișier"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Timp estimat de recepționare:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -458,94 +461,86 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "A intervenit o eroare la trimiterea fișierului %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Omite"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Reîncearcă"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "A apărut o eroare"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Servicii locale"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Cerere de asociere pentru %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autentificare Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Introduceți codul PIN pentru autentificare:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Introduceți cod PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Introduceți parola pentru autentificare:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Introduceți parola"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Parolă de asociere pentru"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Pairing PIN de asociere pentru"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Cerere de asociere pentru:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Confirmați valoarea pentru autentificare:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Confirmă"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Refuză"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Cerere de autorizare pentru:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Serviciu:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Acceptă întotdeauna"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Acceptă"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -576,241 +571,239 @@ msgstr "Da"
 msgid "No"
 msgstr "Nu"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Raportare problemă"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Gestionar de dispozitive"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Arată bara de _unelte"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Arată bara de _stare"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "S_ortează după"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Nume"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Adugat"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Descendent"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Module"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Servicii _locale"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferințe serviciu"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Caută"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Preferințe adaptor"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "Necategorizat"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>De încredere</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Slab"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Sub-optim"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optim"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Mult"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Prea mult"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Scăzut"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Ridicat"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Foarte ridicat"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Succes!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Port serial conectat la %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Eșuat"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Conexiune eșuată: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Se conectează"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Deconenectare eșuată: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Se deconectează..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Deconectează forțat dispozitivul"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Conectare la:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Deconectare:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Trimite un _fișier..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Asociază"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "Este de încredere"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Nu este de încredere"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Redenumire dispozitiv"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Elimină"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Renunță la operațiune"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indicator activitate date"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Totalul datelor recepţionate și rata transmisiei"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Totalul datelor trimise și rata transmisiei"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Nu mai este de încredere"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Selectați un dispozitiv"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mai multe"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Transifex:\n"
@@ -823,7 +816,7 @@ msgstr ""
 "  Ionuț Jula https://launchpad.net/~ionutjula\n"
 "  Ovidiu Nitan https://launchpad.net/~nitanovidiu"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman este un gestionar de Bluetooth GTK+"
 
@@ -831,17 +824,17 @@ msgstr "Blueman este un gestionar de Bluetooth GTK+"
 msgid "GSM Settings"
 msgstr "Stabiliri GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Module"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problemă de dependență"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -852,7 +845,7 @@ msgstr ""
 "va dezactiva și <b>\"%(0)s\"</b>.\n"
 "Continuați?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -863,886 +856,1259 @@ msgstr ""
 "b> va dezctiva <b>%(0)s</b>.\n"
 "Continuați?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Selectare adaptor"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Se deconectează..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "Necategorizat"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Punct de acces rețea"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "desktop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "servitor"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "Dispozitiv de mână"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "celular"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "fără fir"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "smart phone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modern"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd nu este disponibil"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "headset"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "Mâini libere"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "necunoscut"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "microfon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Sursă audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Sursă audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Sursă audio"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tastatură"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "Dispozitiv de indicat"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tastatură"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "Dispozitiv de indicat"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Conectează"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Conectează"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Conectează"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Conectează"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Transfer de fișiere prin Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Conectează"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Transfer de fișiere prin Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Transfer de fișiere prin Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Grupare rețea"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transfer de fișiere prin Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Conectează"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Conectează"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transfer de fișiere prin Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Conectează"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Grupare rețea"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Porturi seriale"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Rețea Dialup (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Transfer de fișiere prin Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "headset"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Sursă audio"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Sincronizare Audio"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Punct de acces rețea"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Grupare rețea"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "Mâini libere"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Punct de acces rețea (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Punct de acces rețea (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Grupare rețea"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Transfer de fișiere prin Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Sursă audio"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Sincronizare Audio"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Sursă audio"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Redenumire dispozitiv"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Arată informații dispozitiv"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Servicii locale"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Transfer"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "miniaplicație"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Servicii locale"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Caută dispozitive în apropiere"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Transfer"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "miniaplicație"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Local Services"
-msgid "Primary Service"
-msgstr "Servicii locale"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Caută dispozitive în apropiere"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Gestionar de dispozitive"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "_Connexiuni recente"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Gestionar de dispozitive"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Preferințe adaptor"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietar"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "da"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nu"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Informații"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Arată informații dispozitiv"
 
@@ -1767,34 +2133,35 @@ msgstr "Profil Audio"
 msgid "Select audio profile for PulseAudio"
 msgstr "Selectectați profilul audio pentru PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Port serial %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Reînnoiește adresa IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Stabiliri dialup"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Porturi seriale"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nespecificat"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Connectat"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1865,29 +2232,24 @@ msgstr " _Utilizare rețea"
 msgid "Shows network traffic usage"
 msgstr "Arată traficul utilizat în rețea"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth pornit"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth oprit"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Administrează serviciile din rețeaua locală, cum ar fi punțiile NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 "Oferă capabilitate rețea Dial Up (DUN) pentru ModemManager și NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1895,38 +2257,38 @@ msgstr ""
 "acces rapid"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maximum de elemente"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Numărul maxim de elemente pe care meniul de conexiuni recente îl va afișa."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "_Connexiuni recente"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Conectat la %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Conectarea a eșuat"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s pe %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adaptorul pentru această conexiune nu este disponibil"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1934,86 +2296,82 @@ msgstr ""
 "Oferă suport pentru rețea zonă personală (PAN) introdudusă în NetworkManager "
 "0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Oferă API DBus pentru alte componente Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Primire fișier prin Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Primire fișier %(0)s de la %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Refuză"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Se primește un fișier"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Se primește fișierul %(0)s de la %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 "Oferă capabilitatatea de a utiliza protocolul OBEX pentru transferul "
 "fișierelor"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Directorul configurat pentru primirea fișierelor nu există"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Fișier primit"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Fișierul %(0)s de la %(1)s a fost primit cu succes"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Transferul a eșuat"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Transferul fișierului %(0)s a eșuat"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Fișiere primite"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "S-a primit %d fișier pe fundal"
 msgstr[1] "S-au primit %d fișiere pe fundal"
 msgstr[2] "S-au primit %d de fișiere pe fundal"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "S-a primit încă %d fișier pe fundal"
@@ -2027,27 +2385,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Adaugă elemente de meniu standrd la meniul pictogramei de stare"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Trimite _fișiere dispozitivului"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Dispozitive"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_toare"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "miniaplicație"
 
@@ -2060,34 +2418,34 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Adaugă un element de ieșire la meniu pentru a ieși din miniaplicație"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Oferă un client dhcp de bază pentru conexiunile PAN Bluetooth."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Rețea Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Interfața %(0)s legată de adresa IP %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Eșuare la obținerea adresei IP pe %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2095,25 +2453,28 @@ msgstr ""
 "Adaugă o indicație pe pictograma de stare când serviciul Bluetooth este "
 "activ și arată numărul de conexiuni într-o fereastră informativă."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth activ"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d conexiune activă</b>"
 msgstr[1] "<b>%d conexiuni active</b>"
 msgstr[2] "<b>%d de conexiuni active</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth oprit"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Utilizează libappindicator pentru a afișa o pictogramă de stare"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2121,35 +2482,36 @@ msgstr ""
 "Oferă un element de meniu pentru facerea adaptorului implicit temporar "
 "vizibil când este stabilit ca ascuns impliicit"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Limită de timp mod vizibil"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Durata de timp a modului vizibil"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Activează modul _vizibil"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Faceți adaptorul implicit temporar vizibil"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Oferă un meniu pentru miniaplicație și un API de manipulat de către "
 "celelalte module"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2158,23 +2520,23 @@ msgstr ""
 "Conectat cu succes la serviciul <b>DUN</b> pe <b>%(0)s.</b>\n"
 "Rețeaua este de acum disponibilă prin <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Oferă capabilitatea de bază pentru conectarea la internet prin profil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Operator conexiune profil SPP standard, permite executarea de acțiune "
 "particularizate"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Script de executat la conectare"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2193,11 +2555,11 @@ msgstr ""
 "La deconectarea dispozitivului, scriptului îi va fi trimis un semnal HUP</"
 "span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Port serial conectat"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2205,11 +2567,11 @@ msgstr ""
 "Serviciu de port serial pe dispozitivul <b>%s</b> va fi disponibil de acum "
 "prin <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Scriptul de conectare port serial a eșuat"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2218,37 +2580,37 @@ msgstr ""
 "A intervenit o eroare la lansarea scriptului %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Controlează stările de energie ale adaptorului Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Pornire automată"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Pornește automat adaptoare"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Oprește Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Oprește toate adaptoarele"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>P_ornește Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Pornește toate adaptoarele"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2256,21 +2618,20 @@ msgstr ""
 "Suspendă temporar protecorul ecran când este conectată o manetă prin "
 "bluetooth."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Rețea"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Adresa IP nu este validă"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "Adresa IP este în conflict cu interfața %s care are aceeași adresă"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2278,8 +2639,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Nu este momentan compatibil cu această configurare"
 
@@ -2293,40 +2654,26 @@ msgstr "Modulul serviciu de transfer al miniaplicației este dezactivat"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adaptoare bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "miniaplicație"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman este un gestionar de Bluetooth GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth pornit"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Dispozitive Bluetooth"
 
@@ -2362,6 +2709,31 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Introduceți cod PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Introduceți parola"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Port serial conectat la %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "headset"
+
+#~ msgid "handsfree"
+#~ msgstr "Mâini libere"
+
+#~ msgid "unknown"
+#~ msgstr "necunoscut"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Dispozitive Bluetooth"
 
@@ -2384,11 +2756,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Elimină..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Conectează"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/ru.po
+++ b/po/ru.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-29 15:23+0000\n"
 "Last-Translator: Artyom <mccoal@hotmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -35,7 +35,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Настройки видимости</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Скрытый"
 
@@ -79,8 +79,8 @@ msgstr "_Устройство"
 msgid "_View"
 msgstr "_Просмотр"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Справка"
 
@@ -93,7 +93,7 @@ msgstr "Поиск устройств"
 msgid "Search"
 msgstr "Найти"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Создать сопряжение с устройством"
 
@@ -102,17 +102,17 @@ msgstr "Создать сопряжение с устройством"
 msgid "Pair"
 msgstr "Сопряжение"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Установить это устройство как Доверенное/Недоверенное"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Доверять"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Запустить помощник установки для этого устройства"
 
@@ -121,7 +121,7 @@ msgstr "Запустить помощник установки для этого
 msgid "Setup..."
 msgstr "Настройки…"
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Удалить это устройство из списка известных устройств"
 
@@ -302,7 +302,12 @@ msgstr "Не указан"
 msgid "<b>Author:</b>"
 msgstr "<b>Автор:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -364,7 +369,7 @@ msgstr "_Сброс"
 msgid "Send note"
 msgstr "Отправить записку"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Для работы менеджера Bluetooth адаптер должен быть включен"
 
@@ -372,14 +377,12 @@ msgstr "Для работы менеджера Bluetooth адаптер долж
 msgid "Bluetooth Adapters"
 msgstr "Адаптеры Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Всегда"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d минута"
@@ -387,20 +390,20 @@ msgstr[1] "%d минуты"
 msgstr[2] "%d минут"
 msgstr[3] "%d минут"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Адаптер"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "Для того, чтобы менеджер устройств работал, Bluetooth должен быть включен"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Не удалось соединиться с BlueZ"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -414,50 +417,50 @@ msgstr ""
 msgid "Searching"
 msgstr "Идёт поиск"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Помощник настройки bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Настройки адаптеров"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Отправитель файлов"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Передача файлов через Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Соединение"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd недоступен"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Не удалось автоматически запустить службу obex. Убедитесь, что демон obex "
 "запущен"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Отмена"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Отправка файла"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Оставшееся время:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -466,94 +469,86 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Произошла ошибка вовремя отправки файла %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Пропустить"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Повторить"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Возникла ошибка"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Локальные службы"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Запрос сопряжения с %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Аутентификация по Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Введите PIN-код для аутентификации:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Введите PIN код"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Введите код авторизации:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Введите код сопряжения"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Сопряжение ключа для"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Сопряжение PIN кода для"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Запрос соединения для:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Подтвердите код авторизации:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Подтвердить"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Отклонить"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Запрос авторизации для:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Служба:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Всегда принимать"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Принять"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -587,240 +582,239 @@ msgstr "Да"
 msgid "No"
 msgstr "Нет"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Сообщить о проблеме"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Менеджер устройств"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Показать _панель инструментов"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Показать _строку состояния"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "C_ортировать по"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Имя"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Добавлен"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Снижение"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Модули"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "сервисный центр"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Настройки служб"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "П_оиск"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "Настройки"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "Выход"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "не классифицировано"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Доверенные и сопряжённые</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Связанные</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Доверенный</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Слабый"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Хуже оптимального"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Оптимальный"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Хорошо"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Очень хорошо"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Низкий"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Высокий"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Самый высокий"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Успешно!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Подключен последовательный порт на %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Неудачно"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Соединение невозможно или разорвано: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Соединение"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Не удалось отсоединиться: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Отключение…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Подключиться</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Подключает профили автосоединения с источниками A2DP, приемниками A2DP и HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Отключиться</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Принудительно отсоединить устройство"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Подключиться к:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Отключиться:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Послать _файл…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Сопряжение"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Доверять"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Не доверять"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Настроить…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Переименовать устройство"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Удалить"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Прервать выполнение операции"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Индикация обмена данными"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Общий объём полученных данных и скорости приёма"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Общий объём отправленных данных и скорости передачи"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Не доверять"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Выберите устройство"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Ещё"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Алексей Сорокин <sor.alexei@meowr.ru>\n"
@@ -831,7 +825,7 @@ msgstr ""
 "Леонид Кантер <leon@asplinux.ru>\n"
 "Александр Сигачёв <ajvol2@gmail.com>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman — это менеджер Bluetooth, построенный на основе GTK+"
 
@@ -839,17 +833,17 @@ msgstr "Blueman — это менеджер Bluetooth, построенный н
 msgid "GSM Settings"
 msgstr "Настройки GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Модули"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Проблема с зависимостями"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -860,7 +854,7 @@ msgstr ""
 "также отключит <b>\"%(0)s\"</b>.\n"
 "Продолжить?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -871,884 +865,1269 @@ msgstr ""
 "%(1)s</b> модуль <b>%(0)s</b> будет выгружен.\n"
 "Продолжить?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Выбор адаптера"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr "Обнаружение…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "не классифицировано"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Точка доступа к сети"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "персональный компьютер"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "сервер"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "ноутбук"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "карманный компьютер"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "ПДА (наладонник)"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "мобильный телефон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "беспроводное устройство"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "смартфон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "модем"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
-
-#. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "наушники"
-
-#. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "гарнитура"
-
-#. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "неизвестно"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
-msgstr "микрофон"
-
-#. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
-msgstr "громкоговоритель"
-
-#. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
-msgstr "наушники"
-
-#. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
-msgstr "портативное аудиоустройство"
-
-#. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr "аудиоустройство для автомобиля"
-
-#. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
-msgstr "телеприставка"
-
-#. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
-msgstr "hifi аудиоустройство"
-
-#. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
-msgstr "видеомагнитофон"
-
-#. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
-msgstr "видеокамера"
-
-#. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
-msgstr "видеокамера"
-
-#. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr "видеомонитор"
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr "видео дисплей и громкоговоритель"
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
-msgstr "видео-конференциальное"
-
-#. translators: device class
-#: blueman/DeviceClass.py:145
-msgid "gaming/toy"
-msgstr "игровое"
-
-#. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "клавиатура"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "манипулятор"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
-msgstr "комбо"
-
-#: blueman/Sdp.py:93
-msgid "SDP"
-msgstr "SDP"
-
-#: blueman/Sdp.py:94
-msgid "UDP"
-msgstr "UDP"
-
-#: blueman/Sdp.py:95
-msgid "RFCOMM"
-msgstr "RFCOMM"
-
-#: blueman/Sdp.py:96
-msgid "TCP"
-msgstr "TCP"
-
-#: blueman/Sdp.py:97
-msgid "TCS-BIN"
-msgstr "TCS-BIN"
-
-#: blueman/Sdp.py:98
-msgid "TCS-AT"
-msgstr "TCS-AT"
-
-#: blueman/Sdp.py:99
-msgid "ATT"
-msgstr "ATT"
-
-#: blueman/Sdp.py:100
-msgid "OBEX"
+msgid "83-99 percent"
 msgstr ""
 
-#: blueman/Sdp.py:101
-msgid "IP"
-msgstr ""
-
-#: blueman/Sdp.py:102
-msgid "FTP"
-msgstr ""
-
-#: blueman/Sdp.py:103
-msgid "HTTP"
-msgstr ""
-
-#: blueman/Sdp.py:104
-msgid "WSP"
-msgstr ""
-
-#: blueman/Sdp.py:105
-msgid "BNEP"
-msgstr ""
-
-#: blueman/Sdp.py:106
-msgid "UPnP/ESDP"
-msgstr ""
-
-#: blueman/Sdp.py:107
-msgid "HIDP"
-msgstr ""
-
-#: blueman/Sdp.py:108
-msgid "Hardcopy Control Channel"
-msgstr ""
-
-#: blueman/Sdp.py:109
-msgid "Hardcopy Data Channel"
-msgstr ""
-
-#: blueman/Sdp.py:110
-msgid "Hardcopy Notification"
-msgstr ""
-
-#: blueman/Sdp.py:111
-msgid "AVCTP"
-msgstr ""
-
-#: blueman/Sdp.py:112
-msgid "AVDTP"
-msgstr ""
-
-#: blueman/Sdp.py:113
-msgid "CMTP"
-msgstr ""
-
-#: blueman/Sdp.py:114
-msgid "UDI_C-Plane"
-msgstr ""
-
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
-msgid "Multi-Channel Adaptation Protocol (MCAP)"
-msgstr ""
-
-#: blueman/Sdp.py:117
-msgid "L2CAP"
-msgstr ""
-
-#: blueman/Sdp.py:118
-msgid "ServiceDiscoveryServerServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:119
-msgid "BrowseGroupDescriptorServiceClassID"
-msgstr ""
-
-#: blueman/Sdp.py:120
-msgid "Public Browse Group"
-msgstr ""
-
-#: blueman/Sdp.py:121
+#. translators: device class
+#: blueman/DeviceClass.py:75
 #, fuzzy
-#| msgid "Serial Ports"
-msgid "Serial Port"
-msgstr "Последовательные порты"
+msgid "Not available"
+msgstr "obexd недоступен"
 
-#: blueman/Sdp.py:122
-msgid "LAN Access Using PPP"
-msgstr ""
-
-#: blueman/Sdp.py:123
-msgid "Dialup Networking (DUN)"
-msgstr "Передача данных через модем (DUN)"
-
-#: blueman/Sdp.py:124
-msgid "IrMC Sync"
-msgstr ""
-
-#: blueman/Sdp.py:125
-msgid "OBEX Object Push"
-msgstr ""
-
-#: blueman/Sdp.py:126
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
-msgid "OBEX File Transfer"
-msgstr "Передача файлов через Bluetooth"
-
-#: blueman/Sdp.py:127
-msgid "IrMC Sync Command"
-msgstr ""
-
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
 msgid "Headset"
 msgstr "наушники"
 
-#: blueman/Sdp.py:129
-msgid "Cordless Telephony"
-msgstr "Беспроводная телефония"
-
-#: blueman/Sdp.py:130
-msgid "Audio Source"
-msgstr "Источник звука"
-
-#: blueman/Sdp.py:131
-msgid "Audio Sink"
-msgstr "Приёмник звука"
-
-#: blueman/Sdp.py:132
-msgid "Remote Control Target"
-msgstr "Пульт ДУ цели"
-
-#: blueman/Sdp.py:133
-msgid "Advanced Audio"
-msgstr ""
-
-#: blueman/Sdp.py:134
-msgid "Remote Control"
-msgstr ""
-
-#: blueman/Sdp.py:135
-msgid "Video Conferencing"
-msgstr ""
-
-#: blueman/Sdp.py:136
-msgid "Intercom"
-msgstr ""
-
-#: blueman/Sdp.py:137
-msgid "Fax"
-msgstr ""
-
-#: blueman/Sdp.py:138
-msgid "Headset Audio Gateway"
-msgstr ""
-
-#: blueman/Sdp.py:139
-msgid "WAP"
-msgstr ""
-
-#: blueman/Sdp.py:140
-msgid "WAP Client"
-msgstr ""
-
-#: blueman/Sdp.py:141
-msgid "PANU"
-msgstr ""
-
-#: blueman/Sdp.py:142
-msgid "Network Access Point"
-msgstr "Точка доступа к сети"
-
-#: blueman/Sdp.py:143
-msgid "Group Network"
-msgstr "Групповая сеть"
-
-#: blueman/Sdp.py:144
-msgid "DirectPrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:145
-msgid "ReferencePrinting (BPP)"
-msgstr ""
-
-#: blueman/Sdp.py:146
-msgid "Imaging (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:147
-msgid "ImagingResponder (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:148
-msgid "ImagingAutomaticArchive (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:149
-msgid "ImagingReferencedObjects (BIP)"
-msgstr ""
-
-#: blueman/Sdp.py:150
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
 #, fuzzy
-#| msgid "handsfree"
 msgid "Handsfree"
 msgstr "гарнитура"
 
-#: blueman/Sdp.py:151
+#. translators: device class
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
+msgstr "микрофон"
+
+#. translators: device class
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
+msgstr "громкоговоритель"
+
+#. translators: device class
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
+msgstr "наушники"
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
+msgstr "портативное аудиоустройство"
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
+msgstr "аудиоустройство для автомобиля"
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
+msgstr "телеприставка"
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
+msgstr "hifi аудиоустройство"
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
+msgstr "видеомагнитофон"
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "видеокамера"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
+msgstr "видеокамера"
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "видеомонитор"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
+msgstr "видео дисплей и громкоговоритель"
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "видео-конференциальное"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+#, fuzzy
+msgid "Gaming/Toy"
+msgstr "игровое"
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "клавиатура"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "манипулятор"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+#, fuzzy
+msgid "Combo"
+msgstr "комбо"
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+msgid "Display"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Обычное подключение"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Обычное подключение"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Обычное подключение"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Обычное подключение"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Передача файлов через Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Пульт ДУ цели"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Передача файлов через Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Передача файлов через Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Групповая сеть"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Передача файлов через Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Обычное подключение"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Обычное подключение"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Передача файлов через Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Обычное подключение"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Групповая сеть"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
+msgid "SDP"
+msgstr "SDP"
+
+#: blueman/Sdp.py:88
+msgid "UDP"
+msgstr "UDP"
+
+#: blueman/Sdp.py:89
+msgid "RFCOMM"
+msgstr "RFCOMM"
+
+#: blueman/Sdp.py:90
+msgid "TCP"
+msgstr "TCP"
+
+#: blueman/Sdp.py:91
+msgid "TCS-BIN"
+msgstr "TCS-BIN"
+
+#: blueman/Sdp.py:92
+msgid "TCS-AT"
+msgstr "TCS-AT"
+
+#: blueman/Sdp.py:93
+msgid "ATT"
+msgstr "ATT"
+
+#: blueman/Sdp.py:94
+msgid "OBEX"
+msgstr ""
+
+#: blueman/Sdp.py:95
+msgid "IP"
+msgstr ""
+
+#: blueman/Sdp.py:96
+msgid "FTP"
+msgstr ""
+
+#: blueman/Sdp.py:97
+msgid "HTTP"
+msgstr ""
+
+#: blueman/Sdp.py:98
+msgid "WSP"
+msgstr ""
+
+#: blueman/Sdp.py:99
+msgid "BNEP"
+msgstr ""
+
+#: blueman/Sdp.py:100
+msgid "UPnP/ESDP"
+msgstr ""
+
+#: blueman/Sdp.py:101
+msgid "HIDP"
+msgstr ""
+
+#: blueman/Sdp.py:102
+msgid "Hardcopy Control Channel"
+msgstr ""
+
+#: blueman/Sdp.py:103
+msgid "Hardcopy Data Channel"
+msgstr ""
+
+#: blueman/Sdp.py:104
+msgid "Hardcopy Notification"
+msgstr ""
+
+#: blueman/Sdp.py:105
+msgid "AVCTP"
+msgstr ""
+
+#: blueman/Sdp.py:106
+msgid "AVDTP"
+msgstr ""
+
+#: blueman/Sdp.py:107
+msgid "CMTP"
+msgstr ""
+
+#: blueman/Sdp.py:108
+msgid "UDI_C-Plane"
+msgstr ""
+
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
+msgid "Multi-Channel Adaptation Protocol (MCAP)"
+msgstr ""
+
+#: blueman/Sdp.py:111
+msgid "L2CAP"
+msgstr ""
+
+#: blueman/Sdp.py:112
+msgid "ServiceDiscoveryServerServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:113
+msgid "BrowseGroupDescriptorServiceClassID"
+msgstr ""
+
+#: blueman/Sdp.py:114
+msgid "Public Browse Group"
+msgstr ""
+
+#: blueman/Sdp.py:115
+#, fuzzy
+msgid "Serial Port"
+msgstr "Последовательные порты"
+
+#: blueman/Sdp.py:116
+msgid "LAN Access Using PPP"
+msgstr ""
+
+#: blueman/Sdp.py:117
+msgid "Dialup Networking (DUN)"
+msgstr "Передача данных через модем (DUN)"
+
+#: blueman/Sdp.py:118
+msgid "IrMC Sync"
+msgstr ""
+
+#: blueman/Sdp.py:119
+msgid "OBEX Object Push"
+msgstr ""
+
+#: blueman/Sdp.py:120
+#, fuzzy
+msgid "OBEX File Transfer"
+msgstr "Передача файлов через Bluetooth"
+
+#: blueman/Sdp.py:121
+msgid "IrMC Sync Command"
+msgstr ""
+
+#: blueman/Sdp.py:123
+msgid "Cordless Telephony"
+msgstr "Беспроводная телефония"
+
+#: blueman/Sdp.py:124
+msgid "Audio Source"
+msgstr "Источник звука"
+
+#: blueman/Sdp.py:125
+msgid "Audio Sink"
+msgstr "Приёмник звука"
+
+#: blueman/Sdp.py:126
+msgid "Remote Control Target"
+msgstr "Пульт ДУ цели"
+
+#: blueman/Sdp.py:127
+msgid "Advanced Audio"
+msgstr ""
+
+#: blueman/Sdp.py:128
+msgid "Remote Control"
+msgstr ""
+
+#: blueman/Sdp.py:129
+msgid "Video Conferencing"
+msgstr ""
+
+#: blueman/Sdp.py:130
+msgid "Intercom"
+msgstr ""
+
+#: blueman/Sdp.py:131
+msgid "Fax"
+msgstr ""
+
+#: blueman/Sdp.py:132
+msgid "Headset Audio Gateway"
+msgstr ""
+
+#: blueman/Sdp.py:133
+msgid "WAP"
+msgstr ""
+
+#: blueman/Sdp.py:134
+msgid "WAP Client"
+msgstr ""
+
+#: blueman/Sdp.py:135
+msgid "PANU"
+msgstr ""
+
+#: blueman/Sdp.py:136
+msgid "Network Access Point"
+msgstr "Точка доступа к сети"
+
+#: blueman/Sdp.py:137
+msgid "Group Network"
+msgstr "Групповая сеть"
+
+#: blueman/Sdp.py:138
+msgid "DirectPrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:139
+msgid "ReferencePrinting (BPP)"
+msgstr ""
+
+#: blueman/Sdp.py:140
+msgid "Imaging (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:141
+msgid "ImagingResponder (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:142
+msgid "ImagingAutomaticArchive (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:143
+msgid "ImagingReferencedObjects (BIP)"
+msgstr ""
+
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Точка доступа к сети (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Точка доступа к сети (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Групповая сеть"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Передача файлов через Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Источник звука"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Приёмник звука"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Источник звука"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Переименовать устройство"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Показать сведения об устройстве"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Локальные службы"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Передача"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "апплет"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Сопряжение с устройством"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Поиск устройств"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Передача"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "апплет"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Сопряжение с устройством"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Поиск устройств"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Менеджер устройств"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Недавние _подключения"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Менеджер устройств"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Настройки адаптеров"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Профили автоматического подключения"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Проприетарный"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "да"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "нет"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Информация"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Показать сведения об устройстве"
 
@@ -1773,34 +2152,35 @@ msgstr "Профиль звука"
 msgid "Select audio profile for PulseAudio"
 msgstr "Выбрать профиль звука для PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Последовательный порт %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Обновить IP адрес"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Настройки службы доступа к сети через модем"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Последовательные порты"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Не указано"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Соединение установлено"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1877,22 +2257,17 @@ msgstr "Использование _сети"
 msgid "Shows network traffic usage"
 msgstr "Показывает статистику использования сети"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth включен"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth отключен"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Управляет местными услугами сети, такими как NAP мосты"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1900,7 +2275,7 @@ msgstr ""
 "Обеспечивает поддержку для Dial Up Networking (DUN) для ModemManager и "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1908,38 +2283,38 @@ msgstr ""
 "соединения для быстрого доступа"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Максимальное число элементов"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Максимальное число элементов, отображаемых в меню «Недавние соединения»."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Недавние _подключения"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Подключено к %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Невозможно установить соединение"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s на %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Адаптер для этого соединения недоступен"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1947,41 +2322,41 @@ msgstr ""
 "Обеспечивает поддержку Personal Area Networking (PAN), представленную в "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Предоставляет API DBus для других компонентов Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Входящий файл через Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Входящий файл %(0)s от %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Отклонить"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Получение файла"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Получение файла %(0)s от %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Обеспечивает обмен файлами по протоколу OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Настроенный каталог для входящих файлов не существует"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1990,33 +2365,31 @@ msgstr ""
 "Убедитесь, что каталог «<b>%s</b>» существует или настройте его через "
 "blueman-services. До тех пор будет использоваться умолчательный каталог «%s»"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Файл получен"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Успешно получен файл %(0)s от %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Передача не удалась"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Передача файла %(0)s не удалась"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Получены файлы"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Получен %d файл в фоне"
@@ -2024,10 +2397,8 @@ msgstr[1] "Получено %d файла в фоне"
 msgstr[2] "Получено %d файлов в фоне"
 msgstr[3] "Получено %d файлов в фоне"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Получен ещё %d файл в фоне"
@@ -2042,27 +2413,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Добавить стандартные пункты меню к меню значка в области уведомления"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Настроить новое устройство"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Послать _файлы на устройство"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Устройства"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "_Адаптеры"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "апплет"
 
@@ -2074,27 +2445,27 @@ msgstr "Предоставляет сервисы обмена ключами и
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Добавляет пункт меню для выхода из приложения"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Предоставляет базовый dhcp клиент для PAN соединений Bluetooth."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Сеть Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Интерфейсу %(0)s присвоен IP адрес %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Невозможно получить IP адрес на %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2103,7 +2474,7 @@ msgstr ""
 "Попытка получить IP адрес на %s\n"
 "Пожалуйста, подождите…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2111,14 +2482,12 @@ msgstr ""
 "Добавить индикацию в значок области уведомления, когда Bluetooth активен, и "
 "показывать количество подключений во всплывающей подсказке."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth активен"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Активное соединение</b>"
@@ -2126,11 +2495,16 @@ msgstr[1] "<b>%d Активных соединения</b>"
 msgstr[2] "<b>%d Активных соединений</b>"
 msgstr[3] "<b>%d Активных соединений</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth отключен"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Используется libappindicator для показа значка уведомления"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2138,36 +2512,37 @@ msgstr ""
 "Пункт меню, который позволяет сделать основной адаптер видимым для внешних "
 "устройств, когда по умолчанию установлен режим невидимости"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Время обнаружения"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 "Период времени, в течение которого адаптер могут обнаружить внешние "
 "устройства"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Сделать _видимым"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Сделать основной адаптор временно видимым"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Видимый...%ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Предоставляет меню апплета и API для плагинов, позволяющее им управлять"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2177,23 +2552,23 @@ msgstr ""
 "b>\n"
 "Сеть теперь доступна через <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Предоставляет базовую поддержку подключения к интернету через профиль DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Стандартный обработчик соединения профиля SPP, позволяющий выполнять "
 "стандартные действия"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Запускаемый после соединения скрипт"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2211,22 +2586,22 @@ msgstr ""
 "\n"
 "После отключения устройства скрипт передаст сигнал HUP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Последовательный порт подключен"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "Последовательный порт на устройстве <b>%s</b> теперь доступен через <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Подключение по последовательному порту не удалось"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2235,37 +2610,37 @@ msgstr ""
 "Появилась проблема при запуске скрипта %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Контролировать состояние питания Bluetooth-адаптера"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Автовключение"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Автоматическое включение адаптеров"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Отключить Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Отключить все адаптеры"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>В_ключить Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Включить все адаптеры"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2273,21 +2648,20 @@ msgstr ""
 "Временно приостанавливает заставку, когда игровой контроллер bluetooth "
 "подключен."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Сеть"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Некорректный IP-адрес"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP-адрес несовместим с интерфейсом %s, который имеет такой же адрес"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2298,8 +2672,8 @@ msgstr ""
 "конфигурацию: %s/%s\n"
 "Это может привести к некорректному поведению сети"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "В данный момент не поддерживается"
 
@@ -2315,10 +2689,6 @@ msgstr "Плагин сервиса передачи апплета отключ
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Установить свойства адаптера Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "Устройство с Bluetooth"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Приложение для работы с Bluetooth"
@@ -2326,11 +2696,6 @@ msgstr "Приложение для работы с Bluetooth"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman — это менеджер Bluetooth"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "сервис работы с bluetooth"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2372,6 +2737,37 @@ msgstr "Установить состояние RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Установка состояния RfKill требует соответствующих привилегий"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Введите PIN код"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Введите код сопряжения"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Подключен последовательный порт на %s"
+
+#~ msgid "palm"
+#~ msgstr "ПДА (наладонник)"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "наушники"
+
+#~ msgid "handsfree"
+#~ msgstr "гарнитура"
+
+#~ msgid "unknown"
+#~ msgstr "неизвестно"
+
+#~ msgid "blueman-device"
+#~ msgstr "Устройство с Bluetooth"
+
+#~ msgid "blueman"
+#~ msgstr "сервис работы с bluetooth"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Устройства Bluetooth"
 
@@ -2394,9 +2790,6 @@ msgstr "Установка состояния RfKill требует соотве
 
 #~ msgid "_Remove..."
 #~ msgstr "_Удалить…"
-
-#~ msgid "Generic Connect"
-#~ msgstr "Обычное подключение"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/sk.po
+++ b/po/sk.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Juraj Liso <lisojuraj@gmail.com>\n"
 "Language-Team: Slovak <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -29,7 +29,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Nastavenie viditeľnosti</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Skrytý"
 
@@ -73,8 +73,8 @@ msgstr "_Zariadenie"
 msgid "_View"
 msgstr "Z_obrazenie"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Pomocník"
 
@@ -87,7 +87,7 @@ msgstr "Vyhľadá zariadenia v blízkosti"
 msgid "Search"
 msgstr "Hľadať"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Spáruje sa s týmto zariadením"
 
@@ -96,17 +96,17 @@ msgstr "Spáruje sa s týmto zariadením"
 msgid "Pair"
 msgstr "Spárovať"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Označí/odznačí toto zariadenie ako dôveryhodné"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Dôveryhodné"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Spustí asistenta nastavovaním tohoto zariadenia"
 
@@ -115,7 +115,7 @@ msgstr "Spustí asistenta nastavovaním tohoto zariadenia"
 msgid "Setup..."
 msgstr "Nastaviť..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Odstráni toto zariadenie zo zoznamu známych zariadení"
 
@@ -296,7 +296,12 @@ msgstr "Neuvedený"
 msgid "<b>Author:</b>"
 msgstr "<b>Autor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -358,7 +363,7 @@ msgstr "O_bnoviť"
 msgid "Send note"
 msgstr "Odoslať poznámku"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth musí byť pre fungovanie správcu adaptérov zapnutý"
 
@@ -366,14 +371,12 @@ msgstr "Bluetooth musí byť pre fungovanie správcu adaptérov zapnutý"
 msgid "Bluetooth Adapters"
 msgstr "Adaptéry Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Vždy"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minúta"
@@ -381,19 +384,19 @@ msgstr[1] "%d minúty"
 msgstr[2] "%d minút"
 msgstr[3] "%d minút"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adaptér"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth musí byť pre fungovania správcu zariadení zapnutý"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Pripojenie k BlueZ zlyhalo"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -407,50 +410,50 @@ msgstr ""
 msgid "Searching"
 msgstr "Hľadá sa"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth asistent"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Nastavenia adaptéra"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Nástroj na odoslanie súborov"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Prenos súborov cez Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Pripája sa"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "Program obexd nie je dostupný"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Nepodarilo sa automaticky spustiť službu obex. Presvedčte sa, že obex démon "
 "je spustený"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Ruší sa"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Odosiela sa súbor"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -459,94 +462,86 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Počas odosielania súboru %s nastala chyba"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Preskočiť"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Skúsiť znovu"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Nastala chyba"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokálne služby"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Požiadavka na spárovánie s %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Overenie Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Vložte PIN kód pre overenie:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Zadajte PIN kód"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Zadajte heslo pre overenie:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Vložte heslo"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Párovacie heslo pre"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Párovací PIN kód pre"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Požadované párovanie pre:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Potvrďte hodnotu pre overenie:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Potvrdiť"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Zamietnuť"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Požadované overenie pre:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Služba:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Vždy prijať"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Prijať"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -581,243 +576,240 @@ msgstr "Áno"
 msgid "No"
 msgstr "Nie"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Nahlásiť problém"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Správca zariadení"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Zobraziť panel _nástrojov"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Zobraziť _stavový riadok"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Z_oradiť podľa"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Názvu"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Pridania"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Zostupne"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Zásuvné moduly"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokálne služby"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Nastavenia služby"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Hľadať"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Nastavenia adaptéra"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Skončiť"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "nezaradené"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Dôveryhodné a spárované</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Spárované</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Dôveryhodný</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Slabé"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Sub-optimálne"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimálne"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Viac"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Prílíš veľa"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Nízke"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Vysoké"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Veľmi vysoké"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Úspech!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Sériový port pripojený na %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Zlyhalo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Pripojenie zlyhalo: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Pripája sa"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Odpojenie zlyhalo: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Odpája sa..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Pripojiť sa</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Prepája profily automatického pripojenie A2DP source, A2DP sink a HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Odpojiť sa</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Nútene odpojiť zariadenie"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Pripojiť sa k:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Odpojiť:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Odoslať súbor..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Spárovať"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Dôverovať"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Nedôverovať"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Nastaviť…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Premenovať zariadenie"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Odstrániť"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Zrušiť operáciu"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Indikácia aktivity údajov"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Celkové prijaté údaje a rýchlosť prenosu"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Celkové odoslané údaje a rýchlosť prenosu"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Nedôverovať"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Vybrať zariadenie"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Viac"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -827,7 +819,7 @@ msgstr ""
 "  vadimo https://launchpad.net/~michalgejdos-azet\n"
 "  xills pills https://launchpad.net/~adamturan"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman je správca Bluetooth založený na GTK+"
 
@@ -835,17 +827,17 @@ msgstr "Blueman je správca Bluetooth založený na GTK+"
 msgid "GSM Settings"
 msgstr "Nastavenia GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Zásuvné moduly"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Chyba so závislosťami"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -856,7 +848,7 @@ msgstr ""
 "uvoľní aj <b>„%(0)s“</b>.\n"
 " Pokračovať?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -867,886 +859,1259 @@ msgstr ""
 "b> uvoľní <b>%(0)s</b>.\n"
 " Pokračovať?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Výber adaptéra"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Objaviteľné… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "nezaradené"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Prístupový bod siete"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "pracovná plocha"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "notebook"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "vreckový"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "cellular"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "bezdrôtové"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "chytrý telefón"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "Program obexd nie je dostupný"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "slúchadlo s mikrofónom"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "neznámy"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofón"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Zdroj zvuku"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Zdroj zvuku"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Zdroj zvuku"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "klávesnica"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "ukazujúce"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "klávesnica"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "ukazujúce"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Pripojiť"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Pripojiť"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Pripojiť"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Pripojiť"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Prenos súborov cez Bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Pripojiť"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Prenos súborov cez Bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Prenos súborov cez Bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Skupinová Sieť"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Prenos súborov cez Bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Pripojiť"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Pripojiť"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Prenos súborov cez Bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Pripojiť"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Skupinová Sieť"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Sériové porty"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Vytáčané spojenie (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Prenos súborov cez Bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "slúchadlo s mikrofónom"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Zdroj zvuku"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Audio Sink"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Prístupový bod siete"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Skupinová Sieť"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Sieťový prítupový bod (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Sieťový prítupový bod (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Skupinová Sieť"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Prenos súborov cez Bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Zdroj zvuku"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Audio Sink"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Zdroj zvuku"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Premenovať zariadenie"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Zobraziť informácie o zariadení"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Lokálne služby"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Prenos"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "aplet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Spárovať zariadenie"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Vyhľadá zariadenia v blízkosti"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Prenos"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "aplet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Spárovať zariadenie"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Vyhľadá zariadenia v blízkosti"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Správca zariadení"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Nedávne _pripojenia"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Správca zariadení"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Nastavenia adaptéra"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Profily automatického pripojenia"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Uzavretý"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "áno"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nie"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Informácie"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Zobraziť informácie o zariadení"
 
@@ -1771,34 +2136,35 @@ msgstr "Zvukový profil"
 msgid "Select audio profile for PulseAudio"
 msgstr "Vybrať zvukový profil pre PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Sériový port %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Obnoviť IP adresu"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Nastavenia vytáčaného spojenia"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Sériové porty"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nešpecifikované"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Pripojené"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Automaticky pripojené k %(service)sna zariadení %(device)s"
@@ -1872,22 +2238,17 @@ msgstr "Využitie _siete"
 msgid "Shows network traffic usage"
 msgstr "Zobrazí využitie sieťovej prevádzky"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth povolený"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth zakázaný"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Spravuje lokálne sieťové služby, ako mosty NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1895,7 +2256,7 @@ msgstr ""
 "Poskytuje podporu vytáčaného pripojenia siete (DUN) pomocou programov "
 "ModemManager a NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1903,37 +2264,37 @@ msgstr ""
 "rýchly prístup"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maximálny počet položiek"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Maximálny počet zobrazených položiek nedávnych spojení."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Nedávne _pripojenia"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Pripojené k %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Pripojenie neúspešné"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s na %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adaptér pre toto pripojenie nie je k dispozícii"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1941,41 +2302,41 @@ msgstr ""
 "Poskytuje podporu pre Personal Area Networking (PAN) uvedené v "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Poskytuje DBus API pre daľšie súčasti Bleueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Prichádza súbor cez Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Prichádza súbor %(0)s z %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Odmietnuť"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Prijatie súboru"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Prijímanie súboru %(0)s z %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Poskytuje schopnosť prenosu súborov OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Nastavený priečinok pre prichádzajúce súbory neexistuje"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1984,33 +2345,31 @@ msgstr ""
 "Skontrolujte, či existuje adresár „<b> %s </b>“, alebo ho nakonfigurujte "
 "pomocou blueman-services. Dovtedy sa použije predvolený adresár „%s“"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Súbor prijatý"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Súbor %(0)s z %(1)s bol úspešne prijatý"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Zlyhal prenos"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Prenos súboru %(0)s zlyhal"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Prijaté súbory"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Prijatý %d súbor na pozadí"
@@ -2018,10 +2377,8 @@ msgstr[1] "Prijaté %d súbory na pozadí"
 msgstr[2] "Prijatých %d súborov na pozadí"
 msgstr[3] "Prijatých %d súborov na pozadí"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Prijatý %d ďalší súbor na pozadí"
@@ -2036,27 +2393,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Pridá štandardné položky menu k menu stavovej ikony"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "Na_staviť nové zariadenie"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "_Odoslať súbory zariadeniu"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "Zaria_denia"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_téry"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "aplet"
 
@@ -2068,27 +2425,27 @@ msgstr "Poskytuje heslo, službu overenia totožnosti pre démona BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Pridá položku do menu pre ukončeniu apletu"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Poskytuje základného dhcp klienta pre pripojenia Bluetooth PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth sieť"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Rozhranie %(0)s je viazané na IP adresu %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Nepodarilo sa získať IP adresu na %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2097,7 +2454,7 @@ msgstr ""
 "Prebieha získavanie adresy IP na %s\n"
 "Prosím, čakajte…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2105,14 +2462,12 @@ msgstr ""
 "Pridá indikáciu na stavovú ikonu ak je Bluetooth aktívne a zobrazí v "
 "nápovede počet pripojení."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth aktívne"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Aktívne pripojenie</b>"
@@ -2120,11 +2475,16 @@ msgstr[1] "<b>%d Aktívne pripojenia</b>"
 msgstr[2] "<b>%d Aktívnych pripojení</b>"
 msgstr[3] "<b>%d Aktívnych pripojení</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth zakázaný"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Použiť libappindicator na zobrazenie statovej ikony"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2132,33 +2492,34 @@ msgstr ""
 "Poskytuje položku menu pre dočasné zviditeľnenie predvoleného adaptéra ak je "
 "v predvolenom stave skrytý"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Objaviteľný časový limit"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Počet minút v sekundách počas ktorých bude objaviteľný režim aktívny"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Spraviť objaviteľným"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Spraviť predvolený adaptér dočasne viditeľným"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Objaviteľné… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "Poskytne menu apletu a API pre ďalšie moduly na narábanie s ním"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2167,23 +2528,23 @@ msgstr ""
 "Úspešne pripojené k službe <b>DUN</b> na <b>%(0)s.</b>\n"
 "Sieť je dostupná cez <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Poskytuje základnú podporu pre pripojenie sa na internet cez profil DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Štandardný SPP profil majúci na starosti pripojenia, povoľuje vykonávanie "
 "vlastných príkazov"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skript na vykonanie po pripojení"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2201,21 +2562,21 @@ msgstr ""
 "\n"
 "Po odpojení zariadenia bude skriptu zaslaný HUP signál</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Pripojený sériový port"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr "Sériový port služby na zariadení <b>%s</b> bude dostupný cez <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Pripájací skript sériového portu zlyhal"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2224,58 +2585,57 @@ msgstr ""
 "Nastala chyba pri spúšťaní skriptu %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Kontroluje stavy napájania Bluetooth adaptérov"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatické zapnutie"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Automaticky zapne adaptéry"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Vyp_núť Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Vypnúť všetky adaptéry"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Zap_núť Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Zapne všetky adaptéry"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "Dočasne preruší šetrič obrazovky, keď je pripojený bluetooth herný ovládač."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Sieť"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Neplatná IP adresa"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP adresa konfliktuje s rozhraním %s ktoré má rovnakú adresu"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2286,8 +2646,8 @@ msgstr ""
 "konfiguráciu  %s/%s\n"
 "Môže to spôsobiť nesprávne správanie siete"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "S týmto nastavením momentálne nie je podporované"
 
@@ -2303,10 +2663,6 @@ msgstr "Modul pre prenosnú službu apletu je vypnutý"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Nastavenie vlastnosti bluetooth adaptéra"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman Applet"
@@ -2314,11 +2670,6 @@ msgstr "Blueman Applet"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Správca Bluetooth Blueman"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2360,6 +2711,37 @@ msgstr "Nastavenie stavu RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Nastavenie stavu RfKill vyžaduje práva"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Zadajte PIN kód"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Vložte heslo"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Sériový port pripojený na %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "slúchadlo s mikrofónom"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "neznámy"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Zariadenia Bluetooth"
 
@@ -2384,11 +2766,6 @@ msgstr "Nastavenie stavu RfKill vyžaduje práva"
 
 #~ msgid "_Remove..."
 #~ msgstr "Odst_rániť..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Pripojiť"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/sl.po
+++ b/po/sl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Slovenian (http://www.transifex.com/mate/MATE/language/sl/)\n"
@@ -27,7 +27,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Nastavitev vidnosti</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Skrito"
 
@@ -71,8 +71,8 @@ msgstr "_Naprava"
 msgid "_View"
 msgstr "_Pogled"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Pomoč"
 
@@ -85,7 +85,7 @@ msgstr "Iskanje bližnjih naprav"
 msgid "Search"
 msgstr "Iskanje"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Ustvari seznanjenje z napravo"
 
@@ -94,17 +94,17 @@ msgstr "Ustvari seznanjenje z napravo"
 msgid "Pair"
 msgstr "Seznani"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Označi/Odznači to napravo kot zaupanja vredno"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Zaupaj"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Zaženi pomočnika nastavitev za to napravo"
 
@@ -113,7 +113,7 @@ msgstr "Zaženi pomočnika nastavitev za to napravo"
 msgid "Setup..."
 msgstr "Nastavi ..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Odstrani to napravo s seznama znanih naprav"
 
@@ -295,7 +295,12 @@ msgstr "Ni navedeno"
 msgid "<b>Author:</b>"
 msgstr "<b>Avtor:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -357,7 +362,7 @@ msgstr "_Ponastavi"
 msgid "Send note"
 msgstr "Pošlji sporočilo"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "Bluetooth mora biti vklopljen, da bo upravljalnik vmesnikov lahko deloval"
@@ -366,14 +371,12 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Adapter bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Vedno"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minuta"
@@ -381,19 +384,19 @@ msgstr[1] "%d minuti"
 msgstr[2] "%d minut"
 msgstr[3] "%d minute"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Vmesnik"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth mora biti vklopljen, da bo upravljalnik naprav deloval"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Povezava z BlueZ je spodletela"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -407,48 +410,48 @@ msgstr ""
 msgid "Searching"
 msgstr "Iskanje"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Pomočnik za Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Lastnosti vmesnika"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Pošiljatelj datotek"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Prenost datotek preko Bluetootha"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Povezovanje"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Preklic"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Pošiljanje datoteke"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -457,94 +460,86 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Med pošiljanjem datoteke %s se je pojavila napaka"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Preskoči"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Poskusi znova"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Prišlo je do napake"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Krajevne storitve"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Zahteva za seznanjanje za %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Overitev Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Vnesite kodo PIN za overitev:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Vnesite kodo PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Vnesite geslo za overitev:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Vnesite geslo"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Geslo za seznanjenje"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "PIN koda za seznanjenje"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Zahteva za seznanjanje za:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Potrdite vrednost za overitev:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Potrdi"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Zavrni"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Zahteva za overitev za:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Storitev:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Vedno sprejmi"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Sprejmi"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -575,241 +570,239 @@ msgstr "Da"
 msgid "No"
 msgstr "Ne"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Prijavi težavo"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Upravljalnik naprav"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Pokaži _orodno vrstico"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Pokaži _vrstica stanja"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "R_azvrsi po"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Ime"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Dodano"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Vstavki"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Krajevne storitve"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Nastavitev storitev"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Išči"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Lastnosti vmesnika"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "nekategorizirano"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Zaupano</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Slabo"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Dobro"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Odlično"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Zadostno"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Preveč"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Nizko"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Visoko"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Zelo visoko"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Uspeh!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Zaporedna vrata so povezana z %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Spodletelo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Povezava je spodletela:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Povezovanje"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Izklop ni uspel:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Prekinjanje povezave ..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Vsili prekinitev povezave z napravo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Poveži z:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Prekini povezavo:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Pošlji _datoteko ..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Seznani"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Zaupaj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Ne zaupaj"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Preimenuj napravo"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Odstrani"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Prekini opravilo"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Pokazatelj dejavnosti podatkov"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Skupaj prejeto in hitrost prenosa"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Skupaj poslano in hitrost prenosa"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Ne zaupaj"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Izbor naprave"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Več"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -817,7 +810,7 @@ msgstr ""
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  Damir Jerovšek <damir.jerovsek@ubuntu.si>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman je upravljalnik Bluetootha, osnovan na GTK+"
 
@@ -825,17 +818,17 @@ msgstr "Blueman je upravljalnik Bluetootha, osnovan na GTK+"
 msgid "GSM Settings"
 msgstr "Nastavitve GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Vstavki"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Težave z odvisnostjo"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -846,7 +839,7 @@ msgstr ""
 "bo razložilo tudi <b>\"%(0)s\"</b>.\n"
 "Nadaljevanje?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -857,886 +850,1258 @@ msgstr ""
 "razložilo <b>%(0)s</b>.\n"
 "Nadaljevanje?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Izbira vmesnika"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Prekinjanje povezave ..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "nekategorizirano"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Omrežna dostopna točka"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "namizje"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "strežnik"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "prenosnik"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "ročni"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "dlan"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobilni"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "brezžično"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "pametni telefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+msgid "Not available"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "Slušalke z mikrofonom"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "prostoročno"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "neznano"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Izvor zvoka"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Izvor zvoka"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Izvor zvoka"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tipkovnica"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "kazanje"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tipkovnica"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "kazanje"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Poveži"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Poveži"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Poveži"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Poveži"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Prenost datotek preko Bluetootha"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Poveži"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Prenost datotek preko Bluetootha"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Prenost datotek preko Bluetootha"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Skupno omrežje"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Prenost datotek preko Bluetootha"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Poveži"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Poveži"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Prenost datotek preko Bluetootha"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Poveži"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Skupno omrežje"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Zaporedna vrata"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Klicno omreženje (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Prenost datotek preko Bluetootha"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "Slušalke z mikrofonom"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Izvor zvoka"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Ponor zvoka"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Omrežna dostopna točka"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Skupno omrežje"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "prostoročno"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Omrežna dostopna točka (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Omrežna dostopna točka (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Skupno omrežje"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Prenost datotek preko Bluetootha"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Izvor zvoka"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Ponor zvoka"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Izvor zvoka"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Preimenuj napravo"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Pokaži podatke o napravi"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Krajevne storitve"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Prenos"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "aplet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Seznani napravo"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Iskanje bližnjih naprav"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Prenos"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "aplet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Seznani napravo"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Iskanje bližnjih naprav"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Upravljalnik naprav"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Nedavne _povezave"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Upravljalnik naprav"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Lastnosti vmesnika"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Lastniško"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "da"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "ne"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Pokaži podatke o napravi"
 
@@ -1761,34 +2126,35 @@ msgstr "Profil zvoka"
 msgid "Select audio profile for PulseAudio"
 msgstr "Izberite profil zvoka za Pulseaudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Zaporedna vrata %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Obnovi naslov IP"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Nastavitev Klicanja"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Zaporedna vrata"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Nedoločeno"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Povezano"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1862,28 +2228,23 @@ msgstr "Uporaba omrežja"
 msgid "Shows network traffic usage"
 msgstr "Prikazuje uporabo omrežnega prometa"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth je omogočen"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth je onemogočen"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Upravlja krajevne omrežne storitve, kot so mostovi NAP"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1891,111 +2252,109 @@ msgstr ""
 "dostop"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Največje število predmetov"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Največje število predmetov, ki jih prikaže meni nedavnih povezav."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Nedavne _povezave"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Povezano z %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Povezovanje je spodletelo"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s na %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Prilagodilnik za to povezavo ni na voljo"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 "Zagotavlja podporo za osebna omrežja (PAN), uvedeno v NetworkManagerju 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Zagotavlja DBus API za ostale sestavne dele Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Dohodna datoteka preko Bluetootha"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Dohodna datoteka %(0)s od %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Zavrni"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Sprejemanje datoteke"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Sprejemanje datoteke %(0)s od %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Zagotavlja zmožnosti prenosa datotek OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Nastavljena mapa za prejete datoteke ne obstaja"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Datoteka je sprejeta"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Datoteka %(0)s od %(1)s uspešno prejeta"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Prenos je spodletel"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Prenos datoteke %(0)s spodletela"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Datoteke so sprejete"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Prejeta %d datoteka v ozadju"
@@ -2003,10 +2362,8 @@ msgstr[1] "Prejeti %d datoteki v ozadju"
 msgstr[2] "Prejete %d datoteke v ozadju"
 msgstr[3] "Prejetih %d datotek v ozadju"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Prejeta %d datoteka več v ozadju"
@@ -2021,27 +2378,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Dodaja standardne predmete menija na meni z ikono stanja"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "Na_stavi novo napravo"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Pošlji _datoteke na napravo"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Naprave"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Vm_esniki"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "aplet"
 
@@ -2053,34 +2410,34 @@ msgstr "Zagotavlja storitve za gesla ter overitve za ozadnji program BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Doda predmet izhodnega menija za izhod iz apleta"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Zagotavlja osnovni odjemalec dhcp za povezave Bluetooth PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Omrežje Bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Vmesnik %(0)s vezan na IP naslov %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Pridobivanje naslova IP od %s je spodletelo"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2088,14 +2445,12 @@ msgstr ""
 "Doda označbo na statusni ikoni, ko je Bluetooth dejaven in pokaže število "
 "povezav v orodnem namigu."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth je dejaven"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d dejavna povezava</b>"
@@ -2103,11 +2458,16 @@ msgstr[1] "<b>%d dejavni povezavi</b>"
 msgstr[2] "<b>%d dejavnih povezav</b>"
 msgstr[3] "<b>%d dejavne povezave</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth je onemogočen"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Uporablja libappindicator za prikaz ikone stanja"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2115,33 +2475,34 @@ msgstr ""
 "Zagotavlja predmet menija, ki naredi prevzeti vmesnik začasno viden, ko je "
 "privzeto nastavljen na skrito"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Časovna omejitev vidnosti"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Količina časa v sekundah trajanja načina vidnosti"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Naredi vidno"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Naredi privzeti vmesnik začasno viden"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "Zagotavlja meni za aplet in API za upravljanje z drugimi vstavki"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2150,22 +2511,22 @@ msgstr ""
 "Uspešno povezano s storitvijo <b>DUN</b> na <b>%(0)s.</b>\n"
 "Omrežje je na voljo preko <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Zagotavlja osnovno podporo za povezovanje z internetom preko profila DUN."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Ročnik povezave standardnega profila SPP omogoča izvajanje dejanj po meri"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skript za izvedbo ob povezavi"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2183,22 +2544,22 @@ msgstr ""
 "\n"
 "Ob izključitvi naprave bo skript poslal signal HUP </span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Zaporedna vrata so povezana"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "Zaporedna vrata na napravi <b>%s</b> bodo sedaj na voljo preko <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Skript povezave zaporednih vrat je spodletel"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2207,37 +2568,37 @@ msgstr ""
 "Med zaganom skripta %s se je pojavila težava\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Nadzira stanja napajanja vmesnika Bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Samodejni vklop"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Samodejno vklopi vmesnike"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Izklopi Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Izklopi vse vmesnike"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Vklopi Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Vklopi vse vmesnike"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2245,21 +2606,20 @@ msgstr ""
 "Začasno zaustavi ohranjevalnik zaslona, ko je priključen bluetooth krmilnik "
 "za igro."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Omrežje"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Neveljaven naslov IP"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "Naslov IP je v sporu z vmesnikom %s , ki ima enak naslov"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2267,8 +2627,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Trenutno ni podprto z to nastavitvijo"
 
@@ -2282,40 +2642,26 @@ msgstr "Apletov vstavek storitve prenosa je onemogočen"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adapter bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "aplet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman je upravljalnik Bluetootha, osnovan na GTK+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Bluetooth je omogočen"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Naprave Bluetooth"
 
@@ -2351,6 +2697,31 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Vnesite kodo PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Vnesite geslo"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Zaporedna vrata so povezana z %s"
+
+#~ msgid "palm"
+#~ msgstr "dlan"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "Slušalke z mikrofonom"
+
+#~ msgid "handsfree"
+#~ msgstr "prostoročno"
+
+#~ msgid "unknown"
+#~ msgstr "neznano"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Naprave Bluetooth"
 
@@ -2375,11 +2746,6 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Odstrani ..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Poveži"
 
 #~ msgid "Bluetooth needs to be turned on for file sending to work"
 #~ msgstr ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-16 21:29+0000\n"
 "Last-Translator: Arben Tapia <arben_tapia@firstclass.com>\n"
 "Language-Team: Albanian <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -24,7 +24,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Konfigurimi i pamjes</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Fshehur"
 
@@ -68,8 +68,8 @@ msgstr "_Pajisje"
 msgid "_View"
 msgstr "_Shfaq"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Ndihmë"
 
@@ -82,7 +82,7 @@ msgstr "Kërko për pajisje të afërta"
 msgid "Search"
 msgstr "Kërko"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Krijo lidhje me këtë pajisje"
 
@@ -91,17 +91,17 @@ msgstr "Krijo lidhje me këtë pajisje"
 msgid "Pair"
 msgstr "Çiftëzo (lidh)"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Shënoje/Hiq shënjën këtë pajisje si të besueshme"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Beso"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Egsekuto ndihmuesin instalues për këtë pajisje"
 
@@ -110,7 +110,7 @@ msgstr "Egsekuto ndihmuesin instalues për këtë pajisje"
 msgid "Setup..."
 msgstr "Instalo..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Hiqe këtë pajisje nga lista e pajisjeve të njohura"
 
@@ -292,7 +292,12 @@ msgstr "E pa specifikuar"
 msgid "<b>Author:</b>"
 msgstr "<b>Autori:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -354,7 +359,7 @@ msgstr "_Rifillo"
 msgid "Send note"
 msgstr "Dërgo njoftim"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth-i kërkon të ndizet që të punojë manaxheri i përshtatësit"
 
@@ -362,33 +367,31 @@ msgstr "Bluetooth-i kërkon të ndizet që të punojë manaxheri i përshtatësi
 msgid "Bluetooth Adapters"
 msgstr "Përshtatësat Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Gjithmonë"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d Minutë"
 msgstr[1] "%d Minuta"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Përshtatës"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 "Bluetooth-i kërkon të ndizet që të funksionojë manaxheri i përshtatësit"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Lidhja me BlueZ dështoi"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -402,144 +405,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Duke kërkuar"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Ndihmuesi Bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Preferencat e Përshtatësit"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Dërgues Dokumenti"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Transmetues Dokumenti Bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Duke u lidhur"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "'obexd' nuk është i disponueshëm"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Dështoi të rifillojë automatikisht shërbimin 'obex'. Sigurohu që shërbyesi "
 "'obexd' po punon"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Duke anuluar"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Duke dërguar dokument"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Ka ndodhur një gabim duke dërguar dokumentin %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Kapërce"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Riprovo"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Ka ndodhur një gabim"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Shërbimet Lokale"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Kërkesë çiftimi për %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Autentikimi Bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Fut kodin PIN për autentikim:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Fut kodin PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Fut çelës-kalimin për autentikim:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Fut çelës-kalimin"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Duke çiftuar çelës-kalimin për"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Duke çiftuar kodin PIN për"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Duke çiftuar kërkesën për:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Konfirmo vlerën për autentikim:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Konfirmo"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Moho"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Kërkesë autorizimi për:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Shërbimet:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Gjithmonë prano"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Prano"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -574,246 +569,245 @@ msgstr "Po"
 msgid "No"
 msgstr "Jo"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Raporto një Problem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Manaxheri i Pajisjeve"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Trego Shiri_TButonat"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Trego _ShiritGjëndjen"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Resht_o Sipas"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Emri"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Shtuar"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Zbritës"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Shtojcat"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Shërbimet _Lokale"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Preferencat e shërbimit"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Kërko"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "_Preferencat"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "_Dil"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "e pa kategorizuar"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>I besuar dhe i çiftuar</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b> I çiftuar</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>I besuar</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Dobët"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Nën-optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimale"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Shumë"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Tepruar"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Ulët"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Lartë"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Shumë e lartë"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Sukses!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Porta në seri është lidhur me %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Dështoi"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Lidhja dështoi:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Duke u lidhur"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Shkëputja Dështoi: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Duke u shkëputur ..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Lidh</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Lidh profilet e auto-lidhjes së burimit A2DP, derdhjes A2DP dhe të HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Shkëput</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Shkëput me force pajisjen"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Lidh me:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Shkëput:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Dërgoni një _Skedar..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "Ç_ifto"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Beso"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Mosbeso"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Konfiguro…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Riemëro pajisjen"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Hiq"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Anulo veprimin"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Tregues i aktivitetit së të dhënave"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Totali i të dhënave të marra dhe shpejtësia e transmetimit"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Totali i të dhënave të dërguara dhe shpejtësia e transmetimit"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Mosbesim"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Zgjidh pajisjen"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Më shumë"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Elian Myftiu <elian@alblinux.net>, Indrit Bashkimi <indrit.bashkimi@gmail."
 "com>, Laurent Dhima <laurenti@alblinux.net>, Arben Tapia <arbentapia@gmail."
 "com>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman është një manaxher Bluetooth i bazuar në GTK+"
 
@@ -821,17 +815,17 @@ msgstr "Blueman është një manaxher Bluetooth i bazuar në GTK+"
 msgid "GSM Settings"
 msgstr "Konfigurimet e GSM-së"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Plugins (Shtojcat)"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Problem varësie"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -842,7 +836,7 @@ msgstr ""
 "b> do të shkarkohet gjithashtu edhe<b>\"%(0)s\"</b>.\n"
 "Doni të vazhdoni?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -853,862 +847,1280 @@ msgstr ""
 "do të shkarkohet <b>%(0)s</b>.\n"
 "Doni të vazhdoni?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Zgjedhje përshtatësi"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr "Duke zbuluar…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "e pa kategorizuar"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Pikë Hyrëse e Rrjetit"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+#, fuzzy
+msgid "Audio/video"
+msgstr "Zë/Figurë"
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+#, fuzzy
+msgid "Peripheral"
+msgstr "Flamuri i Privacisë Periferike"
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "desktop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "shërbyes"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "laptop"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "celular"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "celular"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "pa tela"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
+#: blueman/DeviceClass.py:52
 #, fuzzy
-msgid "smart phone"
+msgid "Smart phone"
 msgstr "smart phone"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
+#: blueman/DeviceClass.py:54
 #, fuzzy
-msgid "modem"
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "ISDN"
+msgid "83-99 percent"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "kufjet"
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "'obexd' nuk është i disponueshëm"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "pa duar"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
+msgstr "Kufje"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "e panjohur"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
+msgstr "Pa duar"
 
 #. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
 msgstr "altoparlant"
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
 msgstr "kufjet"
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
 msgstr "altoparlant portativ"
 
 #. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
 msgstr "pajisje zëri për makinë"
 
 #. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
 msgstr "kutia e përshtatësit të TV-së"
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
 msgstr "Zëri HI-FI"
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
 msgstr "VCR"
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
 msgstr "Kamera"
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
 msgstr "Kamkorder"
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
 msgstr "ekran"
 
 #. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
 msgstr "ekrani dhe altoparlanti"
 
 #. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
 msgstr "konference video"
 
 #. translators: device class
-#: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+#: blueman/DeviceClass.py:116
+#, fuzzy
+msgid "Gaming/Toy"
 msgstr "loja/lodra"
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
 msgstr "tastiera"
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
 msgstr "miu tregues"
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:127
+#, fuzzy
+msgid "Combo"
 msgstr "kombinim"
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:132
+#, fuzzy
+msgid "Display"
+msgstr "Ekran 3D"
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:145
+msgid "Pager"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+#, fuzzy
+msgid "Glasses"
+msgstr "Gjyslyke 3D"
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Lidhje gjenerike"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Lidhje gjenerike"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Hyrje Gjenerike"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Lidhje gjenerike"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Zë Gjenerik"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Pult"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Hyrje Gjenerike"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Zë Gjenerik"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Aktivitete Gjenerike të Rrjetit"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Transferim Gjenerik Dokumentash"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Lidhje gjenerike"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Termometer Shëndeti"
+
+#: blueman/DeviceClass.py:182
+#, fuzzy
+msgid "Thermometer: Ear"
+msgstr "Termometer Shëndeti"
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Transferim Gjenerik Dokumentash"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+#, fuzzy
+msgid "Generic Blood Pressure"
+msgstr "Tensioni i Gjakut"
+
+#: blueman/DeviceClass.py:186
+#, fuzzy
+msgid "Blood Pressure: Arm"
+msgstr "Tensioni i Gjakut"
+
+#: blueman/DeviceClass.py:187
+#, fuzzy
+msgid "Blood Pressure: Wrist"
+msgstr "Tensioni i Gjakut"
+
+#: blueman/DeviceClass.py:188
+#, fuzzy
+msgid "Human Interface Device (HID)"
+msgstr "Pajisje Ndërfaqore Personash"
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Lidhje gjenerike"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Aktivitete Gjenerike të Rrjetit"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+#, fuzzy
+msgid "Cycling: Speed Sensor"
+msgstr "Shpejtësia dhe Ritmi i Biçikletës"
+
+#: blueman/DeviceClass.py:205
+#, fuzzy
+msgid "Cycling: Cadence Sensor"
+msgstr "Shpejtësia dhe Ritmi i Biçikletës"
+
+#: blueman/DeviceClass.py:206
+#, fuzzy
+msgid "Cycling: Power Sensor"
+msgstr "Fuqia e Ngarjes së Biçikletës"
+
+#: blueman/DeviceClass.py:207
+#, fuzzy
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr "Shpejtësia dhe Ritmi i Biçikletës"
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+#, fuzzy
+msgid "Generic: Pulse Oximeter"
+msgstr "Matësi i Oksigjenit"
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+#, fuzzy
+msgid "Generic: Weight Scale"
+msgstr "Peshorja"
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+#, fuzzy
+msgid "Generic Continuous Glucose Monitor"
+msgstr "Vëzhgimi i Vazhduar i Glukozës"
+
+#: blueman/DeviceClass.py:217
+#, fuzzy
+msgid "Generic Insulin Pump"
+msgstr "Zë Gjenerik"
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+#, fuzzy
+msgid "Location and Navigation Display Device"
+msgstr "Vendi dhe Orientimi"
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+#, fuzzy
+msgid "Location and Navigation Pod"
+msgstr "Vendi dhe Orientimi"
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr "SDP"
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr "UDP"
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr "RFCOMM"
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr "TCP"
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr "TCS-BIN"
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr "TCS-AT"
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr "ATT"
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr "OBEX"
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr "IP"
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr "FTP"
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr "HTTP"
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr "WSP"
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr "BNEP"
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr "UPnP/ESDP"
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr "HIDP"
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr "Kanali i Kontrollit të Printim/Skanimit"
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr "Kanali i të Dhënave të Printim/Skanimit"
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr "Njoftimi për Printim/Skanim"
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 #, fuzzy
 msgid "AVCTP"
 msgstr "AVCTP"
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 #, fuzzy
 msgid "AVDTP"
 msgstr "AVDTP"
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 #, fuzzy
 msgid "CMTP"
 msgstr "CMTP"
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr "Plani UDI_C"
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr "Protokolli i Përshtatjes Shumë-Kanalëshe (MCAP)"
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 #, fuzzy
 msgid "L2CAP"
 msgstr "L2CAP"
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr "Grup Publik Shfletimi"
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr "Portë Seriale"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr "Hyrje në LAN duke përdorur PPP"
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Hyrje rrjeti nëpërmjet telefonisë"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr "Shtytje Objekti OBEX"
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 msgid "OBEX File Transfer"
 msgstr "Transferim dokumenti OBEX"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr "Komanda e sinkronizimit IrMC"
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr "Kufje"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr "Telefon pa tel"
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Burim Zëri"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "\"Vesh\" zëri"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr "Objektiv për pult"
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr "Zë i Avancuar"
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr "Pult"
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr "Konference Video"
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr "Ndërkomunikacion"
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr "Faks"
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 #, fuzzy
 msgid "WAP"
 msgstr "WAP"
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr "Klient WAP"
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 #, fuzzy
 msgid "PANU"
 msgstr "PANU"
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Pikë Hyrëse e Rrjetit"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Rrjet Grupi"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr "Printim Direkt (BPP)"
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr "Pa duar"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr "Printimi Base (BPP)"
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr "Gjendja e Printimit"
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr "Sherbimi i Pajisjes së Ndërfaqes për Persona (HID)"
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr "Zëvendësimi i Kabllit tv Printim/Skanimit (HCR)"
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr "_Printim HCR (HCR)"
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr "_Skanim HCR (HCR)"
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr "Hyrje e Përbashkët ISDN (CIP)"
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr "Zë/Figurë"
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr "Hyrje SIM (SAP)"
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr "Hyrje për Librin e Telefonave (PBAP) - PCE"
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr "Hyrje për Librin e Telefonave (PBAP) - PSE"
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr "Hyrje për Librin e Telefonave (PBAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr "Shërbyes për Hyrjen e Mesazheve"
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr "Shërbyes për Mesazhet Njoftuese"
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr "Profili i Hyrjes së Mesazheve (MAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 #, fuzzy
 msgid "GNSS"
 msgstr "GNSS"
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr "Shërbyes GNSS"
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr "Ekran 3D"
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr "Gjyslyke 3D"
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr "Sinkronizim 3D (3DSP)"
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr "Profili Specifikim Shumë-Profilësh (MPS)"
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr "Sherbimi Specifikim Shumë-Profilësh (MPS)"
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr "Shërbimi i Hyrjes Kalendar, Detyrë dhe Shënime (CTN)"
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr "Shërbimi i Njoftimeve Kalendar, Detyrë dhe Shënime (CTN)"
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr "Profili Kalendar, Detyrë dhe Shënime (CTN)"
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr "Informacioni PnP"
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr "Aktivitete Gjenerike të Rrjetit"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr "Transferim Gjenerik Dokumentash"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr "Zë Gjenerik"
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr "Telefoni Gjenerike"
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr "Burim Figure"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr "Tregues Figure"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr "Shpërndarje Figure"
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 #, fuzzy
 msgid "HDP"
 msgstr "HDP"
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr "Burim HDP"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr "Tregues HDP"
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr "Hyrje Gjenerike"
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr "Atribut Gjenerik"
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr "Njoftim Imediat"
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr "Humbje Lidhjeje"
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr "Fuqi Transmetimi"
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Riemëro pajisjen"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr "Sherbim Referent për Përditësimin e Kohës"
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr "Shërbimi për Ndërrimin Pasardhës DST"
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr "Glukoze"
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr "Termometer Shëndeti"
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr "Informacion Pajisjeje"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr "Pulsi i Zëmrës"
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr "Shërbimi i Gjëndjes së Njoftimeve Telefonike"
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Service:"
 msgid "Battery Service"
 msgstr "Shërbimet:"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr "Tensioni i Gjakut"
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr "Shërbimi i Njoftimeve të Sinjaleve"
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr "Pajisje Ndërfaqore Personash"
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr "Parametrat e Skanimit"
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr "Shpejtësia dhe Ritmi i Vrapimit"
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr "Automotizimi i Hyrje/Daljes (IO)"
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr "Shpejtësia dhe Ritmi i Biçikletës"
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr "Fuqia e Ngarjes së Biçikletës"
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr "Vendi dhe Orientimi"
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr "Dallimi i Mjedisit"
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr "Përbërja e Trupit"
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr "Të Dhënat e Përdoruesit"
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr "Peshorja"
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr "Vëzhgimi i Vazhduar i Glukozës"
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr "Mbështetja a Protokollit të Internetit (IP)"
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr "Vendndodhja Brënda"
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr "Matësi i Oksigjenit"
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr "Zbulimi i Transportit"
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr "Transferimi i Objekteve"
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 #, fuzzy
-#| msgid "Service:"
 msgid "Primary Service"
 msgstr "Shërbimet:"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 #, fuzzy
-#| msgid "Rename device"
 msgid "Secondary Service"
 msgstr "Riemëro pajisjen"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr "Përfshi"
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr "Deklarim Karakteristike"
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Device"
 msgid "Device Name"
 msgstr "Dispozitivi"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr "Dukje"
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr "Flamuri i Privacisë Periferike"
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr "Adresa e Rilidhjes"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr "Parametrat a Lidhjes së Preferuar Periferike"
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Service:"
 msgid "Service Changed"
 msgstr "Shërbimet:"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr "ID a Sistemit"
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr "Vargu i Numrit të Modelit"
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr "Vargu i Numrit Serial"
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr "Vargu i Rishikimit të Firmware-it"
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr "Vargu i Rishikimit të Hardware-it"
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr "Vargu i Rishikimit të Software-it"
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr "Vargu i Emrit të Prodhuesit"
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr "ID e PnP"
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "po"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "jo"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1733,34 +2145,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "i lidhur"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1823,141 +2236,136 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Refuzo"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Transferimi dështoi"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Transferimi i skedarit %(0)s dështoi"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1971,27 +2379,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Pajisjet"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
@@ -2003,107 +2411,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2114,78 +2528,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Rrjeti"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2193,8 +2606,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2210,10 +2623,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
@@ -2222,20 +2631,13 @@ msgstr ""
 msgid "Blueman Bluetooth Manager"
 msgstr ""
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Manager"
 msgstr "Pajisjet Bluetooth"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Pajisjet Bluetooth"
 
@@ -2271,6 +2673,31 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Fut kodin PIN"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Fut çelës-kalimin"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Porta në seri është lidhur me %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "ISDN"
+
+#~ msgid "headset"
+#~ msgstr "kufjet"
+
+#~ msgid "handsfree"
+#~ msgstr "pa duar"
+
+#~ msgid "unknown"
+#~ msgstr "e panjohur"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Pajisjet Bluetooth"
 
@@ -2289,6 +2716,3 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Hiq..."
-
-#~ msgid "Generic Connect"
-#~ msgstr "Lidhje gjenerike"

--- a/po/sr.po
+++ b/po/sr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Serbian (http://www.transifex.com/mate/MATE/language/sr/)\n"
@@ -25,7 +25,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Поставкe видљивости</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Скривен"
 
@@ -69,8 +69,8 @@ msgstr "_Уређај"
 msgid "_View"
 msgstr "_Преглед"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "По_моћ"
 
@@ -83,7 +83,7 @@ msgstr "Потражите уређаје у близини"
 msgid "Search"
 msgstr "Тражи"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Упарите са овим уређајем"
 
@@ -92,17 +92,17 @@ msgstr "Упарите са овим уређајем"
 msgid "Pair"
 msgstr "Упари"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Означите/одзначите овај уређај поверљивим"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Веруј"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Покрените чаробњака за подешавање овог уређаја"
 
@@ -111,7 +111,7 @@ msgstr "Покрените чаробњака за подешавање овог
 msgid "Setup..."
 msgstr "Подеси..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Уклоните уређај са списка познатих уређаја"
 
@@ -291,7 +291,12 @@ msgstr "Није наведен"
 msgid "<b>Author:</b>"
 msgstr "<b>Стваралац:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -353,7 +358,7 @@ msgstr "_Поврати"
 msgid "Send note"
 msgstr "Пошаљи напомену"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Блутут треба бити укључен да би управник примопредајника радио"
 
@@ -361,33 +366,31 @@ msgstr "Блутут треба бити укључен да би управни
 msgid "Bluetooth Adapters"
 msgstr "Примопредајници Блутута"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Увек"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d минут"
 msgstr[1] "%d минута"
 msgstr[2] "%d минута"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Примопредајник"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Блутут треба бити укључен да би управник уређаја радио"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Повезивање са Блуезом није успело"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -401,50 +404,50 @@ msgstr ""
 msgid "Searching"
 msgstr "Претражујем"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Чаробњак подешавања Блутута"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Поставке прилагођивача"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Пошиљалац датотеке"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Пренос датотека Блутутом"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Повезујем"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "обексд није доступан"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Нисам успео сам да покренем услугу обекса. Уверите се да је демон обекса "
 "покренут"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Отказујем"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Шаљем датотеку"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Процењено време пријема:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -452,94 +455,86 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Дошло је до грешке приликом слања датотеке „%s“"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Прескочи"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Покушај поново"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Дошло је до грешке"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Месне услуге"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Захтев упаривања за „%s“"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Распознавање Блутута"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Унесите шифру ЛИБ-а за распознавање:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Унесите шифру ЛИБ-а"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Унесите лозинку за распознавање:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Унесите лозинку"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Упарујем лозинку за"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Упарујем шифру ЛИБ-а за"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Захтев упаривaњa за:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Потврдите вредност за распознавање:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Потврди"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Одбиј"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Захтев распознавања за:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Услуга:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Увек прихвати"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Прихвати"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -573,243 +568,240 @@ msgstr "Да"
 msgid "No"
 msgstr "Не"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Пријави проблем"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Управник уређаја"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Прикажи траку _алата"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Прикажи траку _стања"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Поређај _према"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Називу"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Додавању"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Опадајуће"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Прикључци"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Месне услуге"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Поставке услуга"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Тражи"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Поставке прилагођивача"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Изађи"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "неразврстан"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Поверљив и упарен</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Упарен</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Поверљив</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Јадно"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Није најповољнији"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Најповољнији"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Много"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Превише"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Ниско"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Високо"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Врло високо"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Успело је!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Редни прикључник је повезан са „%s“"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Није успело"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Повезивање није успело: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Повезујем"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Прекидање везе није успело: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Прекидам везу..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Повежите самоповезиве профиле А2ДП извора, А2ДП усаглашавања, и ХИД"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Присилно прекини везу уређаја"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Повежи се са:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Прекини везу:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Пошаљи _датотеку..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Упари"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Веруј"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Не веруј"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Преименуј уређај"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Уклони"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Откажи радњу"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Указивање на пренос података"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Укупно примљених података и брзина преноса"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Укупно послатих података и брзина преноса"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Означи неповерљивим"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Изаберите уређај"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Још"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -821,7 +813,7 @@ msgstr ""
 "http://prevod.org — превод на српски језик\n"
 "  Мирослав Николић <miroslavnikolic@rocketmail.com>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Блумен је блутут управник за Гтк+"
 
@@ -829,17 +821,17 @@ msgstr "Блумен је блутут управник за Гтк+"
 msgid "GSM Settings"
 msgstr "Подешавања ГСМ-а"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Прикључци"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Проблем зависности"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -850,7 +842,7 @@ msgstr ""
 "b> из учитаних такође ћете избацити и <b>„%(0)s“</b>.\n"
 "Да наставим?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -861,886 +853,1259 @@ msgstr ""
 "<b>„%(1)s“</b> онда ћете избацити из учитаних <b>„%(0)s“</b>.\n"
 "Да наставим?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Избор примопредајника"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Проналажљив… %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "неразврстан"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Мрежна приступна тачка"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "радна станица"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "сервер"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "преносни рачунар"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "ручни рачунар"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "палмов уређај"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "мобилни телефон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "бежични телефон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "паметни телефон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "модем"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "исдн"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "обексд није доступан"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "слушалице"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "бежичне слушалице са микрофоном"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "непознато"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "микрофон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Извор звука"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Извор звука"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Извор звука"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "тастатура"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "показивач"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "тастатура"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "показивач"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Повежи"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Повежи"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Повежи"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Повежи"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Пренос датотека Блутутом"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Повежи"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Пренос датотека Блутутом"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Пренос датотека Блутутом"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Групна мрежа"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Пренос датотека Блутутом"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Повежи"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Повежи"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Пренос датотека Блутутом"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Повежи"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Групна мрежа"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Редни прикључници"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Импуслно мрежење (ДУН)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Пренос датотека Блутутом"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "слушалице"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Извор звука"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Усклађивање звука"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Мрежна приступна тачка"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Групна мрежа"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "бежичне слушалице са микрофоном"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Мрежна приступна тачка (НАП)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Мрежна приступна тачка (НАП)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Групна мрежа"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Пренос датотека Блутутом"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Извор звука"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Усклађивање звука"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Извор звука"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Преименуј уређај"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Прикажите податке о уређају"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Месне услуге"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Пренос"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "програмче"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Упари уређај"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Потражите уређаје у близини"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Пренос"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "програмче"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Упари уређај"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Потражите уређаје у близини"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Управник уређаја"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Скорашње _везе"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Управник уређаја"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Поставке прилагођивача"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Пресеци самоповезивања"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Власнички"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "да"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "не"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Подаци"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Прикажите податке о уређају"
 
@@ -1765,34 +2130,35 @@ msgstr "Звучни профил"
 msgid "Select audio profile for PulseAudio"
 msgstr "Изаберите звучни профил за Пулсе-аудио"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Редни прикључник %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Освежи адресу ИП-а"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Импулсна подешавања"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Редни прикључници"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Неодређени"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Повезан сам"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Аутоматски повезан на „%(service)s“ на „%(device)s“"
@@ -1863,22 +2229,17 @@ msgstr "Коришћење _мреже"
 msgid "Shows network traffic usage"
 msgstr "Приказује проток мрежног саобраћаја"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Блутут је укључен"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Блутут је искључен"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Управља месним мрежним услугама, као што су мостови НАП-а"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1886,7 +2247,7 @@ msgstr ""
 "Обезбеђује подршку за умрежавање мрежном парицом (ДУН) са управником модема "
 "и управником мреже"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1894,37 +2255,37 @@ msgstr ""
 "приступа"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Највише ставки"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Највећи број ставки за приказ у изборнику скорашњих веза."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Скорашње _везе"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Повезан сам са „%s“"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Нисам успео да се повежем"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s на %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Примопредајник за ову везу није доступан"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1932,41 +2293,41 @@ msgstr ""
 "Обезбеђује подршку за личну област умрежавања (ПАН) која је уведена у "
 "Управнику мреже 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Обезбеђује АПИ Д-сабирнице за друге делове Блумена"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Долазна датотека преко Блутута"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Пристигла је датотека %(0)s са %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Одбиј"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Примање датотеке"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Примам датотеку %(0)s са %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Обезбеђује могућности преноса датотека ОБЕКс-ом"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Подешени директоријум за долазне датотеке не постоји"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1975,43 +2336,39 @@ msgstr ""
 "Уверите се да постоји директоријум „<b>%s</b>“ или га подесите са „blueman-"
 "services“. Све до тада користиће се „%s“"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Датотека је примљења"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Датотека %(0)s је успешно примљена са %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Пренос није успео"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Пренос датотеке %(0)s није успео"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Датотеке су примљене"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Примљена је %d датотека у позадини"
 msgstr[1] "Примљене су %d датотеке у позадини"
 msgstr[2] "Примљено је %d датотека у позадини"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Примљена је још %d датотека у позадини"
@@ -2025,27 +2382,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Додаје уобичајене ставке изборника изборнику иконице стања"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Подеси нови уређај"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Пошаљи _датотеке уређају"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Уређаји"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "_Примопредајници"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "програмче"
 
@@ -2057,27 +2414,27 @@ msgstr "Обезбеђује лозинку, услуге препознавањ
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Додаје ставку излаза у изборник за затварање програмчета"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Обезбеђује основног дхцп клијента за ПАН везе блутута."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Блутутна мрежа"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Уређај „%(0)s“ је привезан на ИП адресу %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Нисам успео да добавим адресу ИП-а на %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2086,7 +2443,7 @@ msgstr ""
 "Покушавам добавити адресу ИП-а са %s\n"
 "Молим, сачекајте…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2094,25 +2451,28 @@ msgstr ""
 "Додаје указивач на иконицу стања када Блутут дејствује и приказује број веза "
 "у облачићу."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Блутут дејствује"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d успостављена веза</b>"
 msgstr[1] "<b>%d успостављене везе</b>"
 msgstr[2] "<b>%d успостављених веза</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Блутут је искључен"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Користи „libappindicator“ да покаже иконицу стања"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2120,35 +2480,36 @@ msgstr ""
 "Обезбеђује ставку изборника за постављање задатог примопредајника привремено "
 "видљивим кад је предодређено постављен као скривен"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Време за проналажење"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Време у секундама за које ће трајати режим проналажења"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "_Учини проналажљивим"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Учини основни примопрдајник привремено видљивим"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Проналажљив… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Обезбеђује изборник за програмче и АПИ за друге прикључке који ће њиме "
 "управљати"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2157,23 +2518,23 @@ msgstr ""
 "Успешно сам повезан на услугу <b>ДУН-а</b> на <b>„%(0)s“.</b>\n"
 "Мрежа је сада доступна кроз <b>„%(1)s“</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Обезбеђује основну подршку за повезивање на Интернет преко ДУН-овог пресека."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Уобичајен руковалац везе профилима СПП-а, омогућава извршавање произвољних "
 "радњи"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Скрипта за извршавање при повезивању"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2191,11 +2552,11 @@ msgstr ""
 "\n"
 "Након прекидања везе уређаја скрипата ће бити послат ХУП-ов сигнал</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Редни прикључник је повезан"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2203,11 +2564,11 @@ msgstr ""
 "Услуга редног прикључника на уређају <b>%s</b> ће сада бити доступна преко "
 "<b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Није успела скрипте везе редног прикључка"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2216,58 +2577,57 @@ msgstr ""
 "Допло је до проблема покретања скрипте „%s“\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Управља стањима напајања блутут примопредајника"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Самостално напајање"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Самостално напајање на прикључцима"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Искључи блутут</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Искључи све примопредајнике"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>_Укључи Блутут</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Укључи све примопредајнике"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 "Привремено зауствља чувара екрана када је прикључен Блутутни управљач играма."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Мрежа"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Неисправна адреса ИП-а"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "Адреса ИП- је у сукобу са уређајем „%s“ који има исту адресу"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2278,8 +2638,8 @@ msgstr ""
 "%s“\n"
 "Ово може довести до неодговарајућег понашања мреже"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Није тренутно подржан овим поставкама"
 
@@ -2293,40 +2653,26 @@ msgstr "Прикључак услуге преноса програмчета ј
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Примопредајници Блутута"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "програмче"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Блумен је блутут управник за Гтк+"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "Блутут је укључен"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Уређаји Блутута"
 
@@ -2362,6 +2708,31 @@ msgstr "Подеси стање „РфУбиј“"
 msgid "Setting RfKill State requires privileges"
 msgstr "За подешавање стања „РфУбиј“ потребна су овлашћења"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Унесите шифру ЛИБ-а"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Унесите лозинку"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Редни прикључник је повезан са „%s“"
+
+#~ msgid "palm"
+#~ msgstr "палмов уређај"
+
+#~ msgid "isdn"
+#~ msgstr "исдн"
+
+#~ msgid "headset"
+#~ msgstr "слушалице"
+
+#~ msgid "handsfree"
+#~ msgstr "бежичне слушалице са микрофоном"
+
+#~ msgid "unknown"
+#~ msgstr "непознато"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Уређаји Блутута"
 
@@ -2384,11 +2755,6 @@ msgstr "За подешавање стања „РфУбиј“ потребна
 
 #~ msgid "_Remove..."
 #~ msgstr "_Уклони..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Повежи"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/sv.po
+++ b/po/sv.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Luna Jernberg <droidbittin@gmail.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -30,7 +30,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Synlighetsinställning</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Dold"
 
@@ -74,8 +74,8 @@ msgstr "_Enhet"
 msgid "_View"
 msgstr "_Visa"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Hjälp"
 
@@ -88,7 +88,7 @@ msgstr "Sök efter närliggande enheter"
 msgid "Search"
 msgstr "Sök"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Skapa ihopparning med enheten"
 
@@ -97,17 +97,17 @@ msgstr "Skapa ihopparning med enheten"
 msgid "Pair"
 msgstr "Par"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Markera/avmarkera denna enhet som pålitlig"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Tillit"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Kör konfigurationsguiden för denna enhet"
 
@@ -116,7 +116,7 @@ msgstr "Kör konfigurationsguiden för denna enhet"
 msgid "Setup..."
 msgstr "Konfigurera..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Ta bort denna enhet från listan över kända enheter"
 
@@ -296,7 +296,12 @@ msgstr "Inte angiven"
 msgid "<b>Author:</b>"
 msgstr "<b>Upphovsman:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -358,7 +363,7 @@ msgstr "_Återställ"
 msgid "Send note"
 msgstr "Skicka notis"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Bluetooth behöver aktiveras för att adapterhanteraren ska fungera"
 
@@ -366,32 +371,30 @@ msgstr "Bluetooth behöver aktiveras för att adapterhanteraren ska fungera"
 msgid "Bluetooth Adapters"
 msgstr "Blåtandsadaptrar"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Alltid"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d minut"
 msgstr[1] "%d minuter"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Adapter"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Bluetooth behöver aktiveras för att enhetshanteraren ska fungera"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Anslutning till BlueZ misslyckades"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -405,142 +408,134 @@ msgstr ""
 msgid "Searching"
 msgstr "Söker"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Blåtandsguide"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Adapterinställningar"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Filsändare"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth filöverföring"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Ansluter"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd inte tillgängligt"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Avbryter"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Skickar fil"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "Färdig om:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Misslyckades med att sända filen %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Hoppa över"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Försök igen"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Ett fel har inträffat"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Lokala tjänster"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Ihopparningsbegäran för %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth-autentisering"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Ange PIN-kod för autentisering:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Ange PIN-kod"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Ange lösennyckel för autentisering:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Ange lösennyckel"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Parningslösenord för"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Parar ihop pin-koden för"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Ihopparningsbegäran för:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Bekräfta värde för autentisering:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Bekräfta"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Neka"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Auktoriseringsbegäran för:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Tjänst:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Acceptera alltid"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Acceptera"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -574,243 +569,240 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nej"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Rapportera ett problem"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Enhetshanterare"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Visa _Verktygsrad"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Visa _Statusrad"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Sortera Efter"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "Namn"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "Tillagd"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "Fallande"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "Insti_cksmoduler"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Lokala tjänster"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Tjänsteinställningar"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Sök"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Adapterinställningar"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Avsluta"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "okategoriserad"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Betrodda och Parade</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Parade</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Pålitlig</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Dålig"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Suboptimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Optimal"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Mycket"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "För mycket"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Låg"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Hög"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Mycket hög"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Lyckades!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Serieport ansluten till %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Misslyckades"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Anslutningen misslyckades: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Ansluter"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Frånkopplingen Misslyckades:"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Kopplar från..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Anslut</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "Ansluter automatisk anslutningsprofiler A2DP källa, A2DP mål och HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Koppla från</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Tvinga frånkoppling av enheten"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Anslut till:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Koppla från:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Sänd en _fil..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Parkoppla"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Lita på"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Sluta lita på"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Ställ in…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Döp om enheten"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Ta bort"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Avbryt åtgärd"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Data aktivitet angiven"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "All data mottagen och överföringshastighet"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Totalt antal data skickat och överföringshastighet"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Inte pålitlig"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Välj enhet"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mer"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad bidragsgivare:\n"
@@ -827,7 +819,7 @@ msgstr ""
 "Transifex bidragsgivare:\n"
 "  Patrik Nilsson <asavar@tzeth.com>"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman är en GTK+ Bluetooth hanterare"
 
@@ -835,17 +827,17 @@ msgstr "Blueman är en GTK+ Bluetooth hanterare"
 msgid "GSM Settings"
 msgstr "GSM-inställningar"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Insticksmoduler"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Beroendeproblem"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -856,7 +848,7 @@ msgstr ""
 "<b>%(1)s</b> kommer även att ta bort <b>\"%(0)s\"</b>.\n"
 "Fortsätt?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -867,886 +859,1259 @@ msgstr ""
 "<b>%(1)s</b> kommer att inaktivera <b>%(0)s</b>.\n"
 "Fortsätt?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Val av adapter"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Synlig... %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "okategoriserad"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Nätverksaccesspunkt"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "stationär dator"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "server"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "bärbar dator"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "handdator"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "mobil"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "sladdlös"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "telefondator"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd inte tillgängligt"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "headset"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "handsfree"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "okänt"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Ljudkälla"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Ljudkälla"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Ljudkälla"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "tangentbord"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "pekenhet"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "tangentbord"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "pekenhet"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Anslut"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Anslut"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Anslut"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Anslut"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Bluetooth filöverföring"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Anslut"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Bluetooth filöverföring"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Bluetooth filöverföring"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Gruppnätverk"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Bluetooth filöverföring"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Anslut"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Anslut"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Bluetooth filöverföring"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Anslut"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Gruppnätverk"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Serieportar"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Uppringt nätverk (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Bluetooth filöverföring"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "headset"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Ljudkälla"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Ljudsink"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Nätverksaccesspunkt"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Gruppnätverk"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "handsfree"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Anslutningspunkt (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Anslutningspunkt (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Gruppnätverk"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Bluetooth filöverföring"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Ljudkälla"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Ljudsink"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Ljudkälla"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Döp om enheten"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Visa information om enheten"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Lokala tjänster"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Överföring"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "panelprogram"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Para Enhet"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Sök efter närliggande enheter"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Överföring"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "panelprogram"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Para Enhet"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Sök efter närliggande enheter"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Enhetshanterare"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Senaste _anslutningar"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Enhetshanterare"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Adapterinställningar"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Ansluta profiler automatiskt"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Proprietär"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ja"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "nej"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "Info"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Visa information om enheten"
 
@@ -1771,34 +2136,35 @@ msgstr "Ljudprofil"
 msgid "Select audio profile for PulseAudio"
 msgstr "Välj ljudprofil för PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Serieport %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Förnya IP Address"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Uppringningsinställningar"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Serieportar"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Inte angiven"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Ansluten"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1866,29 +2232,24 @@ msgstr "Nätverksanvändning"
 msgid "Shows network traffic usage"
 msgstr "Visar trafikanvändning av nätverk"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth aktiverat"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth inaktiverat"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "Hanterar lokala nätverkstjänster, såsom NAP-bryggor"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 "Ger stöd för Uppringt Nätverk (UN) med Modemhanterare och Nätverkshanterare"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1896,38 +2257,38 @@ msgstr ""
 "åtkomst"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Maximalt antal objekt"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 "Det maximala antal objekt i menyn för tidigare anslutningar som ska visas."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Senaste _anslutningar"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Ansluten till %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Misslyckades med att ansluta"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s på %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Adaptern för denna anslutning finns inte tillgänglig"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1935,83 +2296,79 @@ msgstr ""
 "Tillhandahåller stöd för Personal Area Networking (PAN) som introducerades i "
 "NetworkManager 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Tillhandahåller DBus API för andra Blueman-komponenter"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Inkommande fil över Bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Inkommande fil %(0)s från %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Neka"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Tar emot fil"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Tar emot filen %(0)s från %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Tillhandahåller möjligheten för OBEX-filöverföring"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Konfigurerad katalog för inkommande filer finns inte"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Filen har tagits emot"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Filen %(0)s från %(1)s har tagits emot"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Överföringen misslyckades"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Överföringen av filen %(0)s misslyckades"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Filer har tagits emot"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Tog emot %d fil i bakgrunden"
 msgstr[1] "Tog emot %d filer i bakgrunden"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Tog emot %d ytterligare fil i bakgrunden"
@@ -2024,27 +2381,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Lägger till ett standardmenyobjekt till statusikonens meny"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "Ställ in ny enhet"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Skicka _filer till enhet"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Enheter"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adap_trar"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "panelprogram"
 
@@ -2057,29 +2414,29 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Lägger till ett menyobjekt för att avsluta panelprogrammet"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 "Tillhandahåller en grundläggande DHCP-klient för PAN-anslutningar över "
 "Bluetooth."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth Nätverk"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Gränssnittet %(0)s bundet till IP-adress %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Misslyckades med att få en IP-adress på %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2088,7 +2445,7 @@ msgstr ""
 "Försöker få en IP-adress på %s\n"
 "Var god vänta..."
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2096,24 +2453,27 @@ msgstr ""
 "Lägger till en indikator på statusikonen när Bluetooth är aktiverat och "
 "visar antalet anslutningar i verktygstipset."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth aktivt"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d aktiv anslutning</b>"
 msgstr[1] "<b>%d aktiva anslutningar</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth inaktiverat"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Använder libappindicator för att visa en statusikon"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2121,35 +2481,36 @@ msgstr ""
 "Tillhandahåller ett menyobjekt för att göra standardadaptern temporärt "
 "synlig när den är inställd till dold som standard"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Tidsgräns för upptäckningsbar"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Mängden tid i sekunder för upptäckningsbart läge"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Gö_r upptäckningsbar"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Gör standardadaptern tillfälligt synlig"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Synlig... %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Tillhandahåller en meny för panelprogrammet och ett API för andra "
 "insticksmoduler att kommunicera med"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2158,24 +2519,24 @@ msgstr ""
 "Ansluten till <b>DUN</b>-tjänst på <b>%(0)s.</b>\n"
 "Nätverket finns nu tillgängligt via <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Tillhandahåller grundläggande stöd för anslutningar till Internet via DUN-"
 "profil."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standardhanterare för SPP-profilanslutning tillåter körning av anpassade "
 "åtgärder"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Skript att köra vid anslutning"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2193,22 +2554,22 @@ msgstr ""
 "\n"
 "När enheten kopplas från kommer skriptet att skickas en HUP-signal</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Serieport ansluten"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "Serieportstjänsten på enheten <b>%s</b> finns nu tillgänglig via <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Skript för serieportsanslutning misslyckades"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2217,37 +2578,37 @@ msgstr ""
 "Det uppstod ett fel vid start av skriptet %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Styr knapptillstånd för blåtandsadapter"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Automatisk ström-på"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Starta adaptrar automatiskt"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Inaktivera Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Stäng av alla adaptrar"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Aktivera Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Aktivera alla adaptrar"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2255,21 +2616,20 @@ msgstr ""
 "Avbryter tillfälligt skärmsläckaren när en Bluetooth spelkontroll är "
 "ansluten."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Nätverk"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Ogiltig IP-adress"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP-adresskonflikter med gränssnittet %s som har samma adress"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2277,8 +2637,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Stöds för närvarande inte med denna konfiguration"
 
@@ -2292,13 +2652,8 @@ msgstr "Panelprogrammets överföringstjänst är inaktiverad"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Blåtandsadaptrar"
-
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
 
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
@@ -2307,11 +2662,6 @@ msgstr "Blueman panelprogram"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Bluetooth hanterare"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2353,6 +2703,34 @@ msgstr "Ange RfKill tillstånd"
 msgid "Setting RfKill State requires privileges"
 msgstr "Ändra status för RfKill kräver privilegier"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Ange PIN-kod"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Ange lösennyckel"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Serieport ansluten till %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "headset"
+
+#~ msgid "handsfree"
+#~ msgstr "handsfree"
+
+#~ msgid "unknown"
+#~ msgstr "okänt"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Blåtandsenheter"
 
@@ -2373,11 +2751,6 @@ msgstr "Ändra status för RfKill kräver privilegier"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Tag bort..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Anslut"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/sw.po
+++ b/po/sw.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Swahili (http://www.transifex.com/mate/MATE/language/sw/)\n"
@@ -22,7 +22,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Mazingira ya kujulikana</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Nisionekane"
 
@@ -66,8 +66,8 @@ msgstr ""
 msgid "_View"
 msgstr ""
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr "Tafuta mitambo iliyo karibu"
 msgid "Search"
 msgstr "Utafutaji"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -89,17 +89,17 @@ msgstr ""
 msgid "Pair"
 msgstr "jozi"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Weka/Toa alama kwa mtambo huu kama inayoaminika"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Amini"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Tumia msaidizi kwa kusajili mtambo huu"
 
@@ -108,7 +108,7 @@ msgstr "Tumia msaidizi kwa kusajili mtambo huu"
 msgid "Setup..."
 msgstr "Sajili"
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Toa mtambo huu kwa orodha ya mitambo inayojulikana"
 
@@ -283,7 +283,12 @@ msgstr ""
 msgid "<b>Author:</b>"
 msgstr ""
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -345,7 +350,7 @@ msgstr ""
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -353,30 +358,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Adapta za Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr ""
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -387,142 +392,134 @@ msgstr ""
 msgid "Searching"
 msgstr ""
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr ""
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr ""
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr ""
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr ""
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Huduma za kienyeji"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr ""
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -553,241 +550,241 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 msgid "Connecting…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 msgid "Disconnecting…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send File"
 msgid "Send a _File…"
 msgstr "Tuma Faili"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Ita jina jipya kifaa"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Toa kabisa"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr ""
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  MwalimuJini https://launchpad.net/~dude-thony"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -795,17 +792,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -813,7 +810,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -821,854 +818,1218 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:10
+msgid "Phone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:12
+msgid "Access point"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+msgid "Desktop"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:33
+msgid "Server"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:35
+msgid "Laptop"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+msgid "Smart phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
+msgid "17-33 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
+msgid "50-67 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
+msgid "67-83 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+msgid "Microphone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+msgid "Video camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+msgid "Video monitor"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+msgid "Video conferencing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+msgid "Keyboard"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
+msgid "Pointing"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Mtandao wa Kikundi"
+
+#: blueman/DeviceClass.py:170
+msgid "Generic Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:171
+msgid "Generic Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Mtandao wa Kikundi"
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Mtandao wa Kikundi"
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Mtandao wa Kikundi"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Mtandao wa Kikundi"
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+msgid "Generic Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:181
+msgid "Generic Thermometer"
+msgstr ""
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+msgid "Generic Glucose Meter"
+msgstr ""
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Mtandao wa Kikundi"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 msgid "OBEX File Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr ""
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr ""
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Mtandao wa Kikundi"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Kituo cha Kutumia Mtandao (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Kituo cha Kutumia Mtandao (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Mtandao wa Kikundi"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr ""
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr ""
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr ""
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Ita jina jipya kifaa"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Huduma za kienyeji"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 #, fuzzy
-#| msgid "Local Services"
 msgid "Primary Service"
 msgstr "Huduma za kienyeji"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 #, fuzzy
-#| msgid "Search for nearby devices"
 msgid "Secondary Service"
 msgstr "Tafuta mitambo iliyo karibu"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 msgid "Device Name"
 msgstr ""
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr ""
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1693,34 +2054,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1783,141 +2145,136 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1931,27 +2288,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
@@ -1963,107 +2320,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2074,78 +2437,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2153,8 +2515,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2168,13 +2530,8 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Adapta za Bluetooth"
-
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
 
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
@@ -2182,24 +2539,16 @@ msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Blueman Bluetooth Manager"
 msgstr "Adapta za Bluetooth"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Bluetooth Manager"
 msgstr "Adapta za Bluetooth"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Mitambo ya Bluetooth"
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Tamil (http://www.transifex.com/mate/MATE/language/ta/)\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr ""
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "மறைக்கப்பட்ட"
 
@@ -67,8 +67,8 @@ msgstr "_சாதனம்"
 msgid "_View"
 msgstr "_பார்"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_உதவி"
 
@@ -81,7 +81,7 @@ msgstr "அருகில் உள்ள சாதனத்தை தேடு
 msgid "Search"
 msgstr "தேடுக"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -90,17 +90,17 @@ msgstr ""
 msgid "Pair"
 msgstr "பிணைக்க"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "நம்பு"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr ""
 
@@ -109,7 +109,7 @@ msgstr ""
 msgid "Setup..."
 msgstr "அமைப்பு..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "இச்சாதனத்தை தெரிந்த சாதனங்கள் பட்டியலில் இருந்து நீக்கு "
 
@@ -284,7 +284,12 @@ msgstr "குறிப்பிடப்படவில்லை"
 msgid "<b>Author:</b>"
 msgstr "<b>எழுதியவர்:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -346,7 +351,7 @@ msgstr "நிலை மீள் "
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -354,30 +359,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr ""
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "எப்போதும்"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -388,142 +393,134 @@ msgstr ""
 msgid "Searching"
 msgstr ""
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "இணைக்கப்படுகிறது"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr ""
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr ""
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "பிழை ஏற்பட்டது"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "உறுதி செய்"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "நிராகரி"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "சேவை:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "எப்பொழுதும் ஏற்றுக்கொள்"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "ஏற்றுக்கொள்"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -554,246 +551,244 @@ msgstr "ஆம்"
 msgid "No"
 msgstr "இல்லை"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "சாதன மேலாளர்"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_S தேடுக"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "மோசம்"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "குறைவு"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "உயர்வு"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "மிகவும் அதிகமான"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "வெற்றி!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "தோல்வியடைந்தது"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "இணைக்க முடியவில்லை "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "இணைக்கப்படுகிறது"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "துண்டிக்க முடியவில்லை "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "துண்டித்து கொண்டுஇருக்கிறது "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send File"
 msgid "Send a _File…"
 msgstr "கோப்பை அனுப்பு"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "சாதனத்திற்கு மறுபெயரிடு"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "நீக்கு"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "செயல்பாட்டினை கைவிடுக"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr ""
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  bhuvi https://launchpad.net/~bhuvanesh"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -801,17 +796,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "சொருகுப்பொருள்கள்"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -819,7 +814,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -827,858 +822,1233 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "துண்டித்து கொண்டுஇருக்கிறது "
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "ஏற்றுக்கொள்"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "மேல்மேசை"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
+msgstr "சேவை:"
+
+#. translators: device class
+#: blueman/DeviceClass.py:35
+msgid "Laptop"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+msgid "Smart phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
+msgid "17-33 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
+msgid "50-67 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
+msgid "67-83 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "தெரியாதது"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:88
+msgid "Microphone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+msgid "Video camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+msgid "Video monitor"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+msgid "Video conferencing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+msgid "Keyboard"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "இணைக்கப்படுகிறது"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "இணைக்கவும்"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "இணைக்கவும்"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "இணைக்கவும்"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "இணைக்கவும்"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "இணைக்கவும்"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "இணைக்கவும்"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "இணைக்கவும்"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "இணைக்கவும்"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "இணைக்கவும்"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr ""
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr ""
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr ""
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr ""
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr ""
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr ""
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "சாதனத்திற்கு மறுபெயரிடு"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Service:"
 msgid "Battery Service"
 msgstr "சேவை:"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 #, fuzzy
-#| msgid "Service:"
 msgid "Primary Service"
 msgstr "சேவை:"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 #, fuzzy
-#| msgid "Search for nearby devices"
 msgid "Secondary Service"
 msgstr "அருகில் உள்ள சாதனத்தை தேடுக "
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "சாதன மேலாளர்"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "சாதன மேலாளர்"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "ஆம்"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "இல்லை"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1703,34 +2073,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "குறிப்பிடாத"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "இணைக்கப்பட்டது"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1793,141 +2164,136 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "நிராகரி"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "இடமாற்றம்  தோல்வியுற்றது"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1941,27 +2307,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
@@ -1973,107 +2339,113 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2084,78 +2456,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "பிணையம்"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2163,8 +2534,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2180,10 +2551,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
@@ -2192,20 +2559,13 @@ msgstr ""
 msgid "Blueman Bluetooth Manager"
 msgstr ""
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Bluetooth Manager"
 msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Bluetooth Device"
 msgstr "ப்ளூடூத் கோப்பு பரிமாற்றம்"
 
@@ -2241,12 +2601,10 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "unknown"
+#~ msgstr "தெரியாதது"
+
 #, fuzzy
 #~| msgid "Rename device"
 #~ msgid "R_ename device..."
 #~ msgstr "சாதனத்திற்கு மறுபெயரிடு"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "இணைக்கவும்"

--- a/po/tr.po
+++ b/po/tr.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-08-01 08:55+0000\n"
 "Last-Translator: Oğuz Ersen <oguzersen@protonmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/blueman/blueman/"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Görünürlük Ayarı</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Gizli"
 
@@ -72,8 +72,8 @@ msgstr "_Aygıt"
 msgid "_View"
 msgstr "_Görünüm"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Yardım"
 
@@ -86,7 +86,7 @@ msgstr "Çevredeki aygıtları ara"
 msgid "Search"
 msgstr "Ara"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Aygıt ile eşleştir"
 
@@ -95,17 +95,17 @@ msgstr "Aygıt ile eşleştir"
 msgid "Pair"
 msgstr "Eşleştir"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Bu donanımı güvenilir olarak işaretle/işaretleme"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Güvenilirlik"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Bu aygıt için kurulum asistanını başlat"
 
@@ -114,7 +114,7 @@ msgstr "Bu aygıt için kurulum asistanını başlat"
 msgid "Setup..."
 msgstr "Kur..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Bu aygıtı bilinen aygıtlar listesinden kaldır"
 
@@ -295,7 +295,12 @@ msgstr "Belirtilmemiş"
 msgid "<b>Author:</b>"
 msgstr "<b>Yazar:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -357,7 +362,7 @@ msgstr "_Sıfırla"
 msgid "Send note"
 msgstr "Not gönder"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 "Bağdaştırıcı yöneticisinin çalışması için Bluetooth'un açılması gerekir"
@@ -366,30 +371,30 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "Bluetooth Bağdaştırıcıları"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Her zaman"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%(minutes)d Dakika"
 msgstr[1] "%(minutes)d Dakika"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Bağdaştırıcı"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Aygıt yöneticisinin çalışabilmesi için bluetooth açılmalı"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "BlueZ bağlantısı başarısız"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -403,144 +408,136 @@ msgstr ""
 msgid "Searching"
 msgstr "Aranıyor"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Bluetooth Yardımcısı"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Bağdaştırıcı Tercihleri"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Dosya Gönderici"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Bluetooth Dosya Aktarımı"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Bağlanıyor"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd bulunamadı"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Obex hizmeti otomatik olarak başlatılamadı. Obex arka plan programının "
 "çalıştığından emin olun"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "İptal ediliyor"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Dosya Gönderiliyor"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "%s dosyası gönderilirken hata oluştu"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Atla"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Yeniden Dene"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Hata oluştu"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Yerel Servisler"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "%s için eşleme isteği"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Bluetooth Kimlik Doğrulama"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Kimlik doğrulaması için PIN kodunu girin:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "PIN kodunu girin"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Doğrulama için geçiş anahtarını girin:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Şifre girin"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Erişim anahtarı eşleştiriliyor"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "PIN kodu şunun için eşleştiriliyor:"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Eşleme isteği:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Doğrulama için değeri onayla:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Doğrula"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Reddet"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Yetkilendirme isteği:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Servis:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Daima izinli"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Kabul Et"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -574,229 +571,233 @@ msgstr "Evet"
 msgid "No"
 msgstr "Hayır"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Sorun Bildir"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Aygıt Yöneticisi"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "_Araç Çubuğunu Göster"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "_Durum Çubuğunu Göster"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Sıralama"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Ad"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Eklenen"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Azalan"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Eklentiler"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "_Yerel Servisler"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Hizmet Tercihleri"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Ara"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr "_Tercihler"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr "_Çıkış"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "sınıflandırılmamış"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Güvenilir ve Eşlenmiş</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Eşlenmiş</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Güvenilir</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Zayıf"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Optimal altı"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "En Uygun"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Daha fazla"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Çok fazla"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Düşük"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Yüksek"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Çok Yüksek"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Başarılı!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Seri bağlantı noktası %s ile bağlandı"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Başarısız"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Bağlantı Başarısız: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 msgid "Connecting…"
 msgstr "Bağlanıyor…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Bağlantı Kesilemedi: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 msgid "Disconnecting…"
 msgstr "Bağlantı kesiliyor…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "_<b>Bağlan</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "A2DP kaynak, A2DP çöp ve HID otomatik bağlantı profillerini bağlar"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "<b>Bağlantıyı _kes</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Aygıt bağlantısını zorla kes"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Şuna Bağlan:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Bağlantıyı Kes:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 msgid "Send a _File…"
 msgstr "Bir Dosya _Gönder…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Eşleştir"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Güven"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Güvenme"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Kurulum…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr "Aygıtı y_eniden adlandır…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 msgid "_Remove…"
 msgstr "_Kaldır…"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "İşlemi İptal Et"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Veri etkinlik tespiti"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Toplam ulaşan veri ve iletim oranı"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Toplam gönderilen veri ve iletim oranı"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Güvenilmez"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Aygıt Seç"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Daha Fazla"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -816,7 +817,7 @@ msgstr ""
 "  denz https://launchpad.net/~psycho2dct\n"
 "  zeugma https://launchpad.net/~sunder67"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman, bir GTK+ Bluetooth yönetimi aracıdır"
 
@@ -824,17 +825,17 @@ msgstr "Blueman, bir GTK+ Bluetooth yönetimi aracıdır"
 msgid "GSM Settings"
 msgstr "GSM Ayarları"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Eklentiler"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Bağımlılık sorunu"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -845,7 +846,7 @@ msgstr ""
 "kaldırmak <b>\"%(0)s\"</b> öğesini de kaldıracaktır.\n"
 "Devam?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -856,840 +857,1245 @@ msgstr ""
 "eklentisinin yüklenmesi <b>%(0)s</b> eklentisinin silinmesini gerektiriyor.\n"
 "Devam edilsin mi?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Bağdaştırıcı seçimi"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 msgid "Discovering…"
 msgstr "Keşfediliyor…"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "sınıflandırılmamış"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Ağ Erişim Noktası"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "masaüstü"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "sunucu"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "dizüstü bilgisayar"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "taşınabilir"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "telefon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "kablosuz"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "akıllı telefon (Nokia N Series , Symbian vb.)"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "modem"
 
 #. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+msgid "83-99 percent"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
-msgstr "kulaklık"
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd bulunamadı"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
-msgstr "eller serbest"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
+msgstr "Kulaklık"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "bilinmeyen"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
+msgstr "Eller serbest"
 
 #. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "mikrofon"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+#, fuzzy
+msgid "Loudspeaker"
 msgstr "hoparlör"
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+#, fuzzy
+msgid "Headphones"
 msgstr "kulaklık"
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+#, fuzzy
+msgid "Portable audio"
 msgstr "taşınabilir ses sistemi"
 
 #. translators: device class
-#: blueman/DeviceClass.py:125
-msgid "car audio"
+#: blueman/DeviceClass.py:96
+#, fuzzy
+msgid "Car audio"
 msgstr "araç ses sistemi"
 
 #. translators: device class
-#: blueman/DeviceClass.py:127
-msgid "set-top box"
+#: blueman/DeviceClass.py:98
+#, fuzzy
+msgid "Set-top box"
 msgstr "set üstü kutusu"
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:100
+#, fuzzy
+msgid "Hifi audio"
 msgstr "hifi ses sistemi"
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:102
+#, fuzzy
+msgid "Vcr"
 msgstr "vcr"
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
 msgstr "video kamera"
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:106
+#, fuzzy
+msgid "Camcorder"
 msgstr "kayıt kamerası"
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
 msgstr "video ekranı"
 
 #. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
+#: blueman/DeviceClass.py:110
+#, fuzzy
+msgid "Video display and loudspeaker"
 msgstr "video ekranı ve hoparlör"
 
 #. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Video Girişi"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "klavye"
+
+#. translators: device class
+#: blueman/DeviceClass.py:125
+#, fuzzy
+msgid "Pointing"
+msgstr "işaretleme"
+
+#. translators: device class
+#: blueman/DeviceClass.py:127
+msgid "Combo"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:132
+msgid "Display"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:134
+msgid "Camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:138
+msgid "Printer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "klavye"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "işaretleme"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Genel Bağlantı"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Genel Bağlantı"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Genel Bağlantı"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Genel Bağlantı"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Genel Dosya Aktarımı"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Genel Bağlantı"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Genel Dosya Aktarımı"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Genel Dosya Aktarımı"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Genel Ağ"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Genel Dosya Aktarımı"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Genel Bağlantı"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Genel Bağlantı"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Genel Dosya Aktarımı"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Genel Bağlantı"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Genel Ağ"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr "Seri Bağlantı Noktası"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Çevirmeli Ağ (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 msgid "OBEX File Transfer"
 msgstr "OBEX Dosya Aktarımı"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr "Kulaklık"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Ses Girişi"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Ses Çıkışı"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Ağ Erişim Noktası"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Şebeke grubu"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr "Eller serbest"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr "Telefon Defteri Erişimi (PBAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr "Mesaj Erişim Profili (MAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr "Genel Ağ"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr "Genel Dosya Aktarımı"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr "Video Girişi"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr "Video Çıkışı"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr "HDP Girişi"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr "Geçerli Zaman Hizmeti"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr "Aygıt Bilgileri"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr "Pil Hizmeti"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr "Nesne Aktarımı"
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr "AppleAgent"
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr "Birincil Hizmet"
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 msgid "Secondary Service"
 msgstr "İkincil Hizmet"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 msgid "Device Name"
 msgstr "Aygıt Adı"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr "Yeniden Bağlantı Adresi"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr "Hizmet Değişti"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr "Bildirme Referansı"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Otomatik bağlanma profilleri"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Tescilli"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "evet"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "hayır"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Bilgi"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Aygıt bilgisini göster"
 
@@ -1714,34 +2120,35 @@ msgstr "Ses Profili"
 msgid "Select audio profile for PulseAudio"
 msgstr "PulseAudio için ses profili seçin"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Seri Bağlantı Noktası %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "IP Adresini Yenile"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Çevirmeli GSM Data Bağlantı Ayarları"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Seri Bağlantı Noktaları"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Belirtilmemiş"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Bağlandı"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "%(device)s üzerinde %(service)s'e otomatik olarak bağlandı"
@@ -1809,106 +2216,101 @@ msgstr "Ağ _Kullanımı"
 msgid "Shows network traffic usage"
 msgstr "Ağ kullanımını görüntüler"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth Etkin"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth Devredışı"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "NAP köprüleri gibi yerel ağ hizmetlerini yönetir"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 "Çevirmeli Ağ (DUN) için ModemManager ve NetworkManager ile destek sağlar"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "Hızlı ulaşım için son kullanılan bağlantıların menüsünü sunar"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Azami öğe"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Son bağlantılar menüsünün göstereceği maksimum öge sayısı."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Son _Bağlantılar"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "%s cihazına bağlı"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Bağlanma girişimi başarısız"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(device)s üzerinden %(service)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Bu bağlantı için bağdaştırıcı kullanılabilir değil"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 "NetworkManager 0.8'de tanıtılan Kişisel Alan Ağı (PAN) için destek sağlar"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Diğer Blueman öğeleri için DBus API sağlar"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Bluetooth 'dan gelen Dosya"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "%(1)s kaynağından %(0)s dosyası alınıyor"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Reddet"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Alınan dosya"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "%(1)s kaynağından %(0)s dosyası alınıyor"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "OBEX dosya aktarımı yetenekleri sunar"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Gelen dosyalar için ayarlanan dizin mevcut değil"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1917,37 +2319,37 @@ msgstr ""
 "Lütfen \"<b>%s</b>\" dizininin bulunduğundan emin olun veya blueman-services "
 "ile yapılandırın. O zamana kadar öntanımlı \"%s\" kullanılacak"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Dosya alındı"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "%(1)s kaynağından %(0)s dosyası başarıyla alındı"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Aktarım başarısız"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "%(0)s dosyasının aktarımı başarısız oldu"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Alınan dosyalar"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Arka planda %(files)d dosya alındı"
 msgstr[1] "Arka planda %(files)d dosya alındı"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1961,27 +2363,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Standart menü maddelerini durum simgelerine ekle"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "Yeni Cihaz _Kur"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Cihaza dosya gönder"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Aygıtlar"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "Adaptörler"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "uygulama"
 
@@ -1994,27 +2396,27 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Uygulamadan çıkmak için çıkış menüsü ögesi ekle"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "Bluetooth PAN bağlantısı için temel bir DHCP istemcisi sağlar."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Bluetooth Ağı"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Arayüz %(0)s IP adresine geçiş yaptı %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "%s üzerinden IP adresi alınamadı"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2023,7 +2425,7 @@ msgstr ""
 "%s üzerinde IP adresi elde edilmeye çalışılıyor\n"
 "Lütfen bekleyin…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2031,22 +2433,27 @@ msgstr ""
 "Bluetooth etkinken durum simgesine bir gösterge ekler ve araç ipucunda "
 "bağlantı sayısını gösterir."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth Etkin"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%(connections)d Faal Bağlantı</b>"
 msgstr[1] "<b>%(connections)d Faal Bağlantı</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth Devredışı"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Durum ikonu göstermek için libappindicator'ı kullanır"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2054,34 +2461,35 @@ msgstr ""
 "Öntanımlı olarak gizli olarak ayarlandığında öntanımlı bağdaştırıcıyı geçici "
 "olarak görünür yapmak için bir menü ögesi sağlar"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Keşfedilebilirlik zaman aşımı"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Keşfedilebilir moddaki saniye cinsinden süre"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Keşfedilebilir _Yap"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Öntanımlı bağdaştırıcıyı geçici olarak görünür yap"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Keşfedilebilir… %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 "Uygulama için bir menü ve diğer eklentilerin ona erişmesi için bir API sağlar"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2090,22 +2498,22 @@ msgstr ""
 "<b>%(0)s</b> aygıtında <b>DUN</b> hizmetine başarıyla bağlandı.\n"
 "Ağ artık <b>%(1)s</b> üzerinden kullanılabilir"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "DUN profili üzerinden internete bağlanmak için temel destek sağlar."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Standart SPP profil bağlantısı yöneticisi, özel eylemlerin çalıştırılmasına "
 "imkân verir"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "Bağlanıldığında çalıştırılacak betik"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2123,11 +2531,11 @@ msgstr ""
 "\n"
 "Cihazın bağlantısı kesildiğinde betiğe bir HUP sinyali gönderilecektir</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Seri bağlantı noktasından bağlanıldı"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
@@ -2135,11 +2543,11 @@ msgstr ""
 "<b>%s</b> aygıtındaki seri bağlantı noktası hizmeti şimdi <b>%s</b> "
 "üzerinden kullanılabilir"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "Seri bağlantı noktasından bağlantı betiği başarısız oldu"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2148,37 +2556,37 @@ msgstr ""
 "Başlangıç yazısında hata var %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Bluetooth bağdaştırıcısı güç durumlarını denetler"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Kendiliğinden çalıştır"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Bağdaştırıcılar bağlandığında kendiliğinden çalıştır"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>Bluetooth'u _Kapat</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Tüm bağdaştırıcıları kapat"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>Bluetooth'u _Aç</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Tüm bağdaştırıcıları aç"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2186,21 +2594,20 @@ msgstr ""
 "Bir Bluetooth oyun denetleyicisi bağlı ise ekran koruyucuyu geçici olarak "
 "devre dışı bırakır."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Ağ"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Geçersiz IP adresi"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP adresi aynı adrese sahip %s arayüzü ile çakışmaktadır"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2211,8 +2618,8 @@ msgstr ""
 "çakışmaktadır\n"
 "Bu yanlış ağ davranışına neden olabilir"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Bu kurulum halen desteklenmiyor"
 
@@ -2228,10 +2635,6 @@ msgstr "Uygulamanın aktarım hizmeti eklentisi devre dışı"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Bluetooth Bağdaştırıcısı Özelliklerini Ayarla"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Blueman Uygulaması"
@@ -2239,11 +2642,6 @@ msgstr "Blueman Uygulaması"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman Bluetooth Yöneticisi"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2285,6 +2683,37 @@ msgstr "RfKill Durumunu Ayarla"
 msgid "Setting RfKill State requires privileges"
 msgstr "RfKill durumunu ayarlamak özel haklar gerektirir"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "PIN kodunu girin"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Şifre girin"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Seri bağlantı noktası %s ile bağlandı"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "kulaklık"
+
+#~ msgid "handsfree"
+#~ msgstr "eller serbest"
+
+#~ msgid "unknown"
+#~ msgstr "bilinmeyen"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Bluetooth Aygıtları"
 
@@ -2303,9 +2732,6 @@ msgstr "RfKill durumunu ayarlamak özel haklar gerektirir"
 
 #~ msgid "_Remove..."
 #~ msgstr "_Kaldır..."
-
-#~ msgid "Generic Connect"
-#~ msgstr "Genel Bağlantı"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/uk.po
+++ b/po/uk.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-06-05 12:28+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/blueman/"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>Налаштування видимості</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Прихований"
 
@@ -75,8 +75,8 @@ msgstr "_Пристрій"
 msgid "_View"
 msgstr "_Перегляд"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "_Довідка"
 
@@ -89,7 +89,7 @@ msgstr "Шукати пристрої"
 msgid "Search"
 msgstr "Шукати"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Утворити пару з пристроєм"
 
@@ -98,17 +98,17 @@ msgstr "Утворити пару з пристроєм"
 msgid "Pair"
 msgstr "Пара"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "Встановити/зняти позначку з пристрою як \"надійний\""
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "Надійний"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "Запустити помічник налаштування для цього пристрою"
 
@@ -117,7 +117,7 @@ msgstr "Запустити помічник налаштування для ць
 msgid "Setup..."
 msgstr "Встановлення..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Вилучити цей пристрій з переліку відомих пристроїв"
 
@@ -298,7 +298,12 @@ msgstr "Не вказано"
 msgid "<b>Author:</b>"
 msgstr "<b>Автор:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -360,7 +365,7 @@ msgstr "_Скинути"
 msgid "Send note"
 msgstr "Відправити нотатку"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "Для роботи упорядника адаптерів повинен бути увімкнений bluetooth"
 
@@ -368,14 +373,12 @@ msgstr "Для роботи упорядника адаптерів повине
 msgid "Bluetooth Adapters"
 msgstr "Адаптери Bluetooth"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Завжди"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d хвилина"
@@ -383,19 +386,19 @@ msgstr[1] "%d хвилини"
 msgstr[2] "%d хвилин"
 msgstr[3] "%d хвилин"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "Адаптер"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "Потрібно увімкнути bluetooth для роботи упорядника пристроїв"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "Не вдалося під’єднатися до BlueZ"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -409,49 +412,49 @@ msgstr ""
 msgid "Searching"
 msgstr "Пошук"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "Помічник bluetooth"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "Параметри адаптера"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "Передавач файлів"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "Передача файлу через bluetooth"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Під’єднання"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd недоступний"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 "Помилка самозапуску служби obex. Переконайтеся, що запущений демон obex"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "Скасування"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "Надсилання файлу"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "час, що залишився:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
@@ -460,94 +463,86 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "Виникла помилка при надсиланні файлу %s"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "Пропустити"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "Спробувати знову"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "Виникла помилка"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "Локальні служби"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "Запит на утворення пари для %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "Розпізнання bluetooth"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "Уведіть PIN код для розпізнання:"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Уведіть PIN код"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "Уведіть пароль для розпізнання:"
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "Уведіть пароль"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "Спаровування ключа для"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "Спаровування PIN коду для"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "Запит на утворення пари для:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "Схвалити значення для розпізнання:"
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Схвалити"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Заборонити"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "Запит авторизації для:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "Служба:"
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "Завжди приймати"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "Прийняти"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -581,244 +576,241 @@ msgstr "Так"
 msgid "No"
 msgstr "Ні"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "_Сповістити про проблему"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Упорядник пристроїв"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "Показати _панель знарядь"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "Показати _рядок стану"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "Ґа_тункувати за"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "_Ім’я"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "_Доданий"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "_Зниження"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "_Втулки"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "Локальні _служби"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "Налаштування служб"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "_Шукати"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "Параметри адаптера"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "Вийти"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "невизначено"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>Надійні та зв'язані</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>Зв'язані</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>Надійний</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Поганий"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "Середній"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "Оптимальний"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "Значний"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "Дуже значний"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "Низький"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "Високий"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "Дуже високий"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "Успішно!"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "Під’єднаний послідовний порт на %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Невдало"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "Не вдалося під’єднатися: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Під’єднання"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "Помилка від’єднання: "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Від’єднання..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "<b>З'_єднатися</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 "Під’єднує профілі самоз’єднання з джерелами A2DP, приймачами A2DP та HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "_<b>Від'єднатися</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "Примусово від'єднати пристрій"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>Під’єднатися до:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>Від’єднати:</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "Надіслати _файл..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "_Пара"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "_Надійний"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "_Ненадійний"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "_Налаштувати…"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Перейменувати пристрій"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Вилучити"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "Скасувати дію"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "Індикація активности даних"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "Усього отримано даних та швидкість передачі"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "Усього надіслано даних та швидкість передачі"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "Ненадійний"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Оберіть пристрій"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Додатково"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Інформація про перекладачів:\n"
@@ -836,7 +828,7 @@ msgstr ""
 "  shcherbet https://launchpad.net/~shcherbet\n"
 "  Сергій Матрунчик (SkyMan) https://launchpad.net/~skymanphp"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman – це розпорядник Bluetooth, побудований на базі GTK+"
 
@@ -844,17 +836,17 @@ msgstr "Blueman – це розпорядник Bluetooth, побудовани�
 msgid "GSM Settings"
 msgstr "Налаштування GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Втулки"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "Проблема з залежностями"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -865,7 +857,7 @@ msgstr ""
 "призведе також до вивантаження <b>\"%(0)s\"</b>. \n"
 "Вивантажити?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -876,886 +868,1259 @@ msgstr ""
 "призведе до вивантаження <b>%(0)s</b>.\n"
 "Завантажити?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "Вибір пристрою"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "Видимий... %ss"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "невизначено"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "Точка доступу до мережі"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "стаціонарний"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "сервер"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "ноутбук"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "кишеньковий"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "ПДА (надолонник)"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "мобільний"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "бездротовий"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "смартфон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "модем"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd недоступний"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "навушники"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "гарнітура"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "невідомий"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "мікрофон"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Джерело аудіо"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Джерело аудіо"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Джерело аудіо"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "клавіатура"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "маніпулятор"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "клавіатура"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "маніпулятор"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Під’єднати"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Під’єднати"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Під’єднати"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Під’єднати"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "Передача файлу через bluetooth"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Під’єднати"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "Передача файлу через bluetooth"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Передача файлу через bluetooth"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Групова мережа"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "Передача файлу через bluetooth"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Під’єднати"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Під’єднати"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "Передача файлу через bluetooth"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Під’єднати"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Групова мережа"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "Послідовні порти"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "Комутоване з'єднання (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "Передача файлу через bluetooth"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "навушники"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Джерело аудіо"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "Приймач авдіо"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "Точка доступу до мережі"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "Групова мережа"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "гарнітура"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "Точка доступу мережі (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "Точка доступу мережі (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "Групова мережа"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "Передача файлу через bluetooth"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Джерело аудіо"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "Приймач авдіо"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Джерело аудіо"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Перейменувати пристрій"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "Показати інформацію про пристрій"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "Локальні служби"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "Передача"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "аплет"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "Спаровування з пристроєм"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "Шукати пристрої"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "Передача"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "аплет"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "Спаровування з пристроєм"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "Шукати пристрої"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Упорядник пристроїв"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "Нещодавні _з'єднання"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Упорядник пристроїв"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "Параметри адаптера"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "Профілі самочинного під'єднання"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "Власницький"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "так"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "ні"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "_Інформація"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "Показати інформацію про пристрій"
 
@@ -1780,34 +2145,35 @@ msgstr "Звуковий профіль"
 msgid "Select audio profile for PulseAudio"
 msgstr "Оберіть звуковий профіль PulseAudio"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "Послідовний порт %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "Оновити IP адресу"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "Налаштування служби доступу до мережі через модем"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "Послідовні порти"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "Не вказано"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Під’єднано"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "Автоматично з'єднано із %(service)s на %(device)s"
@@ -1881,24 +2247,19 @@ msgstr "Використання _мережі"
 msgid "Shows network traffic usage"
 msgstr "Показати використання мережевого трафіку"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "Bluetooth увімкнено"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "Bluetooth вимкнено"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 "Керує службами локальної мережі, такими як мости точок доступу до мережі "
 "(NAP)"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
@@ -1906,7 +2267,7 @@ msgstr ""
 "Забезпечує підтримку для Dial Up Networking (DUN) для ModemManager і "
 "NetworkManager"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
@@ -1914,37 +2275,37 @@ msgstr ""
 "доступу"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "Щонайбільша кількість елементів"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "Найбільша кількість елементів у меню переліку останніх з’єднань."
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "Нещодавні _з'єднання"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "Під’єднаний до %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Не вдалося під’єднатися"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(service)s на %(device)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "Адаптер для цього з’єднання не доступний"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
@@ -1952,41 +2313,41 @@ msgstr ""
 "Забезпечує підтримку персональної мережі (PAN), зреалізовану у Мережевих "
 "з'єднаннях версії 0.8"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "Надає DBus API для інших компонентів Blueman"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "Вхідний файл через bluetooth"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "Вхідний файл %(0)s від %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "Відхилити"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Отримання файлу"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Отримання файлу %(0)s від %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "Забезпечує передачу файлів через протокол OBEX"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "Налаштованої директорії для вхідних файлів не існує"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1996,33 +2357,31 @@ msgstr ""
 "за допомогою blueman-services. Аж до моменту налаштування, буде використано "
 "«%s»"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Файл отримано"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "Файл %(0)s від %(1)s отримано успішно"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "Помилка передавання"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "Не вдалося передати файл %(0)s"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "Файли отримано"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "Отримано %d файл у режимі тла"
@@ -2030,10 +2389,8 @@ msgstr[1] "Отримано %d файли у режимі тла"
 msgstr[2] "Отримано %d файлів у тловому режимі"
 msgstr[3] "Отримано %d файлів у тловому режимі"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "Отримано ще %d файл у режимі тла"
@@ -2048,27 +2405,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "Додає стандартні елементи до меню піктограми статусу"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "_Налаштувати новий пристрій"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "Надіслати _файли до пристрою"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "_Пристрої"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "_Адаптери"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "аплет"
 
@@ -2080,29 +2437,29 @@ msgstr "Надає пароль доступу, служби розпізнан�
 msgid "Adds an exit menu item to quit the applet"
 msgstr "Додавати в меню аплету кнопку виходу"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 "Забезпечує базову підтримку DHCP клієнта для під’єднань до персональної "
 "мережі PAN."
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "Мережа bluetooth"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "Інтерфейс %(0)s пов'язаний з IP адресою %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "Не вдається отримати IP адресу на %s"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2111,7 +2468,7 @@ msgstr ""
 "Спроба отримати IP адресу на %s\n"
 "Будь ласка, зачекайте…"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
@@ -2119,14 +2476,12 @@ msgstr ""
 "Додає індикацію до піктограми статусу, коли bluetooth активний і показує "
 "кількість під’єднань у підказці."
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "Bluetooth активний"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d Активне Під’єднання</b>"
@@ -2134,11 +2489,16 @@ msgstr[1] "<b>%d Активних Під’єднань</b>"
 msgstr[2] "<b>%d Активних Під’єднань</b>"
 msgstr[3] "<b>%d Активних Під’єднань</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "Bluetooth вимкнено"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "Використовує libappindicator, щоб показати піктограму стану"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
@@ -2146,33 +2506,34 @@ msgstr ""
 "Додає пункт меню, що дозволяє робити основний адаптер видимим для зовнішніх "
 "пристроїв, коли типово встановлено режим невидимості"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "Тривалість видимости"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "Тривалість режиму видимости у секундах"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "Дозволити _виявлення пристрою"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "Зробити типовий адаптер тимчасово видимим"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "Видимий... %ss"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "Надає меню для аплету та API маніпулювання ним для инших втулків"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2182,24 +2543,24 @@ msgstr ""
 "</b>\n"
 "Мережа наразі доступна через <b>%(1)s</b>"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 "Забезпечує базову підтримку під’єднання до тенет через комутоване з'єднання "
 "(DUN профіль)."
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 "Провайдер стандартного профілю з’єднання SPP, дозволяє виконувати дії "
 "користувача"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "При успішному з'єднанні виконувати скрипт"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2217,22 +2578,22 @@ msgstr ""
 "\n"
 "Після від’єднання пристрою скрипту буде послано сигнал HIP</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "Послідовний порт під’єднаний"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 "Послідовний порт на пристрої <b>%s</b> тепер буде доступний через <b>%s</b>"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "При виконанні скрипту з'єднання серійного порту виникла помилка"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2241,37 +2602,37 @@ msgstr ""
 "Виникла помилка при запуску скрипту %s\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "Контролювати стан живлення адаптера bluetooth"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "Автоматичне вмикання"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "Автоматичне увімкнення адаптерів"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>_Вимкнути Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "Вимкнути усі адаптери"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>У_вімкнути Bluetooth</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "Увімкнути на усіх адаптерах"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
@@ -2279,21 +2640,20 @@ msgstr ""
 "Тимчасово призупиняє зберігач екрану, коли ігровий контролер bluetooth "
 "під’єднаний."
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Мережа"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "Невірна IP адреса"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP адреса конфліктує з інтерфейсом %s, що має таку саму адресу"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2304,8 +2664,8 @@ msgstr ""
 "налаштування: %s/%s\n"
 "Це може призвести до некоректної поведінки мережі"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "Назараз не підтримується"
 
@@ -2321,10 +2681,6 @@ msgstr "Програмний втулок передачі файлів вимк
 msgid "Set Bluetooth Adapter Properties"
 msgstr "Встановити властивості адаптера Bluetooth"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr "blueman-device"
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr "Аплет Blueman"
@@ -2332,11 +2688,6 @@ msgstr "Аплет Blueman"
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman — засіб керування Bluetooth"
-
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr "blueman"
 
 #: data/blueman-manager.desktop.in:3
 msgid "Bluetooth Manager"
@@ -2378,6 +2729,37 @@ msgstr "Встановити стан RfKill"
 msgid "Setting RfKill State requires privileges"
 msgstr "Встановлення стану RfKill потребує відповідних привілеїв"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Уведіть PIN код"
+
+#~ msgid "Enter passkey"
+#~ msgstr "Уведіть пароль"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "Під’єднаний послідовний порт на %s"
+
+#~ msgid "palm"
+#~ msgstr "ПДА (надолонник)"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "навушники"
+
+#~ msgid "handsfree"
+#~ msgstr "гарнітура"
+
+#~ msgid "unknown"
+#~ msgstr "невідомий"
+
+#~ msgid "blueman-device"
+#~ msgstr "blueman-device"
+
+#~ msgid "blueman"
+#~ msgstr "blueman"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Пристрої Bluetooth"
 
@@ -2402,11 +2784,6 @@ msgstr "Встановлення стану RfKill потребує відпов
 
 #~ msgid "_Remove..."
 #~ msgstr "_Вилучити..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Під’єднати"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/vi.po
+++ b/po/vi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/mate/MATE/language/vi/)\n"
@@ -22,7 +22,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr ""
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "Ẩn"
 
@@ -66,8 +66,8 @@ msgstr ""
 msgid "_View"
 msgstr "_Xem"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "Trợ _giúp"
 
@@ -80,7 +80,7 @@ msgstr "Tìm thiết bị xung quanh"
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "Tạo kết nối với thiết bị"
 
@@ -89,17 +89,17 @@ msgstr "Tạo kết nối với thiết bị"
 msgid "Pair"
 msgstr "Kết nối"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr ""
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr ""
 
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Setup..."
 msgstr ""
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "Bỏ thiết bị này khỏi danh sách đã biết"
 
@@ -283,7 +283,12 @@ msgstr ""
 msgid "<b>Author:</b>"
 msgstr ""
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -345,7 +350,7 @@ msgstr "Đặt _lại"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -353,29 +358,29 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr ""
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "Lúc nào cũng làm"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -386,141 +391,133 @@ msgstr ""
 msgid "Searching"
 msgstr ""
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr ""
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "Đang kết nối..."
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr ""
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr ""
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr ""
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "Nhập mã PIN"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "Xác nhận"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "Từ chối"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr ""
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -551,239 +548,237 @@ msgstr "Có"
 msgid "No"
 msgstr "Không"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "Trình quản lý thiết bị"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "Tì_m"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "Xấu"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "Thất bại"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "Đang kết nối..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "Đang ngắt kết nối..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send File"
 msgid "Send a _File…"
 msgstr "Gửi tập tin"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "Sửa tên thiết bị"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "Gỡ bỏ"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "Chọn thiết bị"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -791,7 +786,7 @@ msgstr ""
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  huanctv https://launchpad.net/~huanctv"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -799,17 +794,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr "Thiết lập GSM"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "Bổ sung"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -817,7 +812,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -825,854 +820,1228 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "Đang ngắt kết nối..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+msgid "Access point"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "màn hình nền"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+msgid "Server"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+msgid "Laptop"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+msgid "Smart phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
+msgid "17-33 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
+msgid "50-67 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
+msgid "67-83 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "không rõ"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+msgid "Handsfree"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:88
+msgid "Microphone"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "Nguồn âm thanh"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "Nguồn âm thanh"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "Nguồn âm thanh"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+msgid "Keyboard"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "Đang kết nối..."
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "Kết nối"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 msgid "OBEX File Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr ""
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "Nguồn âm thanh"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr ""
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-msgid "Handsfree"
-msgstr ""
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 msgid "Generic Networking"
 msgstr ""
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr ""
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "Nguồn âm thanh"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "Nguồn âm thanh"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "Sửa tên thiết bị"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr ""
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr ""
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 #, fuzzy
-#| msgid "Search for nearby devices"
 msgid "Secondary Service"
 msgstr "Tìm thiết bị xung quanh"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "Trình quản lý thiết bị"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "Trình quản lý thiết bị"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "có"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "không"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1697,34 +2066,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "Đã kết nối"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1784,140 +2154,135 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "Kết nối thất bại"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "Đang nhận tập tin"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "Đang nhận tập tin %(0)s từ %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "Đã nhận tập tin"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1930,27 +2295,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
@@ -1962,106 +2327,112 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2072,78 +2443,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "Mạng"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2151,8 +2521,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2168,10 +2538,6 @@ msgstr ""
 msgid "Set Bluetooth Adapter Properties"
 msgstr ""
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
 msgstr ""
@@ -2180,20 +2546,13 @@ msgstr ""
 msgid "Blueman Bluetooth Manager"
 msgstr ""
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Manager"
 msgstr "Các thiết bị Bluetooth"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "Các thiết bị Bluetooth"
 
@@ -2229,6 +2588,12 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "Enter PIN code"
+#~ msgstr "Nhập mã PIN"
+
+#~ msgid "unknown"
+#~ msgstr "không rõ"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "Các thiết bị Bluetooth"
 
@@ -2239,8 +2604,3 @@ msgstr ""
 
 #~ msgid "_Remove..."
 #~ msgstr "_Bỏ..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "Kết nối"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-07-21 05:24+0000\n"
 "Last-Translator: Heart & Soul <shenzhe100@126.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>可见设定</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "隐藏"
 
@@ -75,8 +75,8 @@ msgstr "设备(_D)"
 msgid "_View"
 msgstr "视图(_V)"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "帮助 (_H)"
 
@@ -89,7 +89,7 @@ msgstr "搜索附近的设备"
 msgid "Search"
 msgstr "查找"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "与设备进行配对"
 
@@ -98,17 +98,17 @@ msgstr "与设备进行配对"
 msgid "Pair"
 msgstr "配对"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "将这个设备标记/取消标记为信任"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "信任"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "为此设备运行设置助理"
 
@@ -117,7 +117,7 @@ msgstr "为此设备运行设置助理"
 msgid "Setup..."
 msgstr "设置..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "将这个设备从已知设备列表中删去"
 
@@ -296,7 +296,12 @@ msgstr "未指定"
 msgid "<b>Author:</b>"
 msgstr "<b>作者:</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -358,7 +363,7 @@ msgstr "复位(_R)"
 msgid "Send note"
 msgstr "发送便笺"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "蓝牙需要开启以便适配器管理器工作"
 
@@ -366,31 +371,29 @@ msgstr "蓝牙需要开启以便适配器管理器工作"
 msgid "Bluetooth Adapters"
 msgstr "蓝牙适配器"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "总是"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d 分钟"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "适配器"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "设备管理器需要开启蓝牙才能工作"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "连接至 BlueZ 失败"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -403,141 +406,133 @@ msgstr ""
 msgid "Searching"
 msgstr "正在搜索"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "蓝牙助手"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "适配器首选项"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "文件发送方"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "蓝牙文件传输"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "正在连接"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd 不可用"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr "无法自动启动obex服务。确保obex守护程序正在运行"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "取消中"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "发送文件"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "ETA:"
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "发送文件 %s 时发生错误"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "跳过"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "重试"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "发生错误"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "本地服务"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "%s 配对请求"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "蓝牙认证"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "输入授权 PIN 码"
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "输入 PIN 码"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "输入认证通行码："
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "输入密码"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "密码配对"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "PIN 码配对"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "配对请求:"
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "确认认证值："
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "确认"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "拒绝"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "授权请求:"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "服务："
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "总是同意"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "接收"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -570,243 +565,240 @@ msgstr "是"
 msgid "No"
 msgstr "否"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "报告问题:(_R)"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "设备管理器"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "显示工具栏(_T)"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "显示状态栏(_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "排序(_O)"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "名称(_N)"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "添加(_A)"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "降序(_D)"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "插件(_P)"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "本地服务(_L)"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "服务首选项"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "搜索(_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "适配器首选项"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "退出"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "未分类"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>已信任且配对</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>已配对</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>信任设备</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "差"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "较佳"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "最佳"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "很多"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "太多"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "低"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "高"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "非常高"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "成功！"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "串口连接至 %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "失败"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "连接失败： "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "正在连接"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "断开连接失败："
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "正在断开连接..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr "<b>连接中</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "连接到如下自动连接档案：A2DP 源，A2DP 池及 HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr "<b>断开连接</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "强制断开"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>连接到：</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>断开连接</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "发送文件:(_F)..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "配对:(_P)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "信任:(_T)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "取消信任(_U)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr "配对"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "重命名设备"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "移除"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "取消操作"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "数据活动表明"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "接收到的数据总量和传输速率"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "发出的数据总量和传输速率"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "不信任"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "选择设备"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "更多"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -835,7 +827,7 @@ msgstr ""
 "  丁鑫_XJTU https://launchpad.net/~xgnid\n"
 "  王英华 https://launchpad.net/~wantinghard"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman 是基于 GTK+ 的蓝牙管理器"
 
@@ -843,17 +835,17 @@ msgstr "Blueman 是基于 GTK+ 的蓝牙管理器"
 msgid "GSM Settings"
 msgstr "GSM 设置"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "插件"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "依赖问题"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -864,7 +856,7 @@ msgstr ""
 "\"%(0)s\"</b>。\n"
 "继续吗?"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -875,886 +867,1259 @@ msgstr ""
 "%(0)s</b>。\n"
 "确定吗?"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "选择适配器"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "设备当前可见…… %s 秒"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "未分类"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "网络接入点"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "桌面"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "服务器"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "笔记本"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "手持设备"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "手机"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "无线设备"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "智能手机"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "调制解调器"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "isdn"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd 不可用"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "耳迈"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "免提设备"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "未知的"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "话筒"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "音频源"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "音频源"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "音频源"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "键盘"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "指向设备"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "键盘"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "指向设备"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "连接"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "连接"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "连接"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "连接"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "蓝牙文件传输"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "连接"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "蓝牙文件传输"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "蓝牙文件传输"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "网络群"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "蓝牙文件传输"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "连接"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "连接"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "蓝牙文件传输"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "连接"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "网络群"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "串口"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "拨号网络 (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "蓝牙文件传输"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "耳迈"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "音频源"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "音频槽"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "网络接入点"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "网络群"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "免提设备"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "网络连接点 (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "网络连接点 (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "网络群"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "蓝牙文件传输"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "音频源"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "音频槽"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "音频源"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "重命名设备"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "显示设备信息"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "本地服务"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "传输"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "applet"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "配对设备"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "搜索附近的设备"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "传输"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "applet"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "配对设备"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "搜索附近的设备"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "设备管理器"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "最近连接:(_C)"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "设备管理器"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "适配器首选项"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "自动连接配置档案"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "专有"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "是"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "否"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "信息(_I)"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "显示设备信息"
 
@@ -1779,34 +2144,35 @@ msgstr "音频配置"
 msgid "Select audio profile for PulseAudio"
 msgstr "选择 PulseAudio 的音频配置"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "串口 %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "更新 IP 地址"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "拨号设置"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "串口"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "未指定"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "已连接"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "自动将%(device)s连接至%(service)s"
@@ -1868,104 +2234,99 @@ msgstr "网络使用情况(_U)"
 msgid "Shows network traffic usage"
 msgstr "显示网络流量使用率"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "蓝牙已启用"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "蓝牙已停用"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "管理本地网络服务，如 NAP 桥"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr "使用调制解调器管理器和网络管理器为拨号网络(DUN)提供支持"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "提供一个包含了以前使用的连接的菜单项以便快速访问"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "最大项目数"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "最近连接菜单显示的最大数目"
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "最近连接:(_C)"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "已连接到 %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "连接失败"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "%(device)s 上的 %(service)s"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "这个连接的适配器不可用"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr "在网络管理器 0.8 中提供对个人局域网(PAN)的支持"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "为其他 Blueman 组件提供了 DBus API"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "通过蓝牙传输的文件"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "从 %(1)s 传入文件 %(0)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "拒绝"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "正在接收的文件"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "正在从 %(1)s 接收文件 %(0)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "提供 OBEX 文件传输的能力"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "指定的文件收取目录不存在"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1974,41 +2335,37 @@ msgstr ""
 "请确保目录\"<b>%s</b>\" 存在或使用blueman-services配置它。在此之前，将使用默"
 "认配置的\"%s\" "
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "文件已接收"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "来自 %(1)s 的文件 %(0)s 已顺利接收"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "传送失败"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "传送文件 %(0)s 失败"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "文件已接收"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "已在后台接收文件 %d"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "在后台又接收了 %d 个文件"
@@ -2020,27 +2377,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "向状态图标菜单添加标准菜单项"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "设置新设备(_S)"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "向设备发送文件:(_F)"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "设备(_D)"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "适配器(_T)"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "applet"
 
@@ -2052,27 +2409,27 @@ msgstr "向BlueZ 守护进程提供密钥、认证服务"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "添加一个退出小程序的 退出 菜单项"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "为蓝牙 PAN 连接提供一个基本的 dhcp 客户端。"
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "蓝牙网络"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "接口 %(0)s 绑定到 IP 地址 %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "在 %s 上获取 IP 地址失败"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2081,61 +2438,65 @@ msgstr ""
 "正在尝试在 %s 在获取 IP 地址\n"
 "请稍候……"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr "在状态图标上添加一个蓝牙活动的指示器，并在弹出提示中显示连接数目。"
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "蓝牙开启"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d 个活跃的连接</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "蓝牙已停用"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "使用 libappindicator 显示一个状态图标"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr "提供一个菜单项，让默认被隐藏的首选适配器临时可见"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "搜寻超时"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "搜寻模式的超时时间（以秒为单位）"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "不可发现(_M)"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "使首选适配器临时可见"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "设备当前可见…… %s 秒"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "提供一个目录以操作为其他插件提供的的 applet 和 API"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2144,20 +2505,20 @@ msgstr ""
 "成功连接到 <b>%(0)s.</b>的<b>DUN</b> 服务 \n"
 "现在可以通过 <b>%(1)s</b>连网"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "为通过 DUN 配置文件连接到 Internet 提供基本支持。"
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr "标准的 SPP 配置连接处理器，允许执行自定义动作"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "连接时执行的脚本"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2175,21 +2536,21 @@ msgstr ""
 "\n"
 "设备断开时将向脚本发送一个 HUP 信号</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "串口已连接"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr "<b>%s</b>设备上的串口服务现在可以通过<b>%s</b>使用"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "串口连接脚本失败"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2198,57 +2559,56 @@ msgstr ""
 "启动脚本 %s 出现了问题\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "控制蓝牙适配器的电源状态"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "自动开启电源"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "自动开启适配器电源"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>关闭蓝牙(_O)</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "关闭所有适配器"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>开启蓝牙(_O)</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "启用全部适配器"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr "连接蓝牙游戏控制器时，暂时挂起屏幕保护程序。"
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "网络"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "无效 IP 地址"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "IP 地址与接口 %s 冲突，它也是这个地址"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2258,8 +2618,8 @@ msgstr ""
 "IP地址与接口 %s的子网重叠，具有以下配置 %s/%s\n"
 "这可能会导致错误的网络行为"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "当前在该设置中不被支持"
 
@@ -2273,40 +2633,26 @@ msgstr "小程序的传输服务插件被禁用"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "蓝牙适配器"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "applet"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman 是基于 GTK+ 的蓝牙管理器"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "蓝牙已启用"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "蓝牙设备"
 
@@ -2342,6 +2688,31 @@ msgstr "设置 RfKill 状态"
 msgid "Setting RfKill State requires privileges"
 msgstr "设置 RfKill 状态需要权限"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "输入 PIN 码"
+
+#~ msgid "Enter passkey"
+#~ msgstr "输入密码"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "串口连接至 %s"
+
+#~ msgid "palm"
+#~ msgstr "palm"
+
+#~ msgid "isdn"
+#~ msgstr "isdn"
+
+#~ msgid "headset"
+#~ msgstr "耳迈"
+
+#~ msgid "handsfree"
+#~ msgstr "免提设备"
+
+#~ msgid "unknown"
+#~ msgstr "未知的"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "蓝牙设备"
 
@@ -2360,11 +2731,6 @@ msgstr "设置 RfKill 状态需要权限"
 
 #~ msgid "_Remove..."
 #~ msgstr "移除:(_R)..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "连接"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Chinese (Hong Kong) (http://www.transifex.com/mate/MATE/"
@@ -24,7 +24,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>可見性設置</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "隱藏"
 
@@ -68,8 +68,8 @@ msgstr ""
 msgid "_View"
 msgstr "檢視(_V)"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "求助(_H)"
 
@@ -82,7 +82,7 @@ msgstr "搜尋附近的裝置"
 msgid "Search"
 msgstr "搜尋"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "與此裝置建立配對"
 
@@ -91,17 +91,17 @@ msgstr "與此裝置建立配對"
 msgid "Pair"
 msgstr "配對"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "標記/取消標記這裝置為信任裝置"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "信任"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "對此裝置運行設定助手"
 
@@ -110,7 +110,7 @@ msgstr "對此裝置運行設定助手"
 msgid "Setup..."
 msgstr "設定"
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "從已知裝置列表中移除該裝置"
 
@@ -285,7 +285,12 @@ msgstr ""
 msgid "<b>Author:</b>"
 msgstr ""
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -347,7 +352,7 @@ msgstr "重設(_R)"
 msgid "Send note"
 msgstr ""
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr ""
 
@@ -355,29 +360,29 @@ msgstr ""
 msgid "Bluetooth Adapters"
 msgstr "藍牙適配器"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "經常"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, python-format
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] ""
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr ""
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr ""
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr ""
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -388,141 +393,133 @@ msgstr ""
 msgid "Searching"
 msgstr ""
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr ""
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr ""
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr ""
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr ""
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr ""
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr ""
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr ""
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr ""
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr ""
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr ""
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr ""
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr ""
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr ""
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -553,244 +550,243 @@ msgstr "是"
 msgid "No"
 msgstr "否"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "搜尋(_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 msgid "_Preferences"
 msgstr ""
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 msgid "_Exit"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+msgid "Uncategorized"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "差"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "低"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "高"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr ""
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "失敗"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting..."
 msgid "Connecting…"
 msgstr "連線中"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "正在中斷..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send File"
 msgid "Send a _File…"
 msgstr "傳送文件"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "移除"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr ""
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr ""
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Valmantas Palikša https://launchpad.net/~walmis\n"
 "  yanq.wang https://launchpad.net/~nile-wangyq"
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 
@@ -798,17 +794,17 @@ msgstr ""
 msgid "GSM Settings"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "外掛程式"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -816,7 +812,7 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -824,850 +820,1224 @@ msgid ""
 "Proceed?"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr ""
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Discovering…"
 msgstr "正在中斷..."
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+msgid "Access point"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "桌面"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+msgid "Server"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+msgid "Laptop"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+msgid "Handheld"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:48
+msgid "Cellular"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:50
+msgid "Cordless"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
+msgstr "智能電話"
+
+#. translators: device class
+#: blueman/DeviceClass.py:54
+msgid "Modem"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:65
-msgid "cellular"
+msgid "17-33 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:67
-msgid "cordless"
+msgid "33-50 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:69
-msgid "smart phone"
-msgstr "智能電話"
+msgid "50-67 percent"
+msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:71
-msgid "modem"
+msgid "67-83 percent"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:73
-msgid "isdn"
+msgid "83-99 percent"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:75
+msgid "Not available"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+msgid "Headset"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "免提裝置"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "不明"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "咪高峰"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+msgid "Video camera"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+msgid "Video monitor"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+msgid "Video conferencing"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+msgid "Keyboard"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
+msgid "Pointing"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:174
+msgid "Generic Display"
+msgstr ""
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:176
+msgid "Generic Eye-glasses"
+msgstr ""
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "羣組網絡"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "羣組網絡"
+
+#: blueman/DeviceClass.py:179
+msgid "Generic Media Player"
+msgstr ""
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+msgid "Generic Heart rate Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "羣組網絡"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 msgid "Serial Port"
 msgstr ""
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr ""
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 msgid "OBEX File Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-msgid "Headset"
-msgstr ""
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr ""
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr ""
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr ""
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "羣組網絡"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "免提裝置"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 msgid "Phonebook Access (PBAP)"
 msgstr ""
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 msgid "Message Access Profile (MAP)"
 msgstr ""
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "羣組網絡"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 msgid "Generic FileTransfer"
 msgstr ""
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 msgid "Video Source"
 msgstr ""
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 msgid "Video Sink"
 msgstr ""
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 msgid "HDP Source"
 msgstr ""
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 msgid "Current Time Service"
 msgstr ""
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 msgid "Device Information"
 msgstr ""
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 msgid "Battery Service"
 msgstr ""
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
 msgstr ""
 
-#: blueman/Sdp.py:228
+#: blueman/Sdp.py:222
 msgid "Object Transfer"
 msgstr ""
 
-#: blueman/Sdp.py:229
+#: blueman/Sdp.py:223
 msgid "AppleAgent"
 msgstr ""
 
-#: blueman/Sdp.py:230
+#: blueman/Sdp.py:224
 msgid "Primary Service"
 msgstr ""
 
-#: blueman/Sdp.py:231
+#: blueman/Sdp.py:225
 #, fuzzy
-#| msgid "Search for nearby devices"
 msgid "Secondary Service"
 msgstr "搜尋附近的裝置"
 
-#: blueman/Sdp.py:232
+#: blueman/Sdp.py:226
 msgid "Include"
 msgstr ""
 
-#: blueman/Sdp.py:233
+#: blueman/Sdp.py:227
 msgid "Characteristic Declaration"
 msgstr ""
 
-#: blueman/Sdp.py:234
+#: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Device"
 msgid "Device Name"
 msgstr "裝置"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 msgid "Reconnection Address"
 msgstr ""
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 msgid "Service Changed"
 msgstr ""
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 msgid "Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr ""
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "yes"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "no"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr ""
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr ""
 
@@ -1692,34 +2062,35 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr ""
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "已連線"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""
@@ -1779,140 +2150,135 @@ msgstr ""
 msgid "Shows network traffic usage"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr ""
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr ""
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr ""
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr ""
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr ""
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr ""
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr ""
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
 "blueman-services. Until then the default \"%s\" will be used"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr ""
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, python-format
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] ""
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, python-format
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
@@ -1925,27 +2291,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr ""
 
@@ -1957,106 +2323,112 @@ msgstr ""
 msgid "Adds an exit menu item to quit the applet"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr ""
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
 "Please wait…"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr ""
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, python-format
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] ""
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr ""
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr ""
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr ""
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
 "Network is now available through <b>%(1)s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2067,78 +2439,77 @@ msgid ""
 "Upon device disconnection the script will be sent a HUP signal</span>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr ""
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
 "%s"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr ""
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr ""
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "網絡"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2146,8 +2517,8 @@ msgid ""
 "This may cause incorrect network behavior"
 msgstr ""
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr ""
 
@@ -2161,13 +2532,8 @@ msgstr ""
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "藍牙適配器"
-
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
 
 #: data/blueman.desktop.in:3
 msgid "Blueman Applet"
@@ -2175,24 +2541,16 @@ msgstr ""
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Blueman Bluetooth Manager"
 msgstr "藍牙適配器"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Bluetooth Manager"
 msgstr "藍牙適配器"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "藍牙裝置"
 
@@ -2228,13 +2586,14 @@ msgstr ""
 msgid "Setting RfKill State requires privileges"
 msgstr ""
 
+#~ msgid "handsfree"
+#~ msgstr "免提裝置"
+
+#~ msgid "unknown"
+#~ msgstr "不明"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "藍牙裝置"
 
 #~ msgid "_Remove..."
 #~ msgstr "移除(_R)..."
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "連線"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-08-01 08:55+0000\n"
+"POT-Creation-Date: 2020-09-26 22:56+0200\n"
 "PO-Revision-Date: 2020-04-14 10:14+0000\n"
 "Last-Translator: Christopher Schramm <transifex@cschramm.eu>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/mate/MATE/language/"
@@ -27,7 +27,7 @@ msgstr ""
 msgid "<b>Visibility Setting</b>"
 msgstr "<b>可見設定</b>"
 
-#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:144
+#: data/ui/adapters-tab.ui:39 blueman/main/Adapter.py:145
 msgid "Hidden"
 msgstr "隱藏"
 
@@ -71,8 +71,8 @@ msgstr "裝置 (_D)"
 msgid "_View"
 msgstr "檢視 (_V)"
 
-#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:50
-#: blueman/plugins/applet/StandardItems.py:46
+#: data/ui/manager-main.ui:77 blueman/gui/manager/ManagerMenu.py:55
+#: blueman/plugins/applet/StandardItems.py:51
 msgid "_Help"
 msgstr "說明(_H)"
 
@@ -85,7 +85,7 @@ msgstr "搜附近的裝置"
 msgid "Search"
 msgstr "搜尋"
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:327
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:334
 msgid "Create pairing with the device"
 msgstr "與裝置配對"
 
@@ -94,17 +94,17 @@ msgstr "與裝置配對"
 msgid "Pair"
 msgstr "配對"
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:345
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Mark/Unmark this device as trusted"
 msgstr "標示此裝置為信任/不信任的"
 
 #. translators: toolbar item: keep it as short as possible
-#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:29
-#: blueman/gui/manager/ManagerToolbar.py:94
+#: data/ui/manager-main.ui:136 blueman/gui/manager/ManagerToolbar.py:39
+#: blueman/gui/manager/ManagerToolbar.py:105
 msgid "Trust"
 msgstr "信任的"
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:351
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:358
 msgid "Run the setup assistant for this device"
 msgstr "執行此裝置的設置精靈"
 
@@ -113,7 +113,7 @@ msgstr "執行此裝置的設置精靈"
 msgid "Setup..."
 msgstr "設置..."
 
-#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:385
+#: data/ui/manager-main.ui:164 blueman/gui/manager/ManagerDeviceMenu.py:392
 msgid "Remove this device from the known devices list"
 msgstr "將此裝置自名單中移除"
 
@@ -292,7 +292,12 @@ msgstr "沒有指定"
 msgid "<b>Author:</b>"
 msgstr "<b>作者：</b>"
 
-#: data/ui/applet-plugins-widget.ui:161 blueman/Sdp.py:381
+#. translators: device class
+#: data/ui/applet-plugins-widget.ui:161
+#: blueman/gui/manager/ManagerDeviceList.py:278
+#: blueman/gui/manager/ManagerDeviceList.py:280 blueman/DeviceClass.py:86
+#: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
+#: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:375
 #: blueman/plugins/applet/NetUsage.py:211
 #: blueman/plugins/applet/NetUsage.py:212
 msgid "Unknown"
@@ -354,7 +359,7 @@ msgstr "重設(_R)"
 msgid "Send note"
 msgstr "傳送便條"
 
-#: blueman/main/Adapter.py:49
+#: blueman/main/Adapter.py:50
 msgid "Bluetooth needs to be turned on for the adapter manager to work"
 msgstr "藍牙必須開啟才可以使用"
 
@@ -362,31 +367,29 @@ msgstr "藍牙必須開啟才可以使用"
 msgid "Bluetooth Adapters"
 msgstr "藍牙配接器"
 
-#: blueman/main/Adapter.py:142
+#: blueman/main/Adapter.py:143
 msgid "Always"
 msgstr "一直"
 
-#: blueman/main/Adapter.py:146 blueman/main/Sendto.py:191
+#: blueman/main/Adapter.py:147 blueman/main/Sendto.py:193
 #, fuzzy, python-format
-#| msgid "%d Minute"
-#| msgid_plural "%d Minutes"
 msgid "%(minutes)d Minute"
 msgid_plural "%(minutes)d Minutes"
 msgstr[0] "%d 分鐘"
 
-#: blueman/main/Adapter.py:212
+#: blueman/main/Adapter.py:214
 msgid "Adapter"
 msgstr "轉接器"
 
-#: blueman/main/Manager.py:87 blueman/main/Manager.py:127
+#: blueman/main/Manager.py:90 blueman/main/Manager.py:130
 msgid "Bluetooth needs to be turned on for the device manager to function"
 msgstr "需要開啟藍牙才可以使用此管理功能"
 
-#: blueman/main/Manager.py:106
+#: blueman/main/Manager.py:109
 msgid "Connection to BlueZ failed"
 msgstr "未能連線到 BlueZ"
 
-#: blueman/main/Manager.py:107
+#: blueman/main/Manager.py:110
 msgid ""
 "Bluez daemon is not running, blueman-manager cannot continue.\n"
 "This probably means that there were no Bluetooth adapters detected or "
@@ -399,141 +402,133 @@ msgstr ""
 msgid "Searching"
 msgstr "搜尋中"
 
-#: blueman/main/Manager.py:212 blueman/plugins/applet/StandardItems.py:71
+#: blueman/main/Manager.py:213 blueman/plugins/applet/StandardItems.py:76
 msgid "Bluetooth Assistant"
 msgstr "藍牙設定精靈"
 
-#: blueman/main/Manager.py:225 blueman/plugins/applet/StandardItems.py:81
+#: blueman/main/Manager.py:226 blueman/plugins/applet/StandardItems.py:86
 msgid "Adapter Preferences"
 msgstr "配接器偏好設定"
 
-#: blueman/main/Manager.py:237 blueman/gui/manager/ManagerDeviceList.py:134
-#: blueman/plugins/applet/StandardItems.py:74
+#: blueman/main/Manager.py:238 blueman/gui/manager/ManagerDeviceList.py:134
+#: blueman/plugins/applet/StandardItems.py:79
 msgid "File Sender"
 msgstr "檔案傳送器"
 
-#: blueman/main/Sendto.py:38
+#: blueman/main/Sendto.py:40
 msgid "Bluetooth File Transfer"
 msgstr "藍牙檔案傳送"
 
-#: blueman/main/Sendto.py:63 blueman/gui/manager/ManagerProgressbar.py:24
+#: blueman/main/Sendto.py:65 blueman/gui/manager/ManagerProgressbar.py:27
 msgid "Connecting"
 msgstr "連線"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "obexd not available"
 msgstr "obexd 無法使用"
 
-#: blueman/main/Sendto.py:115
+#: blueman/main/Sendto.py:117
 msgid "Failed to autostart obex service. Make sure the obex daemon is running"
 msgstr "自動啟動 obex 服務失敗。請確定 obex 守護程式正在執行"
 
-#: blueman/main/Sendto.py:144
+#: blueman/main/Sendto.py:146
 msgid "Cancelling"
 msgstr "取消中..."
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "Sending File"
 msgstr "傳送檔案"
 
-#: blueman/main/Sendto.py:155 blueman/main/Sendto.py:197
+#: blueman/main/Sendto.py:157 blueman/main/Sendto.py:199
 msgid "ETA:"
 msgstr "預計所需時間："
 
-#: blueman/main/Sendto.py:193
+#: blueman/main/Sendto.py:195
 #, python-format
 msgid "%(seconds)d Second"
 msgid_plural "%(seconds)d Seconds"
 msgstr[0] ""
 
-#: blueman/main/Sendto.py:227
+#: blueman/main/Sendto.py:229
 #, python-format
 msgid "Error occurred while sending file %s"
 msgstr "傳送 %s 檔案時發生錯誤"
 
-#: blueman/main/Sendto.py:231
+#: blueman/main/Sendto.py:233
 msgid "Skip"
 msgstr "跳過"
 
-#: blueman/main/Sendto.py:232
+#: blueman/main/Sendto.py:234
 msgid "Retry"
 msgstr "重試"
 
-#: blueman/main/Sendto.py:281
+#: blueman/main/Sendto.py:283
 msgid "Error occurred"
 msgstr "發生錯誤"
 
-#: blueman/main/Services.py:25
+#: blueman/main/Services.py:24
 msgid "Local Services"
 msgstr "本機服務"
 
-#: blueman/main/applet/BluezAgent.py:177
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr "配對需要 %s"
 
-#: blueman/main/applet/BluezAgent.py:189 blueman/main/applet/BluezAgent.py:296
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:314
 msgid "Bluetooth Authentication"
 msgstr "藍牙身分核對"
 
-#: blueman/main/applet/BluezAgent.py:217
+#: blueman/main/applet/BluezAgent.py:232
 msgid "Enter PIN code for authentication:"
 msgstr "輸入 PIN 碼核對身分："
 
-#: blueman/main/applet/BluezAgent.py:218
-msgid "Enter PIN code"
-msgstr "輸入 PIN 碼"
-
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:247
 msgid "Enter passkey for authentication:"
 msgstr "輸入密鑰核對身分："
 
-#: blueman/main/applet/BluezAgent.py:232
-msgid "Enter passkey"
-msgstr "輸入密鑰"
-
-#: blueman/main/applet/BluezAgent.py:242
+#: blueman/main/applet/BluezAgent.py:257
 msgid "Pairing passkey for"
 msgstr "配對密鑰"
 
-#: blueman/main/applet/BluezAgent.py:251
+#: blueman/main/applet/BluezAgent.py:266
 msgid "Pairing PIN code for"
 msgstr "配對的 PIN 代碼"
 
-#: blueman/main/applet/BluezAgent.py:263
+#: blueman/main/applet/BluezAgent.py:279
 msgid "Pairing request for:"
 msgstr "配對需要："
 
-#: blueman/main/applet/BluezAgent.py:266
+#: blueman/main/applet/BluezAgent.py:282
 msgid "Confirm value for authentication:"
 msgstr "確認數值核對身分："
 
-#: blueman/main/applet/BluezAgent.py:267
+#: blueman/main/applet/BluezAgent.py:283
 msgid "Confirm"
 msgstr "確認"
 
-#: blueman/main/applet/BluezAgent.py:267 blueman/main/applet/BluezAgent.py:294
+#: blueman/main/applet/BluezAgent.py:283 blueman/main/applet/BluezAgent.py:312
 msgid "Deny"
 msgstr "取消"
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Authorization request for:"
 msgstr "授權需要："
 
-#: blueman/main/applet/BluezAgent.py:291
+#: blueman/main/applet/BluezAgent.py:309
 msgid "Service:"
 msgstr "服務："
 
-#: blueman/main/applet/BluezAgent.py:292
+#: blueman/main/applet/BluezAgent.py:310
 msgid "Always accept"
 msgstr "一定接受"
 
-#: blueman/main/applet/BluezAgent.py:293
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/main/applet/BluezAgent.py:311
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr "接受"
 
-#: blueman/main/PluginManager.py:68
+#: blueman/main/PluginManager.py:67
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -566,243 +561,240 @@ msgstr "是"
 msgid "No"
 msgstr "否"
 
-#: blueman/gui/manager/ManagerMenu.py:40
+#: blueman/gui/manager/ManagerMenu.py:45
 msgid "_Report a Problem"
 msgstr "回報問題(_R)"
 
-#: blueman/gui/manager/ManagerMenu.py:53
+#: blueman/gui/manager/ManagerMenu.py:59
 msgid "Device Manager"
 msgstr "裝置管理"
 
-#: blueman/gui/manager/ManagerMenu.py:60
+#: blueman/gui/manager/ManagerMenu.py:66
 msgid "Show _Toolbar"
 msgstr "顯示工具列(_T)"
 
-#: blueman/gui/manager/ManagerMenu.py:65
+#: blueman/gui/manager/ManagerMenu.py:71
 msgid "Show _Statusbar"
 msgstr "顯示狀態列(_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:75
+#: blueman/gui/manager/ManagerMenu.py:81
 msgid "S_ort By"
 msgstr "排序由(_O)"
 
-#: blueman/gui/manager/ManagerMenu.py:82
+#: blueman/gui/manager/ManagerMenu.py:88
 msgid "_Name"
 msgstr "名稱(_N)"
 
-#: blueman/gui/manager/ManagerMenu.py:87
+#: blueman/gui/manager/ManagerMenu.py:93
 msgid "_Added"
 msgstr "已加入(_A)"
 
-#: blueman/gui/manager/ManagerMenu.py:101
+#: blueman/gui/manager/ManagerMenu.py:107
 msgid "_Descending"
 msgstr "遞增(_D)"
 
-#: blueman/gui/manager/ManagerMenu.py:114
-#: blueman/plugins/applet/StandardItems.py:48
+#: blueman/gui/manager/ManagerMenu.py:120
+#: blueman/plugins/applet/StandardItems.py:53
 msgid "_Plugins"
 msgstr "外掛 (_P)"
 
-#: blueman/gui/manager/ManagerMenu.py:119
-#: blueman/plugins/applet/StandardItems.py:41
+#: blueman/gui/manager/ManagerMenu.py:125
+#: blueman/plugins/applet/StandardItems.py:46
 msgid "_Local Services"
 msgstr "本機服務 (_L)"
 
-#: blueman/gui/manager/ManagerMenu.py:120
-#: blueman/plugins/applet/StandardItems.py:84
+#: blueman/gui/manager/ManagerMenu.py:126
+#: blueman/plugins/applet/StandardItems.py:89
 msgid "Service Preferences"
 msgstr "服務偏好設定"
 
-#: blueman/gui/manager/ManagerMenu.py:128
+#: blueman/gui/manager/ManagerMenu.py:134
 msgid "_Search"
 msgstr "搜尋 (_S)"
 
-#: blueman/gui/manager/ManagerMenu.py:142
+#: blueman/gui/manager/ManagerMenu.py:148
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "_Preferences"
 msgstr "配接器偏好設定"
 
-#: blueman/gui/manager/ManagerMenu.py:151 blueman/plugins/applet/ExitItem.py:12
+#: blueman/gui/manager/ManagerMenu.py:157 blueman/plugins/applet/ExitItem.py:12
 #, fuzzy
-#| msgid "Exit"
 msgid "_Exit"
 msgstr "結束"
 
-#: blueman/gui/manager/ManagerDeviceList.py:437
+#. translators: device class
+#: blueman/gui/manager/ManagerDeviceList.py:249
+#: blueman/gui/manager/ManagerDeviceList.py:278 blueman/DeviceClass.py:24
+#: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
+#: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
+#, fuzzy
+msgid "Uncategorized"
+msgstr "未分類"
+
+#: blueman/gui/manager/ManagerDeviceList.py:438
 msgid "<b>Trusted and Paired</b>"
 msgstr "<b>已信任並已配對</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:439
+#: blueman/gui/manager/ManagerDeviceList.py:440
 msgid "<b>Paired</b>"
 msgstr "<b>已配對</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:441
+#: blueman/gui/manager/ManagerDeviceList.py:442
 msgid "<b>Trusted</b>"
 msgstr "<b>已信任</b>"
 
-#: blueman/gui/manager/ManagerDeviceList.py:461
+#: blueman/gui/manager/ManagerDeviceList.py:462
 msgid "Poor"
 msgstr "差"
 
-#: blueman/gui/manager/ManagerDeviceList.py:463
-#: blueman/gui/manager/ManagerDeviceList.py:474
+#: blueman/gui/manager/ManagerDeviceList.py:464
+#: blueman/gui/manager/ManagerDeviceList.py:475
 msgid "Sub-optimal"
 msgstr "尚可"
 
-#: blueman/gui/manager/ManagerDeviceList.py:465
-#: blueman/gui/manager/ManagerDeviceList.py:476
+#: blueman/gui/manager/ManagerDeviceList.py:466
+#: blueman/gui/manager/ManagerDeviceList.py:477
 msgid "Optimal"
 msgstr "優"
 
-#: blueman/gui/manager/ManagerDeviceList.py:467
+#: blueman/gui/manager/ManagerDeviceList.py:468
 msgid "Much"
 msgstr "佳"
 
-#: blueman/gui/manager/ManagerDeviceList.py:469
+#: blueman/gui/manager/ManagerDeviceList.py:470
 msgid "Too much"
 msgstr "更佳"
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:473
 msgid "Low"
 msgstr "低"
 
-#: blueman/gui/manager/ManagerDeviceList.py:478
+#: blueman/gui/manager/ManagerDeviceList.py:479
 msgid "High"
 msgstr "高"
 
-#: blueman/gui/manager/ManagerDeviceList.py:480
+#: blueman/gui/manager/ManagerDeviceList.py:481
 msgid "Very High"
 msgstr "極高"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:106
-#: blueman/gui/manager/ManagerDeviceMenu.py:171
+#: blueman/gui/manager/ManagerDeviceMenu.py:118
+#: blueman/gui/manager/ManagerDeviceMenu.py:181
 msgid "Success!"
 msgstr "成功！"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:109
-#, python-format
-msgid "Serial port connected to %s"
-msgstr "串列埠連線到 %s"
-
-#: blueman/gui/manager/ManagerDeviceMenu.py:116
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:125
+#: blueman/gui/manager/ManagerDeviceMenu.py:174
 msgid "Failed"
 msgstr "錯誤"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:121
-#: blueman/gui/manager/ManagerDeviceMenu.py:167
+#: blueman/gui/manager/ManagerDeviceMenu.py:130
+#: blueman/gui/manager/ManagerDeviceMenu.py:177
 msgid "Connection Failed: "
 msgstr "連線錯誤： "
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:123
-#: blueman/gui/manager/ManagerDeviceMenu.py:178
+#: blueman/gui/manager/ManagerDeviceMenu.py:132
+#: blueman/gui/manager/ManagerDeviceMenu.py:188
 #, fuzzy
-#| msgid "Connecting"
 msgid "Connecting…"
 msgstr "連線"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:144
+#: blueman/gui/manager/ManagerDeviceMenu.py:153
 msgid "Disconnection Failed: "
 msgstr "斷線失敗："
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:195
 #, fuzzy
-#| msgid "Disconnecting..."
 msgid "Disconnecting…"
 msgstr "斷線中..."
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:243
+#: blueman/gui/manager/ManagerDeviceMenu.py:253
 msgid "_<b>Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:245
+#: blueman/gui/manager/ManagerDeviceMenu.py:255
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr "連線到自動連接設定檔 A2DP 來源、A2DP 接收器與 HID"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:249
+#: blueman/gui/manager/ManagerDeviceMenu.py:259
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:250
+#: blueman/gui/manager/ManagerDeviceMenu.py:260
 msgid "Forcefully disconnect the device"
 msgstr "強制中斷連線"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:281
+#: blueman/gui/manager/ManagerDeviceMenu.py:288
 msgid "<b>Connect To:</b>"
 msgstr "<b>連線到：</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:293
+#: blueman/gui/manager/ManagerDeviceMenu.py:300
 msgid "<b>Disconnect:</b>"
 msgstr "<b>斷線：</b>"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:313
+#: blueman/gui/manager/ManagerDeviceMenu.py:320
 #, fuzzy
-#| msgid "Send a _File..."
 msgid "Send a _File…"
 msgstr "傳送檔案...(_F)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:326
+#: blueman/gui/manager/ManagerDeviceMenu.py:333
 msgid "_Pair"
 msgstr "配對(_P)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:343
 msgid "_Trust"
 msgstr "信任(_T)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:348
 msgid "_Untrust"
 msgstr "不信任(_U)"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:347
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Set up…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:372
+#: blueman/gui/manager/ManagerDeviceMenu.py:379
 #, fuzzy
-#| msgid "Rename device"
 msgid "R_ename device…"
 msgstr "重新命名裝置"
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:381
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 #, fuzzy
-#| msgid "Remove"
 msgid "_Remove…"
 msgstr "移除"
 
-#: blueman/gui/manager/ManagerProgressbar.py:41
+#: blueman/gui/manager/ManagerProgressbar.py:44
 msgid "Cancel Operation"
 msgstr "取消作業"
 
-#: blueman/gui/manager/ManagerStats.py:29
-#: blueman/gui/manager/ManagerStats.py:32
+#: blueman/gui/manager/ManagerStats.py:38
+#: blueman/gui/manager/ManagerStats.py:41
 msgid "Data activity indication"
 msgstr "當前的資料傳送/接收狀況"
 
-#: blueman/gui/manager/ManagerStats.py:34
-#: blueman/gui/manager/ManagerStats.py:44
+#: blueman/gui/manager/ManagerStats.py:43
+#: blueman/gui/manager/ManagerStats.py:53
 msgid "Total data received and rate of transmission"
 msgstr "總資料接收及接收率"
 
-#: blueman/gui/manager/ManagerStats.py:38
-#: blueman/gui/manager/ManagerStats.py:42
+#: blueman/gui/manager/ManagerStats.py:47
+#: blueman/gui/manager/ManagerStats.py:51
 msgid "Total data sent and rate of transmission"
 msgstr "總資料傳送及傳送率"
 
-#: blueman/gui/manager/ManagerToolbar.py:27
-#: blueman/gui/manager/ManagerToolbar.py:88
+#: blueman/gui/manager/ManagerToolbar.py:37
+#: blueman/gui/manager/ManagerToolbar.py:99
 msgid "Untrust"
 msgstr "不信任"
 
-#: blueman/gui/DeviceSelectorDialog.py:11
+#: blueman/gui/DeviceSelectorDialog.py:16
 msgid "Select Device"
 msgstr "選擇裝置"
 
-#: blueman/gui/MessageArea.py:37
+#: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "更多"
 
-#: blueman/gui/CommonUi.py:40
+#: blueman/gui/CommonUi.py:55
 msgid "translator-credits"
 msgstr ""
 "黃柏諺 <s8321414@yahoo.com.tw>,2013-14\n"
@@ -812,7 +804,7 @@ msgstr ""
 "  fetag https://launchpad.net/~coolfire\n"
 "Walter Cheuk <wwycheuk@gmail.com>, 2016."
 
-#: blueman/gui/CommonUi.py:45
+#: blueman/gui/CommonUi.py:60
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman 是一個 GTK+ 的藍牙管理軟體"
 
@@ -820,17 +812,17 @@ msgstr "Blueman 是一個 GTK+ 的藍牙管理軟體"
 msgid "GSM Settings"
 msgstr "GSM 設定"
 
-#: blueman/gui/applet/PluginDialog.py:89
-#: blueman/plugins/applet/StandardItems.py:90
+#: blueman/gui/applet/PluginDialog.py:94
+#: blueman/plugins/applet/StandardItems.py:95
 msgid "Plugins"
 msgstr "外掛程式"
 
-#: blueman/gui/applet/PluginDialog.py:280
-#: blueman/gui/applet/PluginDialog.py:302
+#: blueman/gui/applet/PluginDialog.py:290
+#: blueman/gui/applet/PluginDialog.py:312
 msgid "Dependency issue"
 msgstr "套件訊息"
 
-#: blueman/gui/applet/PluginDialog.py:282
+#: blueman/gui/applet/PluginDialog.py:292
 #, python-format
 msgid ""
 "Plugin <b>\"%(0)s\"</b> depends on <b>%(1)s</b>. Unloading <b>%(1)s</b> will "
@@ -841,7 +833,7 @@ msgstr ""
 "\"%(0)s\"</b>。\n"
 "是否繼續？"
 
-#: blueman/gui/applet/PluginDialog.py:304
+#: blueman/gui/applet/PluginDialog.py:314
 #, python-format
 msgid ""
 "Plugin <b>%(0)s</b> conflicts with <b>%(1)s</b>. Loading <b>%(1)s</b> will "
@@ -852,886 +844,1259 @@ msgstr ""
 "b>。\n"
 "是否繼續？"
 
-#: blueman/gui/DeviceSelectorWidget.py:37
+#: blueman/gui/DeviceSelectorWidget.py:39
 msgid "Adapter selection"
 msgstr "選取配接器"
 
-#: blueman/gui/DeviceSelectorWidget.py:43
+#: blueman/gui/DeviceSelectorWidget.py:45
 #, fuzzy
-#| msgid "Discoverable… %ss"
 msgid "Discovering…"
 msgstr "可探索…… %s秒"
 
 #. translators: device class
-#: blueman/DeviceClass.py:39 blueman/DeviceClass.py:63
-#: blueman/DeviceClass.py:109 blueman/DeviceClass.py:155
-msgid "uncategorized"
-msgstr "未分類"
+#: blueman/DeviceClass.py:6
+msgid "Miscellaneous"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:41
-msgid "desktop"
+#: blueman/DeviceClass.py:8
+msgid "Computer"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:10
+msgid "Phone"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:12
+#, fuzzy
+msgid "Access point"
+msgstr "網路存取點 (NAP)"
+
+#. translators: device class
+#: blueman/DeviceClass.py:14
+msgid "Audio/video"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:16
+msgid "Peripheral"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:18 blueman/DeviceClass.py:276
+msgid "Imaging"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:20 blueman/DeviceClass.py:41
+msgid "Wearable"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:22
+msgid "Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:31
+#, fuzzy
+msgid "Desktop"
 msgstr "桌上型電腦"
 
 #. translators: device class
-#: blueman/DeviceClass.py:43
-msgid "server"
+#: blueman/DeviceClass.py:33
+#, fuzzy
+msgid "Server"
 msgstr "伺服器"
 
 #. translators: device class
-#: blueman/DeviceClass.py:45
-msgid "laptop"
+#: blueman/DeviceClass.py:35
+#, fuzzy
+msgid "Laptop"
 msgstr "筆記型電腦"
 
 #. translators: device class
-#: blueman/DeviceClass.py:47
-msgid "handheld"
+#: blueman/DeviceClass.py:37
+#, fuzzy
+msgid "Handheld"
 msgstr "手持裝置"
 
 #. translators: device class
-#: blueman/DeviceClass.py:49
-msgid "palm"
-msgstr "Palm"
+#: blueman/DeviceClass.py:39
+msgid "Palm"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:65
-msgid "cellular"
+#: blueman/DeviceClass.py:48
+#, fuzzy
+msgid "Cellular"
 msgstr "行動裝置"
 
 #. translators: device class
-#: blueman/DeviceClass.py:67
-msgid "cordless"
+#: blueman/DeviceClass.py:50
+#, fuzzy
+msgid "Cordless"
 msgstr "無線電"
 
 #. translators: device class
-#: blueman/DeviceClass.py:69
-msgid "smart phone"
+#: blueman/DeviceClass.py:52
+#, fuzzy
+msgid "Smart phone"
 msgstr "智慧手機"
 
 #. translators: device class
-#: blueman/DeviceClass.py:71
-msgid "modem"
+#: blueman/DeviceClass.py:54
+#, fuzzy
+msgid "Modem"
 msgstr "數據機"
 
 #. translators: device class
-#: blueman/DeviceClass.py:73
-msgid "isdn"
-msgstr "整合服務數位網路 (ISDN)"
+#: blueman/DeviceClass.py:56
+msgid "Isdn"
+msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:111
-msgid "headset"
+#: blueman/DeviceClass.py:61
+msgid "Fully"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:63
+msgid "1-17 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:65
+msgid "17-33 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:67
+msgid "33-50 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:69
+msgid "50-67 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:71
+msgid "67-83 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:73
+msgid "83-99 percent"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:75
+#, fuzzy
+msgid "Not available"
+msgstr "obexd 無法使用"
+
+#. translators: device class
+#: blueman/DeviceClass.py:82 blueman/Sdp.py:122 blueman/Sdp.py:163
+#, fuzzy
+msgid "Headset"
 msgstr "耳機"
 
 #. translators: device class
-#: blueman/DeviceClass.py:113
-msgid "handsfree"
+#: blueman/DeviceClass.py:84 blueman/Sdp.py:144
+#, fuzzy
+msgid "Handsfree"
 msgstr "免持裝置"
 
 #. translators: device class
-#: blueman/DeviceClass.py:115 blueman/DeviceClass.py:143
-#: blueman/DeviceClass.py:263 blueman/DeviceClass.py:327
-msgid "unknown"
-msgstr "未知"
-
-#. translators: device class
-#: blueman/DeviceClass.py:117
-msgid "microphone"
+#: blueman/DeviceClass.py:88
+#, fuzzy
+msgid "Microphone"
 msgstr "麥克風"
 
 #. translators: device class
-#: blueman/DeviceClass.py:119
-msgid "loudspeaker"
+#: blueman/DeviceClass.py:90
+msgid "Loudspeaker"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:121
-msgid "headphones"
+#: blueman/DeviceClass.py:92
+msgid "Headphones"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:123
-msgid "portable audio"
+#: blueman/DeviceClass.py:94
+msgid "Portable audio"
 msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:96
+msgid "Car audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:98
+msgid "Set-top box"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:100
+msgid "Hifi audio"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:102
+msgid "Vcr"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:104
+#, fuzzy
+msgid "Video camera"
+msgstr "音訊來源"
+
+#. translators: device class
+#: blueman/DeviceClass.py:106
+msgid "Camcorder"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:108
+#, fuzzy
+msgid "Video monitor"
+msgstr "音訊來源"
+
+#. translators: device class
+#: blueman/DeviceClass.py:110
+msgid "Video display and loudspeaker"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:112
+#, fuzzy
+msgid "Video conferencing"
+msgstr "音訊來源"
+
+#. translators: device class
+#: blueman/DeviceClass.py:116
+msgid "Gaming/Toy"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:123 blueman/DeviceClass.py:189
+#, fuzzy
+msgid "Keyboard"
+msgstr "鍵盤"
 
 #. translators: device class
 #: blueman/DeviceClass.py:125
-msgid "car audio"
-msgstr ""
+#, fuzzy
+msgid "Pointing"
+msgstr "列表機"
 
 #. translators: device class
 #: blueman/DeviceClass.py:127
-msgid "set-top box"
+msgid "Combo"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:129
-msgid "hifi audio"
+#: blueman/DeviceClass.py:132
+msgid "Display"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:131
-msgid "vcr"
+#: blueman/DeviceClass.py:134
+msgid "Camera"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:133
-msgid "video camera"
+#: blueman/DeviceClass.py:136
+msgid "Scanner"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:135
-msgid "camcorder"
+#: blueman/DeviceClass.py:138
+msgid "Printer"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:137
-msgid "video monitor"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:139
-msgid "video display and loudspeaker"
-msgstr ""
-
-#. translators: device class
-#: blueman/DeviceClass.py:141
-msgid "video conferencing"
+#: blueman/DeviceClass.py:143
+msgid "Wrist watch"
 msgstr ""
 
 #. translators: device class
 #: blueman/DeviceClass.py:145
-msgid "gaming/toy"
+msgid "Pager"
 msgstr ""
 
 #. translators: device class
-#: blueman/DeviceClass.py:157
-msgid "keyboard"
-msgstr "鍵盤"
-
-#. translators: device class
-#: blueman/DeviceClass.py:159
-msgid "pointing"
-msgstr "列表機"
-
-#. translators: device class
-#: blueman/DeviceClass.py:161
-msgid "combo"
+#: blueman/DeviceClass.py:147
+msgid "Jacket"
 msgstr ""
 
-#: blueman/Sdp.py:93
+#. translators: device class
+#: blueman/DeviceClass.py:149
+msgid "Helmet"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:151
+msgid "Glasses"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:156
+msgid "Robot"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:158
+msgid "Vehicle"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:160
+msgid "Doll"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:162
+msgid "Controller"
+msgstr ""
+
+#. translators: device class
+#: blueman/DeviceClass.py:164
+msgid "Game"
+msgstr ""
+
+#: blueman/DeviceClass.py:169
+#, fuzzy
+msgid "Generic Phone"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:170
+#, fuzzy
+msgid "Generic Computer"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:171
+#, fuzzy
+msgid "Generic Watch"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:172
+msgid "Watch: Sports Watch"
+msgstr ""
+
+#: blueman/DeviceClass.py:173
+#, fuzzy
+msgid "Generic Clock"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:174
+#, fuzzy
+msgid "Generic Display"
+msgstr "藍牙檔案傳送"
+
+#: blueman/DeviceClass.py:175
+#, fuzzy
+msgid "Generic Remote Control"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:176
+#, fuzzy
+msgid "Generic Eye-glasses"
+msgstr "藍牙檔案傳送"
+
+#: blueman/DeviceClass.py:177
+#, fuzzy
+msgid "Generic Tag"
+msgstr "藍牙檔案傳送"
+
+#: blueman/DeviceClass.py:178
+#, fuzzy
+msgid "Generic Keyring"
+msgstr "群組網路 (GN)"
+
+#: blueman/DeviceClass.py:179
+#, fuzzy
+msgid "Generic Media Player"
+msgstr "藍牙檔案傳送"
+
+#: blueman/DeviceClass.py:180
+#, fuzzy
+msgid "Generic Barcode Scanner"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:181
+#, fuzzy
+msgid "Generic Thermometer"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:182
+msgid "Thermometer: Ear"
+msgstr ""
+
+#: blueman/DeviceClass.py:183
+#, fuzzy
+msgid "Generic Heart rate Sensor"
+msgstr "藍牙檔案傳送"
+
+#: blueman/DeviceClass.py:184
+msgid "Heart Rate Sensor: Heart Rate Belt"
+msgstr ""
+
+#: blueman/DeviceClass.py:185
+msgid "Generic Blood Pressure"
+msgstr ""
+
+#: blueman/DeviceClass.py:186
+msgid "Blood Pressure: Arm"
+msgstr ""
+
+#: blueman/DeviceClass.py:187
+msgid "Blood Pressure: Wrist"
+msgstr ""
+
+#: blueman/DeviceClass.py:188
+msgid "Human Interface Device (HID)"
+msgstr ""
+
+#: blueman/DeviceClass.py:190
+msgid "Mouse"
+msgstr ""
+
+#: blueman/DeviceClass.py:191
+msgid "Joystick"
+msgstr ""
+
+#: blueman/DeviceClass.py:192
+msgid "Gamepad"
+msgstr ""
+
+#: blueman/DeviceClass.py:193
+msgid "Digitizer Tablet"
+msgstr ""
+
+#: blueman/DeviceClass.py:194
+msgid "Card Reader"
+msgstr ""
+
+#: blueman/DeviceClass.py:195
+msgid "Digital Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:196
+msgid "Barcode Scanner"
+msgstr ""
+
+#: blueman/DeviceClass.py:197
+#, fuzzy
+msgid "Generic Glucose Meter"
+msgstr "連線"
+
+#: blueman/DeviceClass.py:198
+msgid "Generic: Running Walking Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:199
+msgid "Running Walking Sensor: In-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:200
+msgid "Running Walking Sensor: On-Shoe"
+msgstr ""
+
+#: blueman/DeviceClass.py:201
+msgid "Running Walking Sensor: On-Hip"
+msgstr ""
+
+#: blueman/DeviceClass.py:202
+#, fuzzy
+msgid "Generic: Cycling"
+msgstr "群組網路 (GN)"
+
+#: blueman/DeviceClass.py:203
+msgid "Cycling: Cycling Computer"
+msgstr ""
+
+#: blueman/DeviceClass.py:204
+msgid "Cycling: Speed Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:205
+msgid "Cycling: Cadence Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:206
+msgid "Cycling: Power Sensor"
+msgstr ""
+
+#: blueman/DeviceClass.py:207
+msgid "Cycling: Speed and Cadence Sensor"
+msgstr ""
+
+#. 19 - 48 reserved
+#: blueman/DeviceClass.py:209
+msgid "Generic: Pulse Oximeter"
+msgstr ""
+
+#: blueman/DeviceClass.py:210
+msgid "Fingertip"
+msgstr ""
+
+#: blueman/DeviceClass.py:211
+msgid "Wrist Worn"
+msgstr ""
+
+#: blueman/DeviceClass.py:212
+msgid "Generic: Weight Scale"
+msgstr ""
+
+#: blueman/DeviceClass.py:213
+msgid "Generic Personal Mobility Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:214
+msgid "Powered Wheelchair"
+msgstr ""
+
+#: blueman/DeviceClass.py:215
+msgid "Mobility Scooter"
+msgstr ""
+
+#: blueman/DeviceClass.py:216
+msgid "Generic Continuous Glucose Monitor"
+msgstr ""
+
+#: blueman/DeviceClass.py:217
+msgid "Generic Insulin Pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:218
+msgid "Insulin Pump, durable pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:219
+msgid "Insulin Pump, patch pump"
+msgstr ""
+
+#: blueman/DeviceClass.py:220
+msgid "Insulin Pen"
+msgstr ""
+
+#: blueman/DeviceClass.py:221
+msgid "Generic Medication Delivery"
+msgstr ""
+
+#. 55 - 80 reserved
+#: blueman/DeviceClass.py:223
+msgid "Generic: Outdoor Sports Activity"
+msgstr ""
+
+#: blueman/DeviceClass.py:224
+msgid "Location Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:225
+msgid "Location and Navigation Display Device"
+msgstr ""
+
+#: blueman/DeviceClass.py:226
+msgid "Location Pod"
+msgstr ""
+
+#: blueman/DeviceClass.py:227
+msgid "Location and Navigation Pod"
+msgstr ""
+
+#: blueman/Sdp.py:87
 msgid "SDP"
 msgstr ""
 
-#: blueman/Sdp.py:94
+#: blueman/Sdp.py:88
 msgid "UDP"
 msgstr ""
 
-#: blueman/Sdp.py:95
+#: blueman/Sdp.py:89
 msgid "RFCOMM"
 msgstr ""
 
-#: blueman/Sdp.py:96
+#: blueman/Sdp.py:90
 msgid "TCP"
 msgstr ""
 
-#: blueman/Sdp.py:97
+#: blueman/Sdp.py:91
 msgid "TCS-BIN"
 msgstr ""
 
-#: blueman/Sdp.py:98
+#: blueman/Sdp.py:92
 msgid "TCS-AT"
 msgstr ""
 
-#: blueman/Sdp.py:99
+#: blueman/Sdp.py:93
 msgid "ATT"
 msgstr ""
 
-#: blueman/Sdp.py:100
+#: blueman/Sdp.py:94
 msgid "OBEX"
 msgstr ""
 
-#: blueman/Sdp.py:101
+#: blueman/Sdp.py:95
 msgid "IP"
 msgstr ""
 
-#: blueman/Sdp.py:102
+#: blueman/Sdp.py:96
 msgid "FTP"
 msgstr ""
 
-#: blueman/Sdp.py:103
+#: blueman/Sdp.py:97
 msgid "HTTP"
 msgstr ""
 
-#: blueman/Sdp.py:104
+#: blueman/Sdp.py:98
 msgid "WSP"
 msgstr ""
 
-#: blueman/Sdp.py:105
+#: blueman/Sdp.py:99
 msgid "BNEP"
 msgstr ""
 
-#: blueman/Sdp.py:106
+#: blueman/Sdp.py:100
 msgid "UPnP/ESDP"
 msgstr ""
 
-#: blueman/Sdp.py:107
+#: blueman/Sdp.py:101
 msgid "HIDP"
 msgstr ""
 
-#: blueman/Sdp.py:108
+#: blueman/Sdp.py:102
 msgid "Hardcopy Control Channel"
 msgstr ""
 
-#: blueman/Sdp.py:109
+#: blueman/Sdp.py:103
 msgid "Hardcopy Data Channel"
 msgstr ""
 
-#: blueman/Sdp.py:110
+#: blueman/Sdp.py:104
 msgid "Hardcopy Notification"
 msgstr ""
 
-#: blueman/Sdp.py:111
+#: blueman/Sdp.py:105
 msgid "AVCTP"
 msgstr ""
 
-#: blueman/Sdp.py:112
+#: blueman/Sdp.py:106
 msgid "AVDTP"
 msgstr ""
 
-#: blueman/Sdp.py:113
+#: blueman/Sdp.py:107
 msgid "CMTP"
 msgstr ""
 
-#: blueman/Sdp.py:114
+#: blueman/Sdp.py:108
 msgid "UDI_C-Plane"
 msgstr ""
 
-#: blueman/Sdp.py:115 blueman/Sdp.py:116
+#: blueman/Sdp.py:109 blueman/Sdp.py:110
 msgid "Multi-Channel Adaptation Protocol (MCAP)"
 msgstr ""
 
-#: blueman/Sdp.py:117
+#: blueman/Sdp.py:111
 msgid "L2CAP"
 msgstr ""
 
-#: blueman/Sdp.py:118
+#: blueman/Sdp.py:112
 msgid "ServiceDiscoveryServerServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:119
+#: blueman/Sdp.py:113
 msgid "BrowseGroupDescriptorServiceClassID"
 msgstr ""
 
-#: blueman/Sdp.py:120
+#: blueman/Sdp.py:114
 msgid "Public Browse Group"
 msgstr ""
 
-#: blueman/Sdp.py:121
+#: blueman/Sdp.py:115
 #, fuzzy
-#| msgid "Serial Ports"
 msgid "Serial Port"
 msgstr "串列埠通訊"
 
-#: blueman/Sdp.py:122
+#: blueman/Sdp.py:116
 msgid "LAN Access Using PPP"
 msgstr ""
 
-#: blueman/Sdp.py:123
+#: blueman/Sdp.py:117
 msgid "Dialup Networking (DUN)"
 msgstr "撥號網路 (DUN)"
 
-#: blueman/Sdp.py:124
+#: blueman/Sdp.py:118
 msgid "IrMC Sync"
 msgstr ""
 
-#: blueman/Sdp.py:125
+#: blueman/Sdp.py:119
 msgid "OBEX Object Push"
 msgstr ""
 
-#: blueman/Sdp.py:126
+#: blueman/Sdp.py:120
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "OBEX File Transfer"
 msgstr "藍牙檔案傳送"
 
-#: blueman/Sdp.py:127
+#: blueman/Sdp.py:121
 msgid "IrMC Sync Command"
 msgstr ""
 
-#: blueman/Sdp.py:128 blueman/Sdp.py:169
-#, fuzzy
-#| msgid "headset"
-msgid "Headset"
-msgstr "耳機"
-
-#: blueman/Sdp.py:129
+#: blueman/Sdp.py:123
 msgid "Cordless Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:130
+#: blueman/Sdp.py:124
 msgid "Audio Source"
 msgstr "音訊來源"
 
-#: blueman/Sdp.py:131
+#: blueman/Sdp.py:125
 msgid "Audio Sink"
 msgstr "音訊終端"
 
-#: blueman/Sdp.py:132
+#: blueman/Sdp.py:126
 msgid "Remote Control Target"
 msgstr ""
 
-#: blueman/Sdp.py:133
+#: blueman/Sdp.py:127
 msgid "Advanced Audio"
 msgstr ""
 
-#: blueman/Sdp.py:134
+#: blueman/Sdp.py:128
 msgid "Remote Control"
 msgstr ""
 
-#: blueman/Sdp.py:135
+#: blueman/Sdp.py:129
 msgid "Video Conferencing"
 msgstr ""
 
-#: blueman/Sdp.py:136
+#: blueman/Sdp.py:130
 msgid "Intercom"
 msgstr ""
 
-#: blueman/Sdp.py:137
+#: blueman/Sdp.py:131
 msgid "Fax"
 msgstr ""
 
-#: blueman/Sdp.py:138
+#: blueman/Sdp.py:132
 msgid "Headset Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:139
+#: blueman/Sdp.py:133
 msgid "WAP"
 msgstr ""
 
-#: blueman/Sdp.py:140
+#: blueman/Sdp.py:134
 msgid "WAP Client"
 msgstr ""
 
-#: blueman/Sdp.py:141
+#: blueman/Sdp.py:135
 msgid "PANU"
 msgstr ""
 
-#: blueman/Sdp.py:142
+#: blueman/Sdp.py:136
 msgid "Network Access Point"
 msgstr "網路存取點 (NAP)"
 
-#: blueman/Sdp.py:143
+#: blueman/Sdp.py:137
 msgid "Group Network"
 msgstr "群組網路 (GN)"
 
-#: blueman/Sdp.py:144
+#: blueman/Sdp.py:138
 msgid "DirectPrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:145
+#: blueman/Sdp.py:139
 msgid "ReferencePrinting (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:146
+#: blueman/Sdp.py:140
 msgid "Imaging (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:147
+#: blueman/Sdp.py:141
 msgid "ImagingResponder (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:148
+#: blueman/Sdp.py:142
 msgid "ImagingAutomaticArchive (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:149
+#: blueman/Sdp.py:143
 msgid "ImagingReferencedObjects (BIP)"
 msgstr ""
 
-#: blueman/Sdp.py:150
-#, fuzzy
-#| msgid "handsfree"
-msgid "Handsfree"
-msgstr "免持裝置"
-
-#: blueman/Sdp.py:151
+#: blueman/Sdp.py:145
 msgid "Handsfree Audio Gateway"
 msgstr ""
 
-#: blueman/Sdp.py:152
+#: blueman/Sdp.py:146
 msgid "DirectPrintingReferenceObjectsService (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:153
+#: blueman/Sdp.py:147
 msgid "ReflectedUI (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:154
+#: blueman/Sdp.py:148
 msgid "Basic Printing (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:155
+#: blueman/Sdp.py:149
 msgid "Printing Status (BPP)"
 msgstr ""
 
-#: blueman/Sdp.py:156
+#: blueman/Sdp.py:150
 msgid "Human Interface Device Service (HID)"
 msgstr ""
 
-#: blueman/Sdp.py:157
+#: blueman/Sdp.py:151
 msgid "HardcopyCableReplacement (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:158
+#: blueman/Sdp.py:152
 msgid "HCR_Print (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:159
+#: blueman/Sdp.py:153
 msgid "HCR_Scan (HCR)"
 msgstr ""
 
-#: blueman/Sdp.py:160
+#: blueman/Sdp.py:154
 msgid "Common ISDN Access (CIP)"
 msgstr ""
 
-#: blueman/Sdp.py:161
+#: blueman/Sdp.py:155
 msgid "VideoConferencingGW (VCP)"
 msgstr ""
 
-#: blueman/Sdp.py:162
+#: blueman/Sdp.py:156
 msgid "UDI-MT"
 msgstr ""
 
-#: blueman/Sdp.py:163
+#: blueman/Sdp.py:157
 msgid "UDI-TA"
 msgstr ""
 
-#: blueman/Sdp.py:164
+#: blueman/Sdp.py:158
 msgid "Audio/Video"
 msgstr ""
 
-#: blueman/Sdp.py:165
+#: blueman/Sdp.py:159
 msgid "SIM Access (SAP)"
 msgstr ""
 
-#: blueman/Sdp.py:166
+#: blueman/Sdp.py:160
 msgid "Phonebook Access (PBAP) - PCE"
 msgstr ""
 
-#: blueman/Sdp.py:167
+#: blueman/Sdp.py:161
 msgid "Phonebook Access (PBAP) - PSE"
 msgstr ""
 
-#: blueman/Sdp.py:168
+#: blueman/Sdp.py:162
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Phonebook Access (PBAP)"
 msgstr "網路接取點 (NAP)"
 
-#: blueman/Sdp.py:170
+#: blueman/Sdp.py:164
 msgid "Message Access Server"
 msgstr ""
 
-#: blueman/Sdp.py:171
+#: blueman/Sdp.py:165
 msgid "Message Notification Server"
 msgstr ""
 
-#: blueman/Sdp.py:172
+#: blueman/Sdp.py:166
 #, fuzzy
-#| msgid "Network Access Point (NAP)"
 msgid "Message Access Profile (MAP)"
 msgstr "網路接取點 (NAP)"
 
-#: blueman/Sdp.py:173
+#: blueman/Sdp.py:167
 msgid "GNSS"
 msgstr ""
 
-#: blueman/Sdp.py:174
+#: blueman/Sdp.py:168
 msgid "GNSS Server"
 msgstr ""
 
-#: blueman/Sdp.py:175
+#: blueman/Sdp.py:169
 msgid "3D Display"
 msgstr ""
 
-#: blueman/Sdp.py:176
+#: blueman/Sdp.py:170
 msgid "3D Glasses"
 msgstr ""
 
-#: blueman/Sdp.py:177
+#: blueman/Sdp.py:171
 msgid "3D Synchronization (3DSP)"
 msgstr ""
 
-#: blueman/Sdp.py:178
+#: blueman/Sdp.py:172
 msgid "Multi-Profile Specification (MPS) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:179
+#: blueman/Sdp.py:173
 msgid "Multi-Profile Specification (MPS) Service"
 msgstr ""
 
-#: blueman/Sdp.py:180
+#: blueman/Sdp.py:174
 msgid "Calendar, Task, and Notes (CTN) Access Service"
 msgstr ""
 
-#: blueman/Sdp.py:181
+#: blueman/Sdp.py:175
 msgid "Calendar, Task, and Notes (CTN) Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:182
+#: blueman/Sdp.py:176
 msgid "Calendar, Task, and Notes (CTN) Profile"
 msgstr ""
 
-#: blueman/Sdp.py:183
+#: blueman/Sdp.py:177
 msgid "PnP Information"
 msgstr ""
 
-#: blueman/Sdp.py:184
+#: blueman/Sdp.py:178
 #, fuzzy
-#| msgid "Group Network"
 msgid "Generic Networking"
 msgstr "群組網路 (GN)"
 
-#: blueman/Sdp.py:185
+#: blueman/Sdp.py:179
 #, fuzzy
-#| msgid "Bluetooth File Transfer"
 msgid "Generic FileTransfer"
 msgstr "藍牙檔案傳送"
 
-#: blueman/Sdp.py:186
+#: blueman/Sdp.py:180
 msgid "Generic Audio"
 msgstr ""
 
-#: blueman/Sdp.py:187
+#: blueman/Sdp.py:181
 msgid "Generic Telephony"
 msgstr ""
 
-#: blueman/Sdp.py:188
+#: blueman/Sdp.py:182
 #, fuzzy
-#| msgid "Audio Source"
 msgid "Video Source"
 msgstr "音訊來源"
 
-#: blueman/Sdp.py:189
+#: blueman/Sdp.py:183
 #, fuzzy
-#| msgid "Audio Sink"
 msgid "Video Sink"
 msgstr "音訊終端"
 
-#: blueman/Sdp.py:190
+#: blueman/Sdp.py:184
 msgid "Video Distribution"
 msgstr ""
 
-#: blueman/Sdp.py:191
+#: blueman/Sdp.py:185
 msgid "HDP"
 msgstr ""
 
-#: blueman/Sdp.py:192
+#: blueman/Sdp.py:186
 #, fuzzy
-#| msgid "Audio Source"
 msgid "HDP Source"
 msgstr "音訊來源"
 
-#: blueman/Sdp.py:193
+#: blueman/Sdp.py:187
 msgid "HDP Sink"
 msgstr ""
 
-#: blueman/Sdp.py:194
+#: blueman/Sdp.py:188
 msgid "Generic Access"
 msgstr ""
 
-#: blueman/Sdp.py:195
+#: blueman/Sdp.py:189
 msgid "Generic Attribute"
 msgstr ""
 
-#: blueman/Sdp.py:196
+#: blueman/Sdp.py:190
 msgid "Immediate Alert"
 msgstr ""
 
-#: blueman/Sdp.py:197
+#: blueman/Sdp.py:191
 msgid "Link Loss"
 msgstr ""
 
-#: blueman/Sdp.py:198
+#: blueman/Sdp.py:192
 msgid "Tx Power"
 msgstr ""
 
-#: blueman/Sdp.py:199
+#: blueman/Sdp.py:193
 #, fuzzy
-#| msgid "Rename device"
 msgid "Current Time Service"
 msgstr "重新命名裝置"
 
-#: blueman/Sdp.py:200
+#: blueman/Sdp.py:194
 msgid "Reference Time Update Service"
 msgstr ""
 
-#: blueman/Sdp.py:201
+#: blueman/Sdp.py:195
 msgid "Next DST Change Service"
 msgstr ""
 
-#: blueman/Sdp.py:202
+#: blueman/Sdp.py:196
 msgid "Glucose"
 msgstr ""
 
-#: blueman/Sdp.py:203
+#: blueman/Sdp.py:197
 msgid "Health Thermometer"
 msgstr ""
 
-#: blueman/Sdp.py:204
+#: blueman/Sdp.py:198
 #, fuzzy
-#| msgid "Show device information"
 msgid "Device Information"
 msgstr "顯示裝置資訊"
 
-#: blueman/Sdp.py:205
+#: blueman/Sdp.py:199
 msgid "Heart Rate"
 msgstr ""
 
-#: blueman/Sdp.py:206
+#: blueman/Sdp.py:200
 msgid "Phone Alert Status Service"
 msgstr ""
 
-#: blueman/Sdp.py:207
+#: blueman/Sdp.py:201
 #, fuzzy
-#| msgid "Local Services"
 msgid "Battery Service"
 msgstr "本機服務"
 
-#: blueman/Sdp.py:208
+#: blueman/Sdp.py:202
 msgid "Blood Pressure"
 msgstr ""
 
-#: blueman/Sdp.py:209
+#: blueman/Sdp.py:203
 msgid "Alert Notification Service"
 msgstr ""
 
-#: blueman/Sdp.py:210
+#: blueman/Sdp.py:204
 msgid "Human Interface Device"
 msgstr ""
 
-#: blueman/Sdp.py:211
+#: blueman/Sdp.py:205
 msgid "Scan Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:212
+#: blueman/Sdp.py:206
 msgid "Running Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:213
+#: blueman/Sdp.py:207
 msgid "Automation IO"
 msgstr ""
 
-#: blueman/Sdp.py:214
+#: blueman/Sdp.py:208
 msgid "Cycling Speed and Cadence"
 msgstr ""
 
-#: blueman/Sdp.py:215
+#: blueman/Sdp.py:209
 msgid "Cycling Power"
 msgstr ""
 
-#: blueman/Sdp.py:216
+#: blueman/Sdp.py:210
 msgid "Location and Navigation"
 msgstr ""
 
-#: blueman/Sdp.py:217
+#: blueman/Sdp.py:211
 msgid "Environmental Sensing"
 msgstr ""
 
-#: blueman/Sdp.py:218
+#: blueman/Sdp.py:212
 msgid "Body Composition"
 msgstr ""
 
-#: blueman/Sdp.py:219
+#: blueman/Sdp.py:213
 msgid "User Data"
 msgstr ""
 
-#: blueman/Sdp.py:220
+#: blueman/Sdp.py:214
 msgid "Weight Scale"
 msgstr ""
 
-#: blueman/Sdp.py:221
+#: blueman/Sdp.py:215
 msgid "Bond Management"
 msgstr ""
 
-#: blueman/Sdp.py:222
+#: blueman/Sdp.py:216
 msgid "Continuous Glucose Monitoring"
 msgstr ""
 
-#: blueman/Sdp.py:223
+#: blueman/Sdp.py:217
 msgid "Internet Protocol Support"
 msgstr ""
 
-#: blueman/Sdp.py:224
+#: blueman/Sdp.py:218
 msgid "Indoor Positioning"
 msgstr ""
 
-#: blueman/Sdp.py:225
+#: blueman/Sdp.py:219
 msgid "Pulse Oximeter"
 msgstr ""
 
-#: blueman/Sdp.py:226
+#: blueman/Sdp.py:220
 msgid "HTTP Proxy"
 msgstr ""
 
-#: blueman/Sdp.py:227
+#: blueman/Sdp.py:221
 msgid "Transport Discovery"
+msgstr ""
+
+#: blueman/Sdp.py:222
+#, fuzzy
+msgid "Object Transfer"
+msgstr "傳送"
+
+#: blueman/Sdp.py:223
+#, fuzzy
+msgid "AppleAgent"
+msgstr "小程式"
+
+#: blueman/Sdp.py:224
+#, fuzzy
+msgid "Primary Service"
+msgstr "配對裝置"
+
+#: blueman/Sdp.py:225
+#, fuzzy
+msgid "Secondary Service"
+msgstr "搜附近的裝置"
+
+#: blueman/Sdp.py:226
+msgid "Include"
+msgstr ""
+
+#: blueman/Sdp.py:227
+msgid "Characteristic Declaration"
 msgstr ""
 
 #: blueman/Sdp.py:228
 #, fuzzy
-#| msgid "Transfer"
-msgid "Object Transfer"
-msgstr "傳送"
-
-#: blueman/Sdp.py:229
-#, fuzzy
-#| msgid "applet"
-msgid "AppleAgent"
-msgstr "小程式"
-
-#: blueman/Sdp.py:230
-#, fuzzy
-#| msgid "Pair Device"
-msgid "Primary Service"
-msgstr "配對裝置"
-
-#: blueman/Sdp.py:231
-#, fuzzy
-#| msgid "Search for nearby devices"
-msgid "Secondary Service"
-msgstr "搜附近的裝置"
-
-#: blueman/Sdp.py:232
-msgid "Include"
-msgstr ""
-
-#: blueman/Sdp.py:233
-msgid "Characteristic Declaration"
-msgstr ""
-
-#: blueman/Sdp.py:234
-#, fuzzy
-#| msgid "Device Manager"
 msgid "Device Name"
 msgstr "裝置管理"
 
-#: blueman/Sdp.py:235
+#: blueman/Sdp.py:229
 msgid "Appearance"
 msgstr ""
 
-#: blueman/Sdp.py:236
+#: blueman/Sdp.py:230
 msgid "Peripheral Privacy Flag"
 msgstr ""
 
-#: blueman/Sdp.py:237
+#: blueman/Sdp.py:231
 #, fuzzy
-#| msgid "Recent _Connections"
 msgid "Reconnection Address"
 msgstr "最近連線(_C)"
 
-#: blueman/Sdp.py:238
+#: blueman/Sdp.py:232
 msgid "Peripheral Preferred Connection Parameters"
 msgstr ""
 
-#: blueman/Sdp.py:239
+#: blueman/Sdp.py:233
 #, fuzzy
-#| msgid "Device Manager"
 msgid "Service Changed"
 msgstr "裝置管理"
 
-#: blueman/Sdp.py:240
+#: blueman/Sdp.py:234
 msgid "System ID"
 msgstr ""
 
-#: blueman/Sdp.py:241
+#: blueman/Sdp.py:235
 msgid "Model Number String"
 msgstr ""
 
-#: blueman/Sdp.py:242
+#: blueman/Sdp.py:236
 msgid "Serial Number String"
 msgstr ""
 
-#: blueman/Sdp.py:243
+#: blueman/Sdp.py:237
 msgid "Firmware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:244
+#: blueman/Sdp.py:238
 msgid "Hardware Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:245
+#: blueman/Sdp.py:239
 msgid "Software Revision String"
 msgstr ""
 
-#: blueman/Sdp.py:246
+#: blueman/Sdp.py:240
 msgid "Manufacturer Name String"
 msgstr ""
 
-#: blueman/Sdp.py:247
+#: blueman/Sdp.py:241
 msgid "PnP ID"
 msgstr ""
 
-#: blueman/Sdp.py:248
+#: blueman/Sdp.py:242
 msgid "Characteristic Extended Properties"
 msgstr ""
 
-#: blueman/Sdp.py:249
+#: blueman/Sdp.py:243
 msgid "Characteristic User Description"
 msgstr ""
 
-#: blueman/Sdp.py:250
+#: blueman/Sdp.py:244
 msgid "Client Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:251
+#: blueman/Sdp.py:245
 msgid "Server Characteristic Configuration"
 msgstr ""
 
-#: blueman/Sdp.py:252
+#: blueman/Sdp.py:246
 msgid "Characteristic Presentation Format"
 msgstr ""
 
-#: blueman/Sdp.py:253
+#: blueman/Sdp.py:247
 msgid "Characteristic Aggregate Format"
 msgstr ""
 
-#: blueman/Sdp.py:254
+#: blueman/Sdp.py:248
 msgid "Valid Range"
 msgstr ""
 
-#: blueman/Sdp.py:255
+#: blueman/Sdp.py:249
 msgid "External Report Reference"
 msgstr ""
 
-#: blueman/Sdp.py:256
+#: blueman/Sdp.py:250
 #, fuzzy
-#| msgid "Adapter Preferences"
 msgid "Report Reference"
 msgstr "配接器偏好設定"
 
-#: blueman/Sdp.py:383
+#: blueman/Sdp.py:377
 msgid "Auto connect profiles"
 msgstr "自動連線設定檔"
 
-#: blueman/Sdp.py:385
+#: blueman/Sdp.py:379
 msgid "Proprietary"
 msgstr "專有"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "yes"
 msgstr "是"
 
-#: blueman/plugins/manager/Info.py:15
+#: blueman/plugins/manager/Info.py:21
 msgid "no"
 msgstr "否"
 
-#: blueman/plugins/manager/Info.py:115
+#: blueman/plugins/manager/Info.py:58
+msgid "<big>Select row(s) and use <i>Control + C</i> to copy</big>"
+msgstr ""
+
+#: blueman/plugins/manager/Info.py:118
 msgid "_Info"
 msgstr "資訊(_I)"
 
-#: blueman/plugins/manager/Info.py:116
+#: blueman/plugins/manager/Info.py:119
 msgid "Show device information"
 msgstr "顯示裝置資訊"
 
@@ -1756,34 +2121,35 @@ msgstr "音訊設定檔"
 msgid "Select audio profile for PulseAudio"
 msgstr "為 PulseAudio 選擇音訊設定檔"
 
-#: blueman/plugins/manager/Services.py:71
+#: blueman/plugins/manager/Services.py:78
 #, python-format
 msgid "Serial Port %s"
 msgstr "串列埠 %s"
 
-#: blueman/plugins/manager/Services.py:84
+#: blueman/plugins/manager/Services.py:91
 msgid "Renew IP Address"
 msgstr "更新 IP 位址"
 
-#: blueman/plugins/manager/Services.py:101
+#: blueman/plugins/manager/Services.py:108
 msgid "Dialup Settings"
 msgstr "撥接設定"
 
-#: blueman/plugins/manager/Services.py:110
+#: blueman/plugins/manager/Services.py:117
 msgid "Serial Ports"
 msgstr "串列埠通訊"
 
-#: blueman/plugins/BasePlugin.py:36 blueman/plugins/BasePlugin.py:37
+#: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr "未指定"
 
-#: blueman/plugins/applet/AutoConnect.py:36
-#: blueman/plugins/applet/RecentConns.py:231
-#: blueman/plugins/applet/PPPSupport.py:51
+#. https://github.com/python/mypy/issues/2608
+#: blueman/plugins/applet/AutoConnect.py:42
+#: blueman/plugins/applet/RecentConns.py:219
+#: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr "已連線"
 
-#: blueman/plugins/applet/AutoConnect.py:36
+#: blueman/plugins/applet/AutoConnect.py:42
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr "自動連線至在 %(device)s 上的 %(service)s"
@@ -1844,104 +2210,99 @@ msgstr "網路使用量(_U)"
 msgid "Shows network traffic usage"
 msgstr "顯示網路使用狀況"
 
-#: blueman/plugins/applet/StatusIcon.py:30
-#: blueman/plugins/applet/StatusIcon.py:52
-#: blueman/plugins/applet/ShowConnected.py:61
-#: blueman/plugins/applet/ShowConnected.py:63
+#: blueman/plugins/applet/StatusIcon.py:42
+#: blueman/plugins/applet/ShowConnected.py:72
+#: blueman/plugins/applet/PowerManager.py:189
 msgid "Bluetooth Enabled"
 msgstr "藍牙開啟"
 
-#: blueman/plugins/applet/StatusIcon.py:55
-msgid "Bluetooth Disabled"
-msgstr "藍牙關閉"
-
-#: blueman/plugins/applet/Networking.py:15
+#: blueman/plugins/applet/Networking.py:17
 msgid "Manages local network services, like NAP bridges"
 msgstr "管理本機網路服務，如同 NAP 橋接。"
 
-#: blueman/plugins/applet/NMDUNSupport.py:13
+#: blueman/plugins/applet/NMDUNSupport.py:18
 msgid ""
 "Provides support for Dial Up Networking (DUN) with ModemManager and "
 "NetworkManager"
 msgstr "在 ModemManager 及 NetworkManager 提供支援撥號網路 (DUN)"
 
-#: blueman/plugins/applet/RecentConns.py:56
+#: blueman/plugins/applet/RecentConns.py:41
 msgid ""
 "Provides a menu item that contains last used connections for quick access"
 msgstr "提供最近連線過的裝置清單，以方便快速連線"
 
 #. the maximum number of items RecentConns menu will display
-#: blueman/plugins/applet/RecentConns.py:67
+#: blueman/plugins/applet/RecentConns.py:52
 msgid "Maximum items"
 msgstr "最大顯示項目"
 
-#: blueman/plugins/applet/RecentConns.py:68
+#: blueman/plugins/applet/RecentConns.py:53
 msgid "The maximum number of items recent connections menu will display."
 msgstr "最多顯示幾個最近使用連線。"
 
-#: blueman/plugins/applet/RecentConns.py:79
+#: blueman/plugins/applet/RecentConns.py:64
 msgid "Recent _Connections"
 msgstr "最近連線(_C)"
 
-#: blueman/plugins/applet/RecentConns.py:231
+#: blueman/plugins/applet/RecentConns.py:219
 #, python-format
 msgid "Connected to %s"
 msgstr "已連線到 %s"
 
-#: blueman/plugins/applet/RecentConns.py:237
+#: blueman/plugins/applet/RecentConns.py:225
 msgid "Failed to connect"
 msgstr "連線錯誤"
 
-#: blueman/plugins/applet/RecentConns.py:256
+#: blueman/plugins/applet/RecentConns.py:245
 #, python-format
 msgid "%(service)s on %(device)s"
 msgstr "連線到 %(device)s (經由 %(service)s)"
 
-#: blueman/plugins/applet/RecentConns.py:260
+#: blueman/plugins/applet/RecentConns.py:249
 msgid "Adapter for this connection is not available"
 msgstr "配接器無法取得此連線"
 
-#: blueman/plugins/applet/NMPANSupport.py:13
+#: blueman/plugins/applet/NMPANSupport.py:18
 msgid ""
 "Provides support for Personal Area Networking (PAN) introduced in "
 "NetworkManager 0.8"
 msgstr "在 NetworkManager 0.8 中提供支援個人區域網路 (PAN)"
 
-#: blueman/plugins/applet/DBusService.py:16
+#: blueman/plugins/applet/DBusService.py:46
 msgid "Provides DBus API for other Blueman components"
 msgstr "提供 DBus API 給其他的 Blueman 元件"
 
-#: blueman/plugins/applet/TransferService.py:114
+#: blueman/plugins/applet/TransferService.py:127
 msgid "Incoming file over Bluetooth"
 msgstr "透過藍牙接收檔案"
 
-#: blueman/plugins/applet/TransferService.py:115
+#: blueman/plugins/applet/TransferService.py:128
 #, python-format
 msgid "Incoming file %(0)s from %(1)s"
 msgstr "接收檔案 %(0)s 從 %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:117
+#: blueman/plugins/applet/TransferService.py:130
 msgid "Reject"
 msgstr "拒絕"
 
-#: blueman/plugins/applet/TransferService.py:124
+#: blueman/plugins/applet/TransferService.py:137
 msgid "Receiving file"
 msgstr "接收檔案"
 
-#: blueman/plugins/applet/TransferService.py:125
+#: blueman/plugins/applet/TransferService.py:138
 #, python-format
 msgid "Receiving file %(0)s from %(1)s"
 msgstr "接收檔案 %(0)s 從 %(1)s"
 
-#: blueman/plugins/applet/TransferService.py:144
+#: blueman/plugins/applet/TransferService.py:157
 msgid "Provides OBEX file transfer capabilities"
 msgstr "提供 OBEX 檔案傳送的能力"
 
-#: blueman/plugins/applet/TransferService.py:167
+#: blueman/plugins/applet/TransferService.py:180
 msgid "Configured directory for incoming files does not exist"
 msgstr "設定好的接收目錄不存在"
 
-#: blueman/plugins/applet/TransferService.py:168
+#: blueman/plugins/applet/TransferService.py:181
 #, python-format
 msgid ""
 "Please make sure that directory \"<b>%s</b>\" exists or configure it with "
@@ -1950,41 +2311,37 @@ msgstr ""
 "請確保目錄「<b>%s</b>」存在或以 blueman-services 設定。在此之前，將使用預設的"
 "「%s」。"
 
-#: blueman/plugins/applet/TransferService.py:298
+#: blueman/plugins/applet/TransferService.py:303
 msgid "File received"
 msgstr "檔案接收"
 
-#: blueman/plugins/applet/TransferService.py:299
+#: blueman/plugins/applet/TransferService.py:304
 #, python-format
 msgid "File %(0)s from %(1)s successfully received"
 msgstr "來自 %(1)s 的檔案 %(0)s 成功接收"
 
-#: blueman/plugins/applet/TransferService.py:307
+#: blueman/plugins/applet/TransferService.py:312
 msgid "Transfer failed"
 msgstr "未能傳送"
 
-#: blueman/plugins/applet/TransferService.py:308
+#: blueman/plugins/applet/TransferService.py:313
 #, python-format
 msgid "Transfer of file %(0)s failed"
 msgstr "未能傳送 %(0)s 檔案"
 
-#: blueman/plugins/applet/TransferService.py:327
-#: blueman/plugins/applet/TransferService.py:336
+#: blueman/plugins/applet/TransferService.py:333
+#: blueman/plugins/applet/TransferService.py:342
 msgid "Files received"
 msgstr "檔案接收"
 
-#: blueman/plugins/applet/TransferService.py:328
+#: blueman/plugins/applet/TransferService.py:334
 #, fuzzy, python-format
-#| msgid "Received %d file in the background"
-#| msgid_plural "Received %d files in the background"
 msgid "Received %(files)d file in the background"
 msgid_plural "Received %(files)d files in the background"
 msgstr[0] "在背景中接收 %d 檔案"
 
-#: blueman/plugins/applet/TransferService.py:337
+#: blueman/plugins/applet/TransferService.py:343
 #, fuzzy, python-format
-#| msgid "Received %d more file in the background"
-#| msgid_plural "Received %d more files in the background"
 msgid "Received %(files)d more file in the background"
 msgid_plural "Received %(files)d more files in the background"
 msgstr[0] "在背景中接收 %d 許多檔案"
@@ -1996,27 +2353,27 @@ msgid ""
 "isn't unplugged by the system, or physically."
 msgstr ""
 
-#: blueman/plugins/applet/StandardItems.py:17
+#: blueman/plugins/applet/StandardItems.py:22
 msgid "Adds standard menu items to the status icon menu"
 msgstr "新增標準的清單項目到狀態圖示清單"
 
-#: blueman/plugins/applet/StandardItems.py:25
+#: blueman/plugins/applet/StandardItems.py:30
 msgid "_Set Up New Device"
 msgstr "設定新裝置 (_S)"
 
-#: blueman/plugins/applet/StandardItems.py:30
+#: blueman/plugins/applet/StandardItems.py:35
 msgid "Send _Files to Device"
 msgstr "傳送檔案 (_F)"
 
-#: blueman/plugins/applet/StandardItems.py:35
+#: blueman/plugins/applet/StandardItems.py:40
 msgid "_Devices"
 msgstr "裝置 (_D)"
 
-#: blueman/plugins/applet/StandardItems.py:38
+#: blueman/plugins/applet/StandardItems.py:43
 msgid "Adap_ters"
 msgstr "配接器 (_T)"
 
-#: blueman/plugins/applet/StandardItems.py:87
+#: blueman/plugins/applet/StandardItems.py:92
 msgid "applet"
 msgstr "小程式"
 
@@ -2028,27 +2385,27 @@ msgstr "提供密鑰、身分核對服務給 BlueZ"
 msgid "Adds an exit menu item to quit the applet"
 msgstr "新增「結束」選單項目以結束小程式"
 
-#: blueman/plugins/applet/DhcpClient.py:12
+#: blueman/plugins/applet/DhcpClient.py:14
 msgid "Provides a basic dhcp client for Bluetooth PAN connections."
 msgstr "提供基本的 DHCP 給藍牙 PAN 連線"
 
-#: blueman/plugins/applet/DhcpClient.py:43
-#: blueman/plugins/applet/DhcpClient.py:51
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:45
+#: blueman/plugins/applet/DhcpClient.py:53
+#: blueman/plugins/applet/DhcpClient.py:58
 msgid "Bluetooth Network"
 msgstr "藍牙網路"
 
-#: blueman/plugins/applet/DhcpClient.py:44
+#: blueman/plugins/applet/DhcpClient.py:46
 #, python-format
 msgid "Interface %(0)s bound to IP address %(1)s"
 msgstr "介面 %(0)s 依附到 IP 位址 %(1)s"
 
-#: blueman/plugins/applet/DhcpClient.py:51
+#: blueman/plugins/applet/DhcpClient.py:53
 #, python-format
 msgid "Failed to obtain an IP address on %s"
 msgstr "未能取得 %s 提供的 IP 位址"
 
-#: blueman/plugins/applet/DhcpClient.py:56
+#: blueman/plugins/applet/DhcpClient.py:58
 #, python-format
 msgid ""
 "Trying to obtain an IP address on %s\n"
@@ -2057,61 +2414,65 @@ msgstr ""
 "嘗試在 %s 上取得 IP 位置\n"
 "請稍候……"
 
-#: blueman/plugins/applet/ShowConnected.py:12
+#: blueman/plugins/applet/ShowConnected.py:17
 msgid ""
 "Adds an indication on the status icon when Bluetooth is active and shows the "
 "number of connections in the tooltip."
 msgstr "當藍牙啟用時，在狀態列新增提示，並顯示連線數量。"
 
-#: blueman/plugins/applet/ShowConnected.py:47
+#: blueman/plugins/applet/ShowConnected.py:61
 msgid "Bluetooth Active"
 msgstr "藍牙使用"
 
-#: blueman/plugins/applet/ShowConnected.py:50
+#: blueman/plugins/applet/ShowConnected.py:64
 #, fuzzy, python-format
-#| msgid "<b>%d Active Connection</b>"
-#| msgid_plural "<b>%d Active Connections</b>"
 msgid "<b>%(connections)d Active Connection</b>"
 msgid_plural "<b>%(connections)d Active Connections</b>"
 msgstr[0] "<b>%d 個運作的連線</b>"
 
-#: blueman/plugins/applet/AppIndicator.py:14
+#: blueman/plugins/applet/ShowConnected.py:74
+#: blueman/plugins/applet/PowerManager.py:192
+msgid "Bluetooth Disabled"
+msgstr "藍牙關閉"
+
+#: blueman/plugins/applet/AppIndicator.py:17
 msgid "Uses libappindicator to show a statusicon"
 msgstr "使用 libappindicator 顯示狀態圖示"
 
-#: blueman/plugins/applet/DiscvManager.py:14
+#: blueman/plugins/applet/DiscvManager.py:16
 msgid ""
 "Provides a menu item for making the default adapter temporarily visible when "
 "it is set to hidden by default"
 msgstr "提供一份清單來設定預設的藍牙配接器可見的時間長短，當裝置設定為隱藏時"
 
-#: blueman/plugins/applet/DiscvManager.py:24
+#: blueman/plugins/applet/DiscvManager.py:26
 msgid "Discoverable timeout"
 msgstr "探索時間逾時"
 
-#: blueman/plugins/applet/DiscvManager.py:25
+#: blueman/plugins/applet/DiscvManager.py:27
 msgid "Amount of time in seconds discoverable mode will last"
 msgstr "設定藍牙至少探索的時間（秒）"
 
-#: blueman/plugins/applet/DiscvManager.py:31
+#: blueman/plugins/applet/DiscvManager.py:35
+#: blueman/plugins/applet/DiscvManager.py:118
 msgid "_Make Discoverable"
 msgstr "可發現 (_M)"
 
-#: blueman/plugins/applet/DiscvManager.py:32
+#: blueman/plugins/applet/DiscvManager.py:36
 msgid "Make the default adapter temporarily visible"
 msgstr "將預設的配接器設定為暫時可見"
 
-#: blueman/plugins/applet/DiscvManager.py:56
+#: blueman/plugins/applet/DiscvManager.py:60
 #, python-format
 msgid "Discoverable… %ss"
 msgstr "可探索…… %s秒"
 
-#: blueman/plugins/applet/Menu.py:89
+#: blueman/plugins/applet/Menu.py:113
 msgid ""
 "Provides a menu for the applet and an API for other plugins to manipulate it"
 msgstr "提供一份清單給藍牙應用服務或是 API 給其他的外掛程式來連線操作"
 
-#: blueman/plugins/applet/PPPSupport.py:48
+#: blueman/plugins/applet/PPPSupport.py:72
 #, python-format
 msgid ""
 "Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
@@ -2120,20 +2481,20 @@ msgstr ""
 "成功連線到 <b>DUN</b> 服務於 <b>%(0)s.</b>。\n"
 "網路可以透過 <b>%(1)s</b> 使用。"
 
-#: blueman/plugins/applet/PPPSupport.py:56
+#: blueman/plugins/applet/PPPSupport.py:80
 msgid "Provides basic support for connecting to the internet via DUN profile."
 msgstr "提供基本的撥號網路 (DUN) 支援，令用戶可以連線到網際網路。"
 
-#: blueman/plugins/applet/SerialManager.py:21
+#: blueman/plugins/applet/SerialManager.py:22
 msgid ""
 "Standard SPP profile connection handler, allows executing custom actions"
 msgstr "標準的 SPP 連線，允許使用者自訂連線。"
 
-#: blueman/plugins/applet/SerialManager.py:30
+#: blueman/plugins/applet/SerialManager.py:31
 msgid "Script to execute on connection"
 msgstr "在連線時執行指令稿"
 
-#: blueman/plugins/applet/SerialManager.py:31
+#: blueman/plugins/applet/SerialManager.py:32
 msgid ""
 "<span size=\"small\">The following arguments will be passed:\n"
 "Address, Name, service name, uuid16s, rfcomm node\n"
@@ -2151,21 +2512,21 @@ msgstr ""
 "\n"
 "以上裝置斷線則會送出 HUP 信號給指令稿</span>"
 
-#: blueman/plugins/applet/SerialManager.py:62
+#: blueman/plugins/applet/SerialManager.py:63
 msgid "Serial port connected"
 msgstr "串列埠連線"
 
-#: blueman/plugins/applet/SerialManager.py:63
+#: blueman/plugins/applet/SerialManager.py:64
 #, python-format
 msgid ""
 "Serial port service on device <b>%s</b> now will be available via <b>%s</b>"
 msgstr "串列埠服務在裝置 <b>%s</b> 現在可以透過 <b>%s</b> 使用。"
 
-#: blueman/plugins/applet/SerialManager.py:113
+#: blueman/plugins/applet/SerialManager.py:114
 msgid "Serial port connection script failed"
 msgstr "串列埠連線腳本失敗"
 
-#: blueman/plugins/applet/SerialManager.py:114
+#: blueman/plugins/applet/SerialManager.py:115
 #, python-format
 msgid ""
 "There was a problem launching script %s\n"
@@ -2174,57 +2535,56 @@ msgstr ""
 "啟動 \"%s\" 腳本發生錯誤\n"
 "%s"
 
-#: blueman/plugins/applet/PowerManager.py:13
+#: blueman/plugins/applet/PowerManager.py:31
 msgid "Controls Bluetooth adapter power states"
 msgstr "控制藍牙配接器的電源狀態"
 
-#: blueman/plugins/applet/PowerManager.py:26
+#: blueman/plugins/applet/PowerManager.py:44
 msgid "Auto power-on"
 msgstr "自動開啟電源"
 
-#: blueman/plugins/applet/PowerManager.py:27
+#: blueman/plugins/applet/PowerManager.py:45
 msgid "Automatically power on adapters"
 msgstr "自動開啟配接器電源"
 
-#: blueman/plugins/applet/PowerManager.py:36
-#: blueman/plugins/applet/PowerManager.py:164
+#: blueman/plugins/applet/PowerManager.py:55
+#: blueman/plugins/applet/PowerManager.py:171
 msgid "<b>Turn Bluetooth _Off</b>"
 msgstr "<b>關閉藍牙 (_O)</b>"
 
-#: blueman/plugins/applet/PowerManager.py:37
-#: blueman/plugins/applet/PowerManager.py:166
+#: blueman/plugins/applet/PowerManager.py:56
+#: blueman/plugins/applet/PowerManager.py:173
 msgid "Turn off all adapters"
 msgstr "開啟所有的裝置連線"
 
-#: blueman/plugins/applet/PowerManager.py:155
+#: blueman/plugins/applet/PowerManager.py:162
 msgid "<b>Turn Bluetooth _On</b>"
 msgstr "<b>開啟藍牙 (_O)</b>"
 
-#: blueman/plugins/applet/PowerManager.py:157
+#: blueman/plugins/applet/PowerManager.py:164
 msgid "Turn on all adapters"
 msgstr "開啟所有的裝置連線"
 
-#: blueman/plugins/applet/GameControllerWakelock.py:18
+#: blueman/plugins/applet/GameControllerWakelock.py:19
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."
 msgstr "當藍牙控制器已連線時，暫時暫停螢幕保護程式。"
 
-#: blueman/plugins/services/Network.py:22
-#: blueman/plugins/services/Network.py:46
+#: blueman/plugins/services/Network.py:25
 msgid "Network"
 msgstr "網路"
 
-#: blueman/plugins/services/Network.py:96
+#: blueman/plugins/services/Network.py:98
 msgid "Invalid IP address"
 msgstr "IP 位址無效"
 
-#: blueman/plugins/services/Network.py:101
+#: blueman/plugins/services/Network.py:103
 #, python-format
 msgid "IP address conflicts with interface %s which has the same address"
 msgstr "與相同位址的 %s 介面有 IP 位址衝突"
 
-#: blueman/plugins/services/Network.py:109
+#: blueman/plugins/services/Network.py:111
 #, python-format
 msgid ""
 "IP address overlaps with subnet of interface %s, which has the following "
@@ -2234,8 +2594,8 @@ msgstr ""
 "IP 位置與介面 %s 子網重疊，其有以下設定 %s/%s\n"
 "這可能會造成不正常的網路行為"
 
-#: blueman/plugins/services/Network.py:236
-#: blueman/plugins/services/Network.py:245
+#: blueman/plugins/services/Network.py:238
+#: blueman/plugins/services/Network.py:247
 msgid "Not currently supported with this setup"
 msgstr "目前無法支援此設置"
 
@@ -2249,40 +2609,26 @@ msgstr "小程式的傳送服務已關閉"
 
 #: data/blueman-adapters.desktop.in:4
 #, fuzzy
-#| msgid "Bluetooth Adapters"
 msgid "Set Bluetooth Adapter Properties"
 msgstr "藍牙配接器"
 
-#: data/blueman-adapters.desktop.in:6
-msgid "blueman-device"
-msgstr ""
-
 #: data/blueman.desktop.in:3
 #, fuzzy
-#| msgid "applet"
 msgid "Blueman Applet"
 msgstr "小程式"
 
 #: data/blueman.desktop.in:4 data/blueman-manager.desktop.in:4
 #, fuzzy
-#| msgid "Blueman is a GTK+ Bluetooth manager"
 msgid "Blueman Bluetooth Manager"
 msgstr "Blueman 是一個 GTK+ 的藍牙管理軟體"
 
-#: data/blueman.desktop.in:5 data/blueman-manager.desktop.in:5
-#: data/thunar-sendto-blueman.desktop.in:6
-msgid "blueman"
-msgstr ""
-
 #: data/blueman-manager.desktop.in:3
 #, fuzzy
-#| msgid "Bluetooth Enabled"
 msgid "Bluetooth Manager"
 msgstr "藍牙開啟"
 
 #: data/thunar-sendto-blueman.desktop.in:5
 #, fuzzy
-#| msgid "Bluetooth Devices"
 msgid "Bluetooth Device"
 msgstr "藍牙裝置"
 
@@ -2318,6 +2664,31 @@ msgstr "設定 RfKill 狀態"
 msgid "Setting RfKill State requires privileges"
 msgstr "設定 RfKill 狀態需要權限"
 
+#~ msgid "Enter PIN code"
+#~ msgstr "輸入 PIN 碼"
+
+#~ msgid "Enter passkey"
+#~ msgstr "輸入密鑰"
+
+#, python-format
+#~ msgid "Serial port connected to %s"
+#~ msgstr "串列埠連線到 %s"
+
+#~ msgid "palm"
+#~ msgstr "Palm"
+
+#~ msgid "isdn"
+#~ msgstr "整合服務數位網路 (ISDN)"
+
+#~ msgid "headset"
+#~ msgstr "耳機"
+
+#~ msgid "handsfree"
+#~ msgstr "免持裝置"
+
+#~ msgid "unknown"
+#~ msgstr "未知"
+
 #~ msgid "Bluetooth Devices"
 #~ msgstr "藍牙裝置"
 
@@ -2336,11 +2707,6 @@ msgstr "設定 RfKill 狀態需要權限"
 
 #~ msgid "_Remove..."
 #~ msgstr "移除...(_R)"
-
-#, fuzzy
-#~| msgid "Connect"
-#~ msgid "Generic Connect"
-#~ msgstr "連線"
 
 #~ msgid ""
 #~ "Toggles a platform Bluetooth killswitch when Bluetooth power state "


### PR DESCRIPTION
Having blueman.pot has its benefits like,

* Allow weblate to add new translations
* No more magic artifacts to avoid pot creation date/time commits
* No need to squash commits anymore.

I do understand it is not really necessary but it makes the integration with weblate easier.