### PR TITLE
ManagerDeviceMenu: Add shortcut key for generic connect

### DIFF
--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -250,7 +250,7 @@ class ManagerDeviceMenu(Gtk.Menu):
         show_generic_connect = self.show_generic_connect_calc(self.SelectedDevice['UUIDs'])
 
         if not row["connected"] and show_generic_connect:
-            connect_item = create_menuitem(_("_<b>Connect</b>"), "blueman")
+            connect_item = create_menuitem(_("_<b>_Connect</b>"), "blueman")
             connect_item.connect("activate", self.generic_connect, self.SelectedDevice, True)
             connect_item.props.tooltip_text = _("Connects auto connect profiles A2DP source, A2DP sink, and HID")
             connect_item.show()


### PR DESCRIPTION
This is an easy fix for generic connect but I for plugins for dun/nap this is a bit more involved. If there is a need I can look into that later. But for now let's at least fix this.