### PR TITLE
Remove misleading license statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Go to the [Weblate blueman project page](https://hosted.weblate.org/projects/blu
 
 ## License
 
-Except for most icons that are under a GPLv2 license and require GPLv2 for redistribution, all parts of the software are licensed under GPLv3 (or GPLv2) and allow redistribution under any later version.
+All parts of the software are licensed under GPLv3 (or GPLv2) and allow redistribution under any later version.


### PR DESCRIPTION
The conclusion we draw there seems to be questionable. The only hint about the icons' license is the license attribute in their code that points to https://creativecommons.org/licenses/GPL/2.0/ which redirects to https://www.gnu.org/licenses/old-licenses/gpl-2.0.html. Neither of the URLs distinguishes between version 2 with or without "any later version", see https://wiki.creativecommons.org/wiki/License_Properties#Source_Code_Licenses and https://www.gnu.org/licenses/#LicenseURLs. The license text says:

> If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation.

As the URLs do not distinguish, it remains unknown if a reference to them is intended to specify version 2 with or without "any later version".

After all, the icons were made by the original blueman authors who published blueman under GPL version 3, so it is rather clear that it was not their intention to allow redistribution of those icons under version 2 only and apart from that it is questionable anyway to what extent GPL is applicable to an icon as it is a software license.