### PR TITLE
Add auto-connect items to device menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Disconnect items in applet menu (plugin)
 * Desktop notifications on connect / disconnect (plugin)
 * Notifications with battery level for connecting devices (applet plugin)
+* Auto-connect settings for supported services
 
 ### Changes
 

--- a/blueman/Sdp.py
+++ b/blueman/Sdp.py
@@ -375,7 +375,7 @@ class ServiceUUID(UUID):
             except KeyError:
                 return _("Unknown")
         elif self.int == 0:
-            return _('Auto connect profiles')
+            return _('Audio and input profiles')
         else:
             return _('Proprietary')
 

--- a/blueman/config/AutoConnectConfig.py
+++ b/blueman/config/AutoConnectConfig.py
@@ -1,0 +1,29 @@
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+from blueman.bluez.Device import Device
+from blueman.main.Config import Config
+
+
+class AutoConnectConfig(Config):
+    def __init__(self) -> None:
+        super().__init__("org.blueman.plugins.autoconnect")
+
+    def bind_to_menuitem(self, item: Gtk.CheckMenuItem, device: Device, uuid: str) -> None:
+        data = device.get_object_path(), uuid
+
+        def switch(active: bool) -> None:
+            services = set(self["services"])
+            if active:
+                self["services"] = set(services).union({data})
+            else:
+                self["services"] = set(self["services"]).difference({data})
+
+        def on_change(config: AutoConnectConfig, key: str) -> None:
+            if key == "services":
+                item.props.active = data in set(config[key])
+
+        item.props.active = data in set(self["services"])
+        item.connect("toggled", lambda i: switch(i.props.active))
+        self.connect("changed", on_change)

--- a/blueman/config/Makefile.am
+++ b/blueman/config/Makefile.am
@@ -1,0 +1,13 @@
+bluemandir = $(pythondir)/blueman/config
+blueman_PYTHON = \
+	__init__.py \
+	AutoConnectConfig.py
+
+CLEANFILES = \
+	$(BUILT_SOURCES)
+
+DISTCLEANFILES = \
+	$(CLEANFILES)
+
+clean-local:
+	rm -rf *.pyc *.pyo

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -328,13 +328,16 @@ class ManagerDeviceMenu(Gtk.Menu):
             for it in sorted(disconnect_items, key=lambda i: i.position):
                 self.append(it.item)
 
-        if show_generic_connect or autoconnect_items:
+        config = AutoConnectConfig()
+        generic_service = ServiceUUID("00000000-0000-0000-0000-000000000000")
+        generic_autoconnect = (self.SelectedDevice.get_object_path(), str(generic_service)) in set(config["services"])
+
+        if row["connected"] or generic_autoconnect or autoconnect_items:
             self.append(self._create_header(_("<b>Auto-connect:</b>")))
 
-            if show_generic_connect:
-                service = ServiceUUID("00000000-0000-0000-0000-000000000000")
-                item = Gtk.CheckMenuItem(label=service.name)
-                AutoConnectConfig().bind_to_menuitem(item, self.SelectedDevice, str(service))
+            if row["connected"] or generic_autoconnect:
+                item = Gtk.CheckMenuItem(label=generic_service.name)
+                config.bind_to_menuitem(item, self.SelectedDevice, str(generic_service))
                 item.show()
                 self.append(item)
 

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -325,18 +325,13 @@ class ManagerDeviceMenu(Gtk.Menu):
             for it in sorted(disconnect_items, key=lambda i: i.position):
                 self.append(it.item)
 
-        if action_items and (connect_items or disconnect_items):
+        if show_generic_connect or connect_items or disconnect_items:
             item = Gtk.SeparatorMenuItem()
             item.show()
             self.append(item)
 
         for it in sorted(action_items, key=lambda i: i.position):
             self.append(it.item)
-
-        if items:
-            item = Gtk.SeparatorMenuItem()
-            item.show()
-            self.append(item)
 
         send_item = create_menuitem(_("Send a _File…"), "edit-copy")
         send_item.props.sensitive = False

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -7,6 +7,7 @@ from blueman.Functions import create_menuitem, e_
 from blueman.Service import Service
 from blueman.bluez.Network import AnyNetwork
 from blueman.bluez.Device import AnyDevice, Device
+from blueman.config.AutoConnectConfig import AutoConnectConfig
 from blueman.gui.manager.ManagerProgressbar import ManagerProgressbar
 from blueman.main.Builder import Builder
 from blueman.main.DBusProxies import AppletService, DBusProxyFailed
@@ -36,6 +37,7 @@ class DeviceMenuItem:
     class Group(Enum):
         CONNECT = auto()
         DISCONNECT = auto()
+        AUTOCONNECT = auto()
         ACTIONS = auto()
 
     def __init__(self, item: Gtk.MenuItem, group: Group, position: int):
@@ -313,6 +315,7 @@ class ManagerDeviceMenu(Gtk.Menu):
 
         connect_items = [i for i in items if i.group == DeviceMenuItem.Group.CONNECT]
         disconnect_items = [i for i in items if i.group == DeviceMenuItem.Group.DISCONNECT]
+        autoconnect_items = [item for item in items if item.group == DeviceMenuItem.Group.AUTOCONNECT]
         action_items = [i for i in items if i.group == DeviceMenuItem.Group.ACTIONS]
 
         if connect_items:
@@ -325,7 +328,20 @@ class ManagerDeviceMenu(Gtk.Menu):
             for it in sorted(disconnect_items, key=lambda i: i.position):
                 self.append(it.item)
 
-        if show_generic_connect or connect_items or disconnect_items:
+        if show_generic_connect or autoconnect_items:
+            self.append(self._create_header(_("<b>Auto-connect:</b>")))
+
+            if show_generic_connect:
+                service = ServiceUUID("00000000-0000-0000-0000-000000000000")
+                item = Gtk.CheckMenuItem(label=service.name)
+                AutoConnectConfig().bind_to_menuitem(item, self.SelectedDevice, str(service))
+                item.show()
+                self.append(item)
+
+            for it in sorted(autoconnect_items, key=lambda i: i.position):
+                self.append(it.item)
+
+        if show_generic_connect or connect_items or disconnect_items or autoconnect_items:
             item = Gtk.SeparatorMenuItem()
             item.show()
             self.append(item)

--- a/blueman/plugins/manager/Info.py
+++ b/blueman/plugins/manager/Info.py
@@ -11,7 +11,7 @@ from blueman.Functions import create_menuitem
 from blueman.Sdp import ServiceUUID
 from blueman.bluez.Device import Device
 from blueman.bluez.errors import BluezDBusException
-from blueman.gui.manager.ManagerDeviceMenu import MenuItemsProvider, ManagerDeviceMenu
+from blueman.gui.manager.ManagerDeviceMenu import MenuItemsProvider, ManagerDeviceMenu, DeviceMenuItem
 
 from blueman.plugins.ManagerPlugin import ManagerPlugin
 
@@ -116,11 +116,11 @@ def show_info(device: Device, parent: Gtk.Window) -> None:
 
 
 class Info(ManagerPlugin, MenuItemsProvider):
-    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[Tuple[Gtk.MenuItem, int]]:
+    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[DeviceMenuItem]:
         item = create_menuitem(_("_Info"), "dialog-information")
         item.props.tooltip_text = _("Show device information")
         _window = manager_menu.get_toplevel()
         assert isinstance(_window, Gtk.Window)
         window = _window  # https://github.com/python/mypy/issues/2608
         item.connect('activate', lambda x: show_info(device, window))
-        return [(item, 400)]
+        return [DeviceMenuItem(item, DeviceMenuItem.Group.ACTIONS, 400)]

--- a/blueman/plugins/manager/Notes.py
+++ b/blueman/plugins/manager/Notes.py
@@ -1,11 +1,11 @@
 import datetime
 from gettext import gettext as _
 from tempfile import NamedTemporaryFile
-from typing import List, Tuple
+from typing import List
 
 from blueman.Functions import create_menuitem, launch
 from blueman.bluez.Device import Device
-from blueman.gui.manager.ManagerDeviceMenu import MenuItemsProvider, ManagerDeviceMenu
+from blueman.gui.manager.ManagerDeviceMenu import MenuItemsProvider, ManagerDeviceMenu, DeviceMenuItem
 from blueman.main.Builder import Builder
 from blueman.plugins.ManagerPlugin import ManagerPlugin
 
@@ -47,11 +47,11 @@ def send_note(device: Device, parent: Gtk.Window) -> None:
 
 
 class Notes(ManagerPlugin, MenuItemsProvider):
-    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[Tuple[Gtk.MenuItem, int]]:
+    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[DeviceMenuItem]:
         item = create_menuitem(_("Send _note"), "dialog-information")
         item.props.tooltip_text = _("Send a text note")
         _window = manager_menu.get_toplevel()
         assert isinstance(_window, Gtk.Window)
         window = _window  # https://github.com/python/mypy/issues/2608
         item.connect('activate', lambda x: send_note(device, window))
-        return [(item, 500)]
+        return [DeviceMenuItem(item, DeviceMenuItem.Group.ACTIONS, 500)]

--- a/blueman/plugins/manager/PulseAudioProfile.py
+++ b/blueman/plugins/manager/PulseAudioProfile.py
@@ -1,11 +1,11 @@
 from gettext import gettext as _
 import logging
-from typing import Dict, List, TYPE_CHECKING, Tuple, Mapping, Sequence
+from typing import Dict, List, TYPE_CHECKING, Mapping, Sequence
 
 from blueman.bluez.Device import Device
 from blueman.plugins.ManagerPlugin import ManagerPlugin
 from blueman.main.PulseAudioUtils import PulseAudioUtils, EventType
-from blueman.gui.manager.ManagerDeviceMenu import ManagerDeviceMenu, MenuItemsProvider
+from blueman.gui.manager.ManagerDeviceMenu import ManagerDeviceMenu, MenuItemsProvider, DeviceMenuItem
 from blueman.gui.MessageArea import MessageArea
 from blueman.Functions import create_menuitem
 from blueman.Sdp import AUDIO_SOURCE_SVCLASS_ID, AUDIO_SINK_SVCLASS_ID, ServiceUUID
@@ -111,7 +111,7 @@ class PulseAudioProfile(ManagerPlugin, MenuItemsProvider):
             item.set_submenu(sub)
             item.show()
 
-    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[Tuple[Gtk.MenuItem, int]]:
+    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[DeviceMenuItem]:
         audio_source = False
         for uuid in device['UUIDs']:
             if ServiceUUID(uuid).short_uuid in (AUDIO_SOURCE_SVCLASS_ID, AUDIO_SINK_SVCLASS_ID):
@@ -136,4 +136,4 @@ class PulseAudioProfile(ManagerPlugin, MenuItemsProvider):
         else:
             return []
 
-        return [(item, 300)]
+        return [DeviceMenuItem(item, DeviceMenuItem.Group.ACTIONS, 300)]

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -3,6 +3,7 @@ from typing import List
 import cairo
 
 from blueman.bluez.Device import Device
+from blueman.config.AutoConnectConfig import AutoConnectConfig
 from blueman.gui.manager.ManagerDeviceMenu import MenuItemsProvider, ManagerDeviceMenu, DeviceMenuItem
 from blueman.plugins.ManagerPlugin import ManagerPlugin
 from blueman.Functions import create_menuitem
@@ -62,6 +63,14 @@ class Services(ManagerPlugin, MenuItemsProvider):
                 item.connect("activate", manager_menu.on_disconnect, service, instance.port)
                 items.append(DeviceMenuItem(item, DeviceMenuItem.Group.DISCONNECT, service.priority + 100))
                 item.show()
+
+        if services:
+            config = AutoConnectConfig()
+            for service in services:
+                item = Gtk.CheckMenuItem(label=service.name)
+                config.bind_to_menuitem(item, device, service.uuid)
+                item.show()
+                items.append(DeviceMenuItem(item, DeviceMenuItem.Group.AUTOCONNECT, service.priority))
 
         for action, priority in set((action, service.priority)
                                     for service in services for action in service.common_actions

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -66,11 +66,13 @@ class Services(ManagerPlugin, MenuItemsProvider):
 
         if services:
             config = AutoConnectConfig()
+            autoconnect_services = set(config["services"])
             for service in services:
-                item = Gtk.CheckMenuItem(label=service.name)
-                config.bind_to_menuitem(item, device, service.uuid)
-                item.show()
-                items.append(DeviceMenuItem(item, DeviceMenuItem.Group.AUTOCONNECT, service.priority))
+                if service.connected_instances or (device.get_object_path(), service.uuid) in autoconnect_services:
+                    item = Gtk.CheckMenuItem(label=service.name)
+                    config.bind_to_menuitem(item, device, service.uuid)
+                    item.show()
+                    items.append(DeviceMenuItem(item, DeviceMenuItem.Group.AUTOCONNECT, service.priority))
 
         for action, priority in set((action, service.priority)
                                     for service in services for action in service.common_actions

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -63,7 +63,6 @@ blueman/plugins/manager/Info.py
 blueman/plugins/manager/Notes.py
 blueman/plugins/manager/PulseAudioProfile.py
 blueman/plugins/manager/__init__.py
-blueman/plugins/manager/Services.py
 blueman/plugins/ManagerPlugin.py
 blueman/plugins/BasePlugin.py
 blueman/plugins/ServicePlugin.py

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:355
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:350
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Pair"
 msgstr ""
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:373
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:368
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "Trust"
 msgstr ""
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:406
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:401
 msgid "Remove this device from the known devices list"
 msgstr ""
 
@@ -662,27 +662,27 @@ msgstr ""
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:341
+#: blueman/gui/manager/ManagerDeviceMenu.py:336
 msgid "Send a _File…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:354
+#: blueman/gui/manager/ManagerDeviceMenu.py:349
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:364
+#: blueman/gui/manager/ManagerDeviceMenu.py:359
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:369
+#: blueman/gui/manager/ManagerDeviceMenu.py:364
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:393
+#: blueman/gui/manager/ManagerDeviceMenu.py:388
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:402
+#: blueman/gui/manager/ManagerDeviceMenu.py:397
 msgid "_Remove…"
 msgstr ""
 

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:369
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:355
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Pair"
 msgstr ""
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:387
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:373
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "Trust"
 msgstr ""
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:420
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:406
 msgid "Remove this device from the known devices list"
 msgstr ""
 
@@ -593,96 +593,96 @@ msgstr ""
 msgid "Very High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:118
-#: blueman/gui/manager/ManagerDeviceMenu.py:207
+#: blueman/gui/manager/ManagerDeviceMenu.py:129
+#: blueman/gui/manager/ManagerDeviceMenu.py:218
 msgid "Success!"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:125
-#: blueman/gui/manager/ManagerDeviceMenu.py:201
+#: blueman/gui/manager/ManagerDeviceMenu.py:136
+#: blueman/gui/manager/ManagerDeviceMenu.py:212
 msgid "Failed"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:130
-#: blueman/gui/manager/ManagerDeviceMenu.py:196
+#: blueman/gui/manager/ManagerDeviceMenu.py:141
+#: blueman/gui/manager/ManagerDeviceMenu.py:207
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:132
-#: blueman/gui/manager/ManagerDeviceMenu.py:214
+#: blueman/gui/manager/ManagerDeviceMenu.py:143
+#: blueman/gui/manager/ManagerDeviceMenu.py:225
 msgid "Connecting…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:153
+#: blueman/gui/manager/ManagerDeviceMenu.py:164
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:181
+#: blueman/gui/manager/ManagerDeviceMenu.py:192
 msgid "No audio endpoints registered"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:185
+#: blueman/gui/manager/ManagerDeviceMenu.py:196
 msgid "Input/output error"
 msgstr ""
 
 #. EHOSTDOWN (Bluetooth errors 0x04 (Page Timeout) or 0x3c (Advertising Timeout))
-#: blueman/gui/manager/ManagerDeviceMenu.py:188
+#: blueman/gui/manager/ManagerDeviceMenu.py:199
 msgid "Device did not respond"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:193
+#: blueman/gui/manager/ManagerDeviceMenu.py:204
 msgid "Resource temporarily unavailable"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:221
+#: blueman/gui/manager/ManagerDeviceMenu.py:232
 msgid "Disconnecting…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:288
+#: blueman/gui/manager/ManagerDeviceMenu.py:297
 msgid "_<b>_Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:290
+#: blueman/gui/manager/ManagerDeviceMenu.py:299
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:294
+#: blueman/gui/manager/ManagerDeviceMenu.py:303
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:295
+#: blueman/gui/manager/ManagerDeviceMenu.py:304
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:323
+#: blueman/gui/manager/ManagerDeviceMenu.py:319
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:335
+#: blueman/gui/manager/ManagerDeviceMenu.py:324
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:355
+#: blueman/gui/manager/ManagerDeviceMenu.py:341
 msgid "Send a _File…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:368
+#: blueman/gui/manager/ManagerDeviceMenu.py:354
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:378
+#: blueman/gui/manager/ManagerDeviceMenu.py:364
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:383
+#: blueman/gui/manager/ManagerDeviceMenu.py:369
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:407
+#: blueman/gui/manager/ManagerDeviceMenu.py:393
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:416
+#: blueman/gui/manager/ManagerDeviceMenu.py:402
 msgid "_Remove…"
 msgstr ""
 

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:350
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:366
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Pair"
 msgstr ""
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:368
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:384
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "Trust"
 msgstr ""
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:401
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:417
 msgid "Remove this device from the known devices list"
 msgstr ""
 
@@ -593,96 +593,100 @@ msgstr ""
 msgid "Very High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:129
-#: blueman/gui/manager/ManagerDeviceMenu.py:218
+#: blueman/gui/manager/ManagerDeviceMenu.py:131
+#: blueman/gui/manager/ManagerDeviceMenu.py:220
 msgid "Success!"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:136
-#: blueman/gui/manager/ManagerDeviceMenu.py:212
+#: blueman/gui/manager/ManagerDeviceMenu.py:138
+#: blueman/gui/manager/ManagerDeviceMenu.py:214
 msgid "Failed"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:141
-#: blueman/gui/manager/ManagerDeviceMenu.py:207
+#: blueman/gui/manager/ManagerDeviceMenu.py:143
+#: blueman/gui/manager/ManagerDeviceMenu.py:209
 msgid "Connection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:143
-#: blueman/gui/manager/ManagerDeviceMenu.py:225
+#: blueman/gui/manager/ManagerDeviceMenu.py:145
+#: blueman/gui/manager/ManagerDeviceMenu.py:227
 msgid "Connecting…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:164
+#: blueman/gui/manager/ManagerDeviceMenu.py:166
 msgid "Disconnection Failed: "
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:192
+#: blueman/gui/manager/ManagerDeviceMenu.py:194
 msgid "No audio endpoints registered"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:196
+#: blueman/gui/manager/ManagerDeviceMenu.py:198
 msgid "Input/output error"
 msgstr ""
 
 #. EHOSTDOWN (Bluetooth errors 0x04 (Page Timeout) or 0x3c (Advertising Timeout))
-#: blueman/gui/manager/ManagerDeviceMenu.py:199
+#: blueman/gui/manager/ManagerDeviceMenu.py:201
 msgid "Device did not respond"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:204
+#: blueman/gui/manager/ManagerDeviceMenu.py:206
 msgid "Resource temporarily unavailable"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:232
+#: blueman/gui/manager/ManagerDeviceMenu.py:234
 msgid "Disconnecting…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:297
+#: blueman/gui/manager/ManagerDeviceMenu.py:299
 msgid "_<b>_Connect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:299
+#: blueman/gui/manager/ManagerDeviceMenu.py:301
 msgid "Connects auto connect profiles A2DP source, A2DP sink, and HID"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:303
+#: blueman/gui/manager/ManagerDeviceMenu.py:305
 msgid "_<b>Disconnect</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:304
+#: blueman/gui/manager/ManagerDeviceMenu.py:306
 msgid "Forcefully disconnect the device"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:319
+#: blueman/gui/manager/ManagerDeviceMenu.py:322
 msgid "<b>Connect To:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:324
+#: blueman/gui/manager/ManagerDeviceMenu.py:327
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:336
+#: blueman/gui/manager/ManagerDeviceMenu.py:332
+msgid "<b>Auto-connect:</b>"
+msgstr ""
+
+#: blueman/gui/manager/ManagerDeviceMenu.py:352
 msgid "Send a _File…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:349
+#: blueman/gui/manager/ManagerDeviceMenu.py:365
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:359
+#: blueman/gui/manager/ManagerDeviceMenu.py:375
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:364
+#: blueman/gui/manager/ManagerDeviceMenu.py:380
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:388
+#: blueman/gui/manager/ManagerDeviceMenu.py:404
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:397
+#: blueman/gui/manager/ManagerDeviceMenu.py:413
 msgid "_Remove…"
 msgstr ""
 
@@ -1927,7 +1931,7 @@ msgid "Report Reference"
 msgstr ""
 
 #: blueman/Sdp.py:378
-msgid "Auto connect profiles"
+msgid "Audio and input profiles"
 msgstr ""
 
 #: blueman/Sdp.py:380

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:366
+#: data/ui/manager-main.ui:121 blueman/gui/manager/ManagerDeviceMenu.py:369
 msgid "Create pairing with the device"
 msgstr ""
 
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Pair"
 msgstr ""
 
-#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:384
+#: data/ui/manager-main.ui:135 blueman/gui/manager/ManagerDeviceMenu.py:387
 msgid "Mark/Unmark this device as trusted"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "Trust"
 msgstr ""
 
-#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:417
+#: data/ui/manager-main.ui:149 blueman/gui/manager/ManagerDeviceMenu.py:420
 msgid "Remove this device from the known devices list"
 msgstr ""
 
@@ -662,31 +662,31 @@ msgstr ""
 msgid "<b>Disconnect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:332
+#: blueman/gui/manager/ManagerDeviceMenu.py:336
 msgid "<b>Auto-connect:</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:352
+#: blueman/gui/manager/ManagerDeviceMenu.py:355
 msgid "Send a _File…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:365
+#: blueman/gui/manager/ManagerDeviceMenu.py:368
 msgid "_Pair"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:375
+#: blueman/gui/manager/ManagerDeviceMenu.py:378
 msgid "_Trust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:380
+#: blueman/gui/manager/ManagerDeviceMenu.py:383
 msgid "_Untrust"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:404
+#: blueman/gui/manager/ManagerDeviceMenu.py:407
 msgid "R_ename device…"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceMenu.py:413
+#: blueman/gui/manager/ManagerDeviceMenu.py:416
 msgid "_Remove…"
 msgstr ""
 

--- a/stubs/gi/repository/Gtk.pyi
+++ b/stubs/gi/repository/Gtk.pyi
@@ -7861,6 +7861,31 @@ class ListBoxRow(Bin, Actionable):
 class MenuItem(Bin, Actionable, Activatable):
     bin: Bin
 
+    def __init__(self,
+        *,
+        label: str = "",
+        use_underline: bool = False,
+        # Container
+        border_width: int = 0,
+        # Widget
+        halign: Align = Align.FILL,
+        has_tooltip: bool = False,
+        height_request: int = -1,
+        hexpand: bool = False,
+        margin: int = 0,
+        margin_left: int = 0,
+        name: typing.Optional[str] = None,
+        opacity: float = 1,
+        parent: typing.Optional[Container] = None,
+        receives_default: bool = False,
+        sensitive: bool = True,
+        tooltip_text: typing.Optional[str] = None,
+        valign: Align = Align.FILL,
+        vexpand: bool = False,
+        visible: bool = False,
+        width_request: int = -1,
+    ) -> None: ...
+
     def activate(self) -> None: ...  # type: ignore
 
     def deselect(self) -> None: ...
@@ -9337,6 +9362,9 @@ class CheckMenuItem(MenuItem):
 
     def __init__(self,
         *,
+        # MenuItem
+        label: str = "",
+        use_underline: bool = False,
         # Container
         border_width: int = 0,
         # Widget
@@ -9392,8 +9420,28 @@ class ImageMenuItem(MenuItem):
     def __init__(self,
         *,
         image: typing.Optional[Widget] = None,
+        # MenuItem
         label: str = "",
-        use_underline: bool = False
+        use_underline: bool = False,
+        # Container
+        border_width: int = 0,
+        # Widget
+        halign: Align = Align.FILL,
+        has_tooltip: bool = False,
+        height_request: int = -1,
+        hexpand: bool = False,
+        margin: int = 0,
+        margin_left: int = 0,
+        name: typing.Optional[str] = None,
+        opacity: float = 1,
+        parent: typing.Optional[Container] = None,
+        receives_default: bool = False,
+        sensitive: bool = True,
+        tooltip_text: typing.Optional[str] = None,
+        valign: Align = Align.FILL,
+        vexpand: bool = False,
+        visible: bool = False,
+        width_request: int = -1,
     ) -> None: ...
 
     def get_always_show_image(self) -> builtins.bool: ...


### PR DESCRIPTION
The first four commits are refactoring and improvements for the service interface and menu handling.

Then comes the actual implementation for https://github.com/blueman-project/blueman/issues/239#issuecomment-375131266 - finally :tada:. As the wizard is no more, menu items seem like the only logical place to do this. The last commit is kind of an optional idea to keep the menu lean, but I think it makes sense. The only downside I see is that people might not open the menu a second time after connecting a service when looking for a way to auto-connect.