### PR TITLE
Fix GenericList.selected

### DIFF
--- a/blueman/gui/GenericList.py
+++ b/blueman/gui/GenericList.py
@@ -59,9 +59,8 @@ class GenericList(Gtk.TreeView):
             self.columns[row["id"]] = column
             self.append_column(column)
 
-    def selected(self) -> Gtk.TreeIter:
+    def selected(self) -> Optional[Gtk.TreeIter]:
         (model, tree_iter) = self.selection.get_selected()
-        assert tree_iter is not None
         return tree_iter
 
     def delete(self, iterid: Union[Gtk.TreeIter, Gtk.TreePath, int, str]) -> bool:
@@ -158,7 +157,7 @@ class GenericList(Gtk.TreeView):
     def clear(self) -> None:
         self.liststore.clear()
 
-    def compare(self, iter_a: Gtk.TreeIter, iter_b: Gtk.TreeIter) -> bool:
+    def compare(self, iter_a: Optional[Gtk.TreeIter], iter_b: Optional[Gtk.TreeIter]) -> bool:
         if iter_a is not None and iter_b is not None:
             model = self.get_model()
             assert model is not None

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -167,7 +167,9 @@ class ManagerDeviceList(DeviceList):
 
         window = self.get_window()
         assert window is not None
-        rect = self.get_cell_area(self.liststore.get_path(self.selected()), self.get_column(1))
+        selected = self.selected()
+        assert selected is not None
+        rect = self.get_cell_area(self.liststore.get_path(selected), self.get_column(1))
         self.menu.popup_at_rect(window, rect, Gdk.Gravity.CENTER, Gdk.Gravity.NORTH)
 
         return True

--- a/blueman/main/Services.py
+++ b/blueman/main/Services.py
@@ -134,6 +134,7 @@ class BluemanServices(Gtk.Application):
 
     def on_selection_changed(self, _selection: Gtk.TreeSelection) -> None:
         tree_iter = self.List.selected()
+        assert tree_iter
         if self.List.get_cursor()[0]:
             # GtkTreePath returns row when used as string
             self.Config["services-last-item"] = int(str(self.List.get_cursor()[0]))


### PR DESCRIPTION
The TreeIter can actually be None and GenericList.compare can actually handle that while ManagerDeviceList._on_popup_menu and BluemanServices.on_selection_changed expect a proper TreeIter.

Fixes #1420