### PR TITLE
Streamline translator credits

### DIFF
--- a/blueman/gui/CommonUi.py
+++ b/blueman/gui/CommonUi.py
@@ -55,7 +55,6 @@ def show_about_dialog(app_name: str, run: bool = True, parent: Optional[Gtk.Wind
     about.set_transient_for(parent)
     about.set_name(app_name)
     about.set_version(VERSION)
-    about.set_translator_credits(_("translator-credits"))
     about.set_copyright('Copyright © 2008 Valmantas Palikša\n'
                         'Copyright © 2008 Tadas Dailyda\n'
                         f'Copyright © 2008 - {datetime.now().year} blueman project'

--- a/po/af.po
+++ b/po/af.po
@@ -2,7 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
+# Valmantas Palikša https://launchpad.net/~walmis
+# maiatoday https://launchpad.net/~maiatoday
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
@@ -707,13 +708,6 @@ msgstr ""
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  maiatoday https://launchpad.net/~maiatoday"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/am.po
+++ b/po/am.po
@@ -723,12 +723,6 @@ msgstr "አካል ይምረጡ"
 msgid "More"
 msgstr "ተጨማሪ"
 
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"ምስጋና ለተርጓሚዎች:\n"
-"  samson https://launchpad.net/~sambelet"
-
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman is a GTK+ የ ብሉቱዝ አስተዳዳሪ"

--- a/po/ar.po
+++ b/po/ar.po
@@ -13,6 +13,7 @@
 # Mubarak Qahtani <abu-q76@hotmail.com>, 2016-2017
 # مهدي السطيفي <chinoune.mehdi@gmail.com>, 2014-2015
 # وجدي أبو سلطان, 2016
+# Yaron Shahrabani <sh.yaron@gmail.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/ar.po
+++ b/po/ar.po
@@ -6,10 +6,8 @@
 # مصعب الزعبي <moceap@hotmail.com>
 # alibacha19 <alibacha19@gmail.com>, 2015
 # El Acheche ANIS <elachecheanis@gmail.com>, 2014
-# El Acheche ANIS <elachecheanis@gmail.com>, 2014
 # 353299c7e7800cea9c13ae6ee14dbf9d, 2016
 # Hayder Majid <cteehayder@gmail.com>, 2016
-# مهدي السطيفي <chinoune.mehdi@gmail.com>, 2014
 # Mubarak Qahtani <abu-q76@hotmail.com>, 2016-2017
 # مهدي السطيفي <chinoune.mehdi@gmail.com>, 2014-2015
 # وجدي أبو سلطان, 2016

--- a/po/ar.po
+++ b/po/ar.po
@@ -2,6 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# فريق عيون العرب للترجمة http://www.arabeyes.org
+# مصعب الزعبي <moceap@hotmail.com>
 # alibacha19 <alibacha19@gmail.com>, 2015
 # El Acheche ANIS <elachecheanis@gmail.com>, 2014
 # El Acheche ANIS <elachecheanis@gmail.com>, 2014
@@ -736,12 +738,6 @@ msgstr "حدّد جهازا"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "أكثر"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"فريق عيون العرب للترجمة http://www.arabeyes.org :\n"
-"مصعب الزعبي\t<moceap@hotmail.com>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/ast.po
+++ b/po/ast.po
@@ -2,6 +2,7 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Softastur <www.softastur.org>
 # enolp <enolp@softastur.org>, 2014-2015
 # Ḷḷumex03, 2014
 # Xuacu Saturio <xuacusk8@gmail.com>, 2014
@@ -723,10 +724,6 @@ msgstr "Esbillar preséu"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Más"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr "Softastur <www.softastur.org>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/be.po
+++ b/po/be.po
@@ -2,8 +2,9 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2009,2014-2015
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2009,2014-2015, 2016
+# Iryna Nikanchuk https://launchpad.net/~unetriste
+# Mikola Tsekhan https://launchpad.net/~tsekhan
+# Mihas' Varantsou <meequz@gmail.com>
 # Zmicer Turok <nashtlumach@gmail.com>, 2019, 2020.
 msgid ""
 msgstr ""
@@ -720,15 +721,6 @@ msgstr "Абярыце прыладу"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Яшчэ"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"Iryna Nikanchuk https://launchpad.net/~unetriste\n"
-"Mikola Tsekhan https://launchpad.net/~tsekhan\n"
-"Others:\n"
-"Mihas' Varantsou <meequz@gmail.com>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/bg.po
+++ b/po/bg.po
@@ -2,8 +2,12 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Alex Stanev https://launchpad.net/~realender
+# Geno Roupsky https://launchpad.net/~groupsky
+# Svetoslav Stefanov https://launchpad.net/~svetlisashkov
+# Valmantas Palikša https://launchpad.net/~walmis
+# Vladimir Kolev https://launchpad.net/~vladimir.kolev
 # breaker loc <breaker9loc@gmail.com>, 2014
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # Замфир Йончев <zamfir.yonchev@gmail.com>, 2016
 # Любомир Василев, 2016-2017
 msgid ""
@@ -729,16 +733,6 @@ msgstr "Избор на устройство"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Още"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Alex Stanev https://launchpad.net/~realender\n"
-"  Geno Roupsky https://launchpad.net/~groupsky\n"
-"  Svetoslav Stefanov https://launchpad.net/~svetlisashkov\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Vladimir Kolev https://launchpad.net/~vladimir.kolev"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman 2.2\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-11-09 00:15+0100\n"
+"POT-Creation-Date: 2020-11-24 00:51+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -219,8 +219,8 @@ msgstr ""
 
 #. translators: device class
 #: data/ui/applet-plugins-widget.ui:161
-#: blueman/gui/manager/ManagerDeviceList.py:305
-#: blueman/gui/manager/ManagerDeviceList.py:307 blueman/DeviceClass.py:86
+#: blueman/gui/manager/ManagerDeviceList.py:308
+#: blueman/gui/manager/ManagerDeviceList.py:310 blueman/DeviceClass.py:86
 #: blueman/DeviceClass.py:114 blueman/DeviceClass.py:168
 #: blueman/DeviceClass.py:242 blueman/DeviceClass.py:291 blueman/Sdp.py:376
 #: blueman/plugins/applet/NetUsage.py:209
@@ -330,7 +330,7 @@ msgstr ""
 msgid "Adapter Preferences"
 msgstr ""
 
-#: blueman/main/Manager.py:233 blueman/gui/manager/ManagerDeviceList.py:135
+#: blueman/main/Manager.py:233 blueman/gui/manager/ManagerDeviceList.py:138
 #: blueman/plugins/applet/StandardItems.py:72
 msgid "File Sender"
 msgstr ""
@@ -540,56 +540,56 @@ msgid "_Exit"
 msgstr ""
 
 #. translators: device class
-#: blueman/gui/manager/ManagerDeviceList.py:274
-#: blueman/gui/manager/ManagerDeviceList.py:305 blueman/DeviceClass.py:24
+#: blueman/gui/manager/ManagerDeviceList.py:277
+#: blueman/gui/manager/ManagerDeviceList.py:308 blueman/DeviceClass.py:24
 #: blueman/DeviceClass.py:29 blueman/DeviceClass.py:46
 #: blueman/DeviceClass.py:80 blueman/DeviceClass.py:121
 msgid "Uncategorized"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:468
+#: blueman/gui/manager/ManagerDeviceList.py:474
 msgid "<b>Trusted and Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:470
+#: blueman/gui/manager/ManagerDeviceList.py:476
 msgid "<b>Paired</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:472
+#: blueman/gui/manager/ManagerDeviceList.py:478
 msgid "<b>Trusted</b>"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:493
+#: blueman/gui/manager/ManagerDeviceList.py:499
 msgid "Poor"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:495
-#: blueman/gui/manager/ManagerDeviceList.py:506
+#: blueman/gui/manager/ManagerDeviceList.py:501
+#: blueman/gui/manager/ManagerDeviceList.py:512
 msgid "Sub-optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:497
-#: blueman/gui/manager/ManagerDeviceList.py:508
+#: blueman/gui/manager/ManagerDeviceList.py:503
+#: blueman/gui/manager/ManagerDeviceList.py:514
 msgid "Optimal"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:499
+#: blueman/gui/manager/ManagerDeviceList.py:505
 msgid "Much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:501
+#: blueman/gui/manager/ManagerDeviceList.py:507
 msgid "Too much"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:504
+#: blueman/gui/manager/ManagerDeviceList.py:510
 msgid "Low"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:510
+#: blueman/gui/manager/ManagerDeviceList.py:516
 msgid "High"
 msgstr ""
 
-#: blueman/gui/manager/ManagerDeviceList.py:512
+#: blueman/gui/manager/ManagerDeviceList.py:518
 msgid "Very High"
 msgstr ""
 
@@ -701,11 +701,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-
-#: blueman/gui/CommonUi.py:63
+#: blueman/gui/CommonUi.py:62
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""
 

--- a/po/bs.po
+++ b/po/bs.po
@@ -2,7 +2,9 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
+# Miro Glavić https://launchpad.net/~klek
+# Sanel https://launchpad.net/~sanel-bih
+# kenan3008 https://launchpad.net/~kenan3008
 # Sky Lion <xskylionx@gmail.com>, 2016
 msgid ""
 msgstr ""
@@ -719,14 +721,6 @@ msgstr "Odaberi Uređaj"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Još"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Miro Glavić https://launchpad.net/~klek\n"
-"  Sanel https://launchpad.net/~sanel-bih\n"
-"  kenan3008 https://launchpad.net/~kenan3008"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/ca.po
+++ b/po/ca.po
@@ -4,6 +4,7 @@
 # Translators:
 # Francesc Famadas <kiski97@gmail.com>, 2015
 # Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2015-2019
+# Sergi Almacellas Abellana <sergi@koolpi.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -2,10 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
-# Francesc Famadas, 2015
-# Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2016-2019
-# Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2015-2016
+# Francesc Famadas <kiski97@gmail.com>, 2015
+# Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2015-2019
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
@@ -736,12 +734,6 @@ msgstr "Selecciona el dispositiu"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Més"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Francesc Famadas <kiski97@gmail.com>\n"
-"Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/cs.po
+++ b/po/cs.po
@@ -18,19 +18,14 @@
 # clever_fox https://launchpad.net/~clever-fox
 # schunka https://launchpad.net/~schunka
 # xills pills https://launchpad.net/~adamturan
-# Honza K. <honza889@gmail.com>, 2014
-# jakubtalich, 2014
 # jakubtalich, 2014
 # Honza K. <honza889@gmail.com>, 2014
 # LiberteCzech <liberte.czech@gmail.com>, 2015,2017
 # Lucas Lommer <drom@kdyne.net>, 2020
 # Lukáš Kvídera <lukas.kvidera@seznam.cz>, 2014
-# LiberteCzech <liberte.czech@gmail.com>, 2015,2017
-# LiberteCzech <liberte.czech@gmail.com>, 2015
 # Michal Procházka <mich.procha@seznam.cz>, 2014
 # Michal <sinope@seznam.cz>, 2014
 # Pavel Borecki <pavel.borecki@gmail.com>, 2019
-# Stanislav Kučera <inactive+kacernator@transifex.com>, 2015
 # Stanislav Kučera <inactive+kacernator@transifex.com>, 2015
 msgid ""
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -2,7 +2,22 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
+# 6n64 https://launchpad.net/~6n
+# Brbla80 https://launchpad.net/~brbla
+# Dr.Silenec https://launchpad.net/~dr-silenec
+# DrakecZ https://launchpad.net/~drakec48
+# Horanus https://launchpad.net/~val-hon
+# Jakub Žáček https://launchpad.net/~dawon
+# Kamil Páral https://launchpad.net/~kamil.paral
+# Kuvaly [LCT] https://launchpad.net/~kuvaly
+# Mr. Ego https://launchpad.net/~pavel-benak
+# Pepa https://launchpad.net/~lhotskypepa
+# Roman Horník https://launchpad.net/~roman.hornik
+# Valmantas Palikša https://launchpad.net/~walmis
+# Vladimír \"Thang\" Kincl https://launchpad.net/~thang
+# clever_fox https://launchpad.net/~clever-fox
+# schunka https://launchpad.net/~schunka
+# xills pills https://launchpad.net/~adamturan
 # Honza K. <honza889@gmail.com>, 2014
 # jakubtalich, 2014
 # jakubtalich, 2014
@@ -748,27 +763,6 @@ msgstr "Vybrat zařízení"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Více"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  6n64 https://launchpad.net/~6n\n"
-"  Brbla80 https://launchpad.net/~brbla\n"
-"  Dr.Silenec https://launchpad.net/~dr-silenec\n"
-"  DrakecZ https://launchpad.net/~drakec48\n"
-"  Horanus https://launchpad.net/~val-hon\n"
-"  Jakub Žáček https://launchpad.net/~dawon\n"
-"  Kamil Páral https://launchpad.net/~kamil.paral\n"
-"  Kuvaly [LCT] https://launchpad.net/~kuvaly\n"
-"  Mr. Ego https://launchpad.net/~pavel-benak\n"
-"  Pepa https://launchpad.net/~lhotskypepa\n"
-"  Roman Horník https://launchpad.net/~roman.hornik\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Vladimír \"Thang\" Kincl https://launchpad.net/~thang\n"
-"  clever_fox https://launchpad.net/~clever-fox\n"
-"  schunka https://launchpad.net/~schunka\n"
-"  xills pills https://launchpad.net/~adamturan"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/cy.po
+++ b/po/cy.po
@@ -2,8 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Cadan ap Tomos https://launchpad.net/~cadz123
 # ciaran, 2014-2015
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2009
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
@@ -722,12 +722,6 @@ msgstr ""
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mwy"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Cadan ap Tomos https://launchpad.net/~cadz123"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/da.po
+++ b/po/da.po
@@ -2,8 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Dansk-gruppen <dansk@dansk-gruppen.dk>
 # Allan Nordhøy <epost@anotheragency.no>, 2016
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
 # Joe Hansen <joedalton2@yahoo.dk>, 2014-2017,2019
 msgid ""
 msgstr ""
@@ -728,14 +728,6 @@ msgstr "Vælg enhed"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mere"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Joe Hansen, 2014.\n"
-"\n"
-"Dansk-gruppen <dansk@dansk-gruppen.dk>\n"
-"Mere info: http://www.dansk-gruppen.dk"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/de.po
+++ b/po/de.po
@@ -48,6 +48,7 @@
 # Tobias Bannert <tobannert@gmail.com>, 2014-2015,2017
 # jugendhacker <jugendhacker@gmail.com>, 2020.
 # Christopher Schramm <github@cschramm.eu>, 2020.
+# J. Lavoie <j.lavoie@net-c.ca>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/de.po
+++ b/po/de.po
@@ -2,12 +2,44 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Andreas Kohlbach https://launchpad.net/~ank
+# Bernhard Gehl https://launchpad.net/~bernhard-gehl
+# Felix Möller https://launchpad.net/~felix-derklecks
+# Jochen Kemnade https://launchpad.net/~jochenkemnade
+# JonasL https://launchpad.net/~jonas-lieb
+# Julian Jacques Maurer https://launchpad.net/~mail-julianjmaurer
+# Julian Rother https://launchpad.net/~julian-sda
+# Keruskerfuerst https://launchpad.net/~arminmohring
+# MarcusLS https://launchpad.net/~marcusls
+# Mark Stuppacher https://launchpad.net/~mark-happynet
+# Martin Lettner https://launchpad.net/~m.lettner
+# MixCool https://launchpad.net/~mixcool
+# MyUser https://launchpad.net/~myuser
+# Nils https://launchpad.net/~nilswoetzel
+# Patrick Eigensatz https://launchpad.net/~p.eigensatz
+# Patrick Schaake https://launchpad.net/~patrick-schaake
+# Peter Altherr https://launchpad.net/~peter-altherr
+# Sekhmet https://launchpad.net/~sekhmet
+# Severin Heiniger https://launchpad.net/~lantash
+# Steve M. https://launchpad.net/~steve-m
+# Tobias Duehr https://launchpad.net/~mrbordello
+# Ubert Shok https://launchpad.net/~ushok
+# Vinzenz Vietzke https://launchpad.net/~v1nz
+# Waldemar R. https://launchpad.net/~lux5
+# ahsamuel https://launchpad.net/~samuel-orsenne
+# axoin https://launchpad.net/~schrott4711
+# benste https://launchpad.net/~benste
+# dauerbaustelle https://launchpad.net/~dauerbaustelle
+# dominik langer https://launchpad.net/~dominiklanger
+# meru https://launchpad.net/~merualhemio
+# mx82 https://launchpad.net/~mx82
+# tim♡mint https://launchpad.net/~tim.h.s
+# tofro https://launchpad.net/~tobias-froeschle
 # Almin <GermannenMarkus@googlemail.com>, 2015
 # negativezero <blackhole89@gmail.com>, 2014
 # Christian Wagner <wagnerschristian@gmail.com>, 2017
 # Christopher Schramm <transifex@cschramm.eu>, 2019
 # Ettore Atalan <atalanttore@googlemail.com>, 2015,2017
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # otazl <oliver.tazl@gmail.com>, 2014
 # petr <b.fischer025@gmail.com>, 2015
 # bambuhle <politik@philippoi.de>, 2014
@@ -731,44 +763,6 @@ msgstr "Gerät auswählen"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mehr"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Andreas Kohlbach https://launchpad.net/~ank\n"
-"  Bernhard Gehl https://launchpad.net/~bernhard-gehl\n"
-"  Felix Möller https://launchpad.net/~felix-derklecks\n"
-"  Jochen Kemnade https://launchpad.net/~jochenkemnade\n"
-"  JonasL https://launchpad.net/~jonas-lieb\n"
-"  Julian Jacques Maurer https://launchpad.net/~mail-julianjmaurer\n"
-"  Julian Rother https://launchpad.net/~julian-sda\n"
-"  Keruskerfuerst https://launchpad.net/~arminmohring\n"
-"  MarcusLS https://launchpad.net/~marcusls\n"
-"  Mark Stuppacher https://launchpad.net/~mark-happynet\n"
-"  Martin Lettner https://launchpad.net/~m.lettner\n"
-"  MixCool https://launchpad.net/~mixcool\n"
-"  MyUser https://launchpad.net/~myuser\n"
-"  Nils https://launchpad.net/~nilswoetzel\n"
-"  Patrick Eigensatz https://launchpad.net/~p.eigensatz\n"
-"  Patrick Schaake https://launchpad.net/~patrick-schaake\n"
-"  Peter Altherr https://launchpad.net/~peter-altherr\n"
-"  Sekhmet https://launchpad.net/~sekhmet\n"
-"  Severin Heiniger https://launchpad.net/~lantash\n"
-"  Steve M. https://launchpad.net/~steve-m\n"
-"  Tobias Duehr https://launchpad.net/~mrbordello\n"
-"  Ubert Shok https://launchpad.net/~ushok\n"
-"  Vinzenz Vietzke https://launchpad.net/~v1nz\n"
-"  Waldemar R. https://launchpad.net/~lux5\n"
-"  ahsamuel https://launchpad.net/~samuel-orsenne\n"
-"  axoin https://launchpad.net/~schrott4711\n"
-"  benste https://launchpad.net/~benste\n"
-"  dauerbaustelle https://launchpad.net/~dauerbaustelle\n"
-"  dominik langer https://launchpad.net/~dominiklanger\n"
-"  meru https://launchpad.net/~merualhemio\n"
-"  mx82 https://launchpad.net/~mx82\n"
-"  tim♡mint https://launchpad.net/~tim.h.s\n"
-"  tofro https://launchpad.net/~tobias-froeschle"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/el.po
+++ b/po/el.po
@@ -14,11 +14,8 @@
 # Valmantas Palikša https://launchpad.net/~walmis
 # Τάσος Παπανικολάου https://launchpad.net/~taspap
 # alexandros_ <alexandros.venn@gmail.com>, 2014
-# alexandros_ <alexandros.venn@gmail.com>, 2014
 # Angelos Chraniotis <chraniotis@gmail.com>, 2016
 # Efstathios Iosifidis <iefstathios@gmail.com>, 2014-2015
-# Νίκος Κοντ. <nkontopos@gmail.com>, 2016
-# thunk <thunk77@gmail.com>, 2014
 # thunk <thunk77@gmail.com>, 2014
 # Αλέξανδρος Καπετάνιος <alexandros@gnugr.org>, 2017-2018
 # Νίκος Κοντ. <nkontopos@gmail.com>, 2016

--- a/po/el.po
+++ b/po/el.po
@@ -2,11 +2,21 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Adonis Papaderos https://launchpad.net/~ado-papas
+# Burak Anıl https://launchpad.net/~abstract-tr39
+# Clopy https://launchpad.net/~muz-diktio
+# Galatsanos Panagiotis https://launchpad.net/~oneinchman
+# George Kontis https://launchpad.net/~giormatsis
+# Giorgos Skafidas https://launchpad.net/~giorgos-skafidas
+# Petros Kyladitis https://launchpad.net/~multipetros
+# Spiros Gezerlis https://launchpad.net/~gezerlis
+# Thanos Lefteris https://launchpad.net/~alefteris
+# Valmantas Palikša https://launchpad.net/~walmis
+# Τάσος Παπανικολάου https://launchpad.net/~taspap
 # alexandros_ <alexandros.venn@gmail.com>, 2014
 # alexandros_ <alexandros.venn@gmail.com>, 2014
 # Angelos Chraniotis <chraniotis@gmail.com>, 2016
 # Efstathios Iosifidis <iefstathios@gmail.com>, 2014-2015
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # Νίκος Κοντ. <nkontopos@gmail.com>, 2016
 # thunk <thunk77@gmail.com>, 2014
 # thunk <thunk77@gmail.com>, 2014
@@ -744,22 +754,6 @@ msgstr "Επιλογή συσκευής"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Περισσότερα"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Adonis Papaderos https://launchpad.net/~ado-papas\n"
-"  Burak Anıl https://launchpad.net/~abstract-tr39\n"
-"  Clopy https://launchpad.net/~muz-diktio\n"
-"  Galatsanos Panagiotis https://launchpad.net/~oneinchman\n"
-"  George Kontis https://launchpad.net/~giormatsis\n"
-"  Giorgos Skafidas https://launchpad.net/~giorgos-skafidas\n"
-"  Petros Kyladitis https://launchpad.net/~multipetros\n"
-"  Spiros Gezerlis https://launchpad.net/~gezerlis\n"
-"  Thanos Lefteris https://launchpad.net/~alefteris\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Τάσος Παπανικολάου https://launchpad.net/~taspap"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/el.po
+++ b/po/el.po
@@ -22,6 +22,7 @@
 # thunk <thunk77@gmail.com>, 2014
 # Αλέξανδρος Καπετάνιος <alexandros@gnugr.org>, 2017-2018
 # Νίκος Κοντ. <nkontopos@gmail.com>, 2016
+# george k <norhorn@gmail.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -4,6 +4,7 @@
 # Translators:
 # Michael Findlay <translate@cobber-linux.org>, 2015
 # Michael Findlay <translate@cobber-linux.org>, 2017
+# Jeannette L <j.lavoie@net-c.ca>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -728,10 +728,6 @@ msgstr "Select Device"
 msgid "More"
 msgstr "More"
 
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr "translator-credits"
-
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman is a GTK+ Bluetooth manager"

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -2,8 +2,7 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# Michael Findlay <translate@cobber-linux.org>, 2015
-# Michael Findlay <translate@cobber-linux.org>, 2017
+# Michael Findlay <translate@cobber-linux.org>, 2015,2017
 # Jeannette L <j.lavoie@net-c.ca>
 msgid ""
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -12,6 +12,7 @@
 # Andi Chandler <andi@gowling.com>, 2015
 # Bradley Jones <brdjns@gmx.us>, 2018
 # Martin Wimpress <code@flexion.org>, 2014-2015
+# Jeannette L <j.lavoie@net-c.ca>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -2,9 +2,15 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Jen Ockwell https://launchpad.net/~rj-ockwell
+# Joel Auterson https://launchpad.net/~joel-auterson
+# John Drinkwater https://launchpad.net/~johndrinkwater
+# Robert Readman https://launchpad.net/~robert-readman
+# Steve Holmes https://launchpad.net/~bouncysteve
+# Tristan Brindle https://launchpad.net/~tristan-brindle
+# Valmantas Palikša https://launchpad.net/~walmis
 # Andi Chandler <andi@gowling.com>, 2015
 # Bradley Jones <brdjns@gmx.us>, 2018
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
 # Martin Wimpress <code@flexion.org>, 2014-2015
 msgid ""
 msgstr ""
@@ -731,18 +737,6 @@ msgstr "Select Device"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "More"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Jen Ockwell https://launchpad.net/~rj-ockwell\n"
-"  Joel Auterson https://launchpad.net/~joel-auterson\n"
-"  John Drinkwater https://launchpad.net/~johndrinkwater\n"
-"  Robert Readman https://launchpad.net/~robert-readman\n"
-"  Steve Holmes https://launchpad.net/~bouncysteve\n"
-"  Tristan Brindle https://launchpad.net/~tristan-brindle\n"
-"  Valmantas Palikša https://launchpad.net/~walmis"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/es.po
+++ b/po/es.po
@@ -2,17 +2,13 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# Adolfo Jayme-Barrientos, 2017,2019
-# Adolfo Jayme-Barrientos, 2015
-# Adolfo Jayme-Barrientos, 2014
 # Emiliano Fascetti, 2015
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # Joel Barrios <darkshram@gmail.com>, 2017
 # Lluís Tusquellas <lutusq@gmail.com>, 2014
 # elio <micta2003@hotmail.com>, 2017
 # Pablo Díaz <reznorix@yahoo.es>, 2017
 # Toni Estévez <toni.estevez@gmail.com>, 2019-2020
-# Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2020.
+# Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2014-2015, 2017, 2019-2020
 # Amaro Martínez <xoas@airmail.cc>, 2020.
 msgid ""
 msgstr ""
@@ -729,13 +725,6 @@ msgstr "Seleccionar dispositivo"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Más"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Amaro Martínez <xoas@airmail.cc>, 2020\n"
-"Toni Estevez <toni.estevez@gmail.com>, 2019\n"
-"Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2014-2015, 2019-2020"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/es.po
+++ b/po/es.po
@@ -10,6 +10,7 @@
 # Toni Estévez <toni.estevez@gmail.com>, 2019-2020
 # Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2014-2015, 2017, 2019-2020
 # Amaro Martínez <xoas@airmail.cc>, 2020.
+# Allan Nordhøy <epost@anotheragency.no>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/et.po
+++ b/po/et.po
@@ -2,7 +2,13 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2009
+# Cancer https://launchpad.net/~kancer
+# René Pärts https://launchpad.net/~renep
+# Valmantas Palikša https://launchpad.net/~walmis
+# gert7 https://launchpad.net/~gertoja
+# lyyser https://launchpad.net/~logard-1961
+# mahfiaz https://launchpad.net/~mahfiaz
+# veidu https://launchpad.net/~viljarveidenberg
 # Ivar Smolin <okul@linux.ee>, 2014-2015,2018
 # Rivo Zängov <eraser@eraser.ee>, 2018
 msgid ""
@@ -723,20 +729,6 @@ msgstr "Seadme valimine"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Veel"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Ivar Smolin, 2014–2015, 2018\n"
-"\n"
-"Launchpad Contributions:\n"
-"  Cancer https://launchpad.net/~kancer\n"
-"  René Pärts https://launchpad.net/~renep\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  gert7 https://launchpad.net/~gertoja\n"
-"  lyyser https://launchpad.net/~logard-1961\n"
-"  mahfiaz https://launchpad.net/~mahfiaz\n"
-"  veidu https://launchpad.net/~viljarveidenberg"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/eu.po
+++ b/po/eu.po
@@ -722,12 +722,6 @@ msgstr "Hautatu gailua"
 msgid "More"
 msgstr "Gehiago"
 
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Asier Iturralde Sarasola <asier.iturralde@gmail.com>\n"
-"Aritz Jorge Sánchez"
-
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -2,9 +2,10 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Artin https://launchpad.net/~artin
+# Valmantas Palikša https://launchpad.net/~walmis
 # am1r.ar3alan <am1r.ar3alan@yahoo.com>, 2014
 # Dante Marshal <marshal.devilhunter@gmail.com>, 2018
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
 # Mahdi Pourghasem <mahdipourghasem@gmail.com>, 2016
 msgid ""
 msgstr ""
@@ -714,13 +715,6 @@ msgstr ""
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Artin https://launchpad.net/~artin\n"
-"  Valmantas Palikša https://launchpad.net/~walmis"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/fi.po
+++ b/po/fi.po
@@ -2,6 +2,7 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Tuomas Lähteenmäki <lahtis@gmail.com>
 # Atte Virtanen https://launchpad.net/~atte
 # Christian Hellberg https://launchpad.net/~christian-hellberg
 # Elias Julkunen https://launchpad.net/~eliasj

--- a/po/fi.po
+++ b/po/fi.po
@@ -2,8 +2,18 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Atte Virtanen https://launchpad.net/~atte
+# Christian Hellberg https://launchpad.net/~christian-hellberg
+# Elias Julkunen https://launchpad.net/~eliasj
+# Jussi Aalto https://launchpad.net/~jtaalto
+# Jussi Laitinen https://launchpad.net/~jussilait92
+# Mika Filpus https://launchpad.net/~mfilpus
+# Pekka Niemi https://launchpad.net/~pekka-niemi
+# Sami Olmari https://launchpad.net/~olmari
+# Tuukka Tolvanen https://launchpad.net/~sp3000
+# Valmantas Palikša https://launchpad.net/~walmis
+# Ville Lindfors https://launchpad.net/~villi
 # Eslam Ali <talvikahvi@gmail.com>, 2015
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # Lasse Liehu <larso@gmx.com>, 2016
 # nomen omen, 2017-2018
 # Rauli L. <rauli.laine@iki.fi>, 2016
@@ -735,22 +745,6 @@ msgstr "Valitse laite"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Lisää"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Atte Virtanen https://launchpad.net/~atte\n"
-"  Christian Hellberg https://launchpad.net/~christian-hellberg\n"
-"  Elias Julkunen https://launchpad.net/~eliasj\n"
-"  Jussi Aalto https://launchpad.net/~jtaalto\n"
-"  Jussi Laitinen https://launchpad.net/~jussilait92\n"
-"  Mika Filpus https://launchpad.net/~mfilpus\n"
-"  Pekka Niemi https://launchpad.net/~pekka-niemi\n"
-"  Sami Olmari https://launchpad.net/~olmari\n"
-"  Tuukka Tolvanen https://launchpad.net/~sp3000\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Ville Lindfors https://launchpad.net/~villi"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,13 +2,45 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Anthony Guéchoum https://launchpad.net/~athael
+# Benjamin Pineau https://launchpad.net/~ben-pineau
+# Christophe Painchaud https://launchpad.net/~dash-ionblast
+# Claude Gagné https://launchpad.net/~miltiad
+# David Perrenoud https://launchpad.net/~dperrenoud
+# Francois Magimel https://launchpad.net/~linkid
+# Francois Perruchas https://launchpad.net/~francoisperruchas
+# François Tissandier https://launchpad.net/~baloo
+# Gabriel https://launchpad.net/~gabriel-r3g
+# Gueraph Mayax https://launchpad.net/~yoann-weber
+# Guilhem Lettron https://launchpad.net/~guilhem-fr
+# Jerod212 https://launchpad.net/~jerod212
+# Johan Serre https://launchpad.net/~serre-johan
+# Laurent Peuch https://launchpad.net/~psycojoker
+# Lstr https://launchpad.net/~rlstr87
+# Léobaillard https://launchpad.net/~leobaillard
+# Marc Plano-Lesay https://launchpad.net/~marc31boss
+# Mathieu Pasquet https://launchpad.net/~mathieui
+# Nicolas Delvaux https://launchpad.net/~malaria
+# Nicolas Sabatier https://launchpad.net/~nicolassabatier
+# Niki https://launchpad.net/~nikiroo
+# Nizar Kerkeni https://launchpad.net/~nizarus
+# Penegal https://launchpad.net/~penegal
+# Pierre Slamich https://launchpad.net/~pierre-slamich
+# Sorkin https://launchpad.net/~kosnila
+# Valmantas Palikša https://launchpad.net/~walmis
+# Yves MATHIEU https://launchpad.net/~ymathieu
+# axx https://launchpad.net/~axx-simon
+# chgarde https://launchpad.net/~christophe-garde
+# djedail https://launchpad.net/~troussard-jerome
+# hugo https://launchpad.net/~gogosnake
+# jad_jay https://launchpad.net/~jay-man3
+# ooliver27 https://launchpad.net/~ooliver27
 # Charles Monzat <c.monzat@laposte.net>, 2017
 # Charles Monzat <c.monzat@laposte.net>, 2017
 # Scoubidou <david.vantyghem@free.fr>, 2014
 # ericbsd <ericturgeon@ghostbsd.org>, 2015
 # ericbsd <ericturgeon@ghostbsd.org>, 2015
 # Étienne Deparis <etienne@depar.is>, 2017
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # Lionel Brianto <kinobi@kinobiweb.com>, 2017
 # mauron, 2015,2017
 # mauron, 2015,2017
@@ -733,44 +765,6 @@ msgstr "Sélectionner un périphérique"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Plus"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Anthony Guéchoum https://launchpad.net/~athael\n"
-"  Benjamin Pineau https://launchpad.net/~ben-pineau\n"
-"  Christophe Painchaud https://launchpad.net/~dash-ionblast\n"
-"  Claude Gagné https://launchpad.net/~miltiad\n"
-"  David Perrenoud https://launchpad.net/~dperrenoud\n"
-"  Francois Magimel https://launchpad.net/~linkid\n"
-"  Francois Perruchas https://launchpad.net/~francoisperruchas\n"
-"  François Tissandier https://launchpad.net/~baloo\n"
-"  Gabriel https://launchpad.net/~gabriel-r3g\n"
-"  Gueraph Mayax https://launchpad.net/~yoann-weber\n"
-"  Guilhem Lettron https://launchpad.net/~guilhem-fr\n"
-"  Jerod212 https://launchpad.net/~jerod212\n"
-"  Johan Serre https://launchpad.net/~serre-johan\n"
-"  Laurent Peuch https://launchpad.net/~psycojoker\n"
-"  Lstr https://launchpad.net/~rlstr87\n"
-"  Léobaillard https://launchpad.net/~leobaillard\n"
-"  Marc Plano-Lesay https://launchpad.net/~marc31boss\n"
-"  Mathieu Pasquet https://launchpad.net/~mathieui\n"
-"  Nicolas Delvaux https://launchpad.net/~malaria\n"
-"  Nicolas Sabatier https://launchpad.net/~nicolassabatier\n"
-"  Niki https://launchpad.net/~nikiroo\n"
-"  Nizar Kerkeni https://launchpad.net/~nizarus\n"
-"  Penegal https://launchpad.net/~penegal\n"
-"  Pierre Slamich https://launchpad.net/~pierre-slamich\n"
-"  Sorkin https://launchpad.net/~kosnila\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Yves MATHIEU https://launchpad.net/~ymathieu\n"
-"  axx https://launchpad.net/~axx-simon\n"
-"  chgarde https://launchpad.net/~christophe-garde\n"
-"  djedail https://launchpad.net/~troussard-jerome\n"
-"  hugo https://launchpad.net/~gogosnake\n"
-"  jad_jay https://launchpad.net/~jay-man3\n"
-"  ooliver27 https://launchpad.net/~ooliver27"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/fr.po
+++ b/po/fr.po
@@ -36,20 +36,14 @@
 # jad_jay https://launchpad.net/~jay-man3
 # ooliver27 https://launchpad.net/~ooliver27
 # Charles Monzat <c.monzat@laposte.net>, 2017
-# Charles Monzat <c.monzat@laposte.net>, 2017
-# Scoubidou <david.vantyghem@free.fr>, 2014
-# ericbsd <ericturgeon@ghostbsd.org>, 2015
 # ericbsd <ericturgeon@ghostbsd.org>, 2015
 # Étienne Deparis <etienne@depar.is>, 2017
 # Lionel Brianto <kinobi@kinobiweb.com>, 2017
 # mauron, 2015,2017
-# mauron, 2015,2017
 # Nicolas Dobigeon <dobigeon@gmail.com>, 2017
 # Rox fr <roxfr@outlook.fr>, 2020
 # Scoubidou <david.vantyghem@free.fr>, 2014
-# Tubuntu, 2014
 # Tubuntu <tubuntu@testimonium.be>, 2014-2015
-# Xorg, 2017
 # Xorg, 2017
 # Nathan <bonnemainsnathan@gmail.com>
 # Djeremaille <jeremy.tisserand@gmail.com>

--- a/po/fr.po
+++ b/po/fr.po
@@ -51,6 +51,16 @@
 # Tubuntu <tubuntu@testimonium.be>, 2014-2015
 # Xorg, 2017
 # Xorg, 2017
+# Nathan <bonnemainsnathan@gmail.com>
+# Djeremaille <jeremy.tisserand@gmail.com>
+# Boris Faure <billiob@gmail.com>
+# Johan Cwiklinski <trasher@x-tnd.be>
+# OozeBalk <oozebalk@gmail.com>
+# J. Lavoie <j.lavoie@net-c.ca>
+# Colomban Wendling <hypra@ban.netlib.re>
+# Estébastien Robespi <estebastien@mailbox.org>
+# Julien Humbert <julroy67@gmail.com>
+# Yoan <yoan@konqi.fr>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/gl.po
+++ b/po/gl.po
@@ -2,8 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Proxecto Trasno <proxecto@trasno.gal>
 # André Rivero Castillo <hab130@gmail.com>, 2016
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
 # Miguel Anxo Bouzada <mbouzada@gmail.com>, 2014,2018-2019
 msgid ""
 msgstr ""
@@ -732,12 +732,6 @@ msgstr "Seleccione o dispositivo"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Máis"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Miguel Anxo Bouzada <mbouzada@gmail.com>\n"
-"Proxecto Trasno <proxecto@trasno.gal>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/he.po
+++ b/po/he.po
@@ -715,10 +715,6 @@ msgstr "בחירת התקן"
 msgid "More"
 msgstr "עוד"
 
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr "Yaron Shahrabani <sh.yaron@gmail.com>"
-
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman הוא מנהל Bluetooth לסביבתGTK+ ‎"

--- a/po/he.po
+++ b/po/he.po
@@ -6,6 +6,7 @@
 # haxoc c11 <haxoc112@disroot.org>, 2018
 # shy tzedaka <shaytzedaka123@gmail.com>, 2016
 # Yaron Shahrabani <sh.yaron@gmail.com>, 2017, 2020.
+# Omeritzics Games <omeritzicschwartz@gmail.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -2,6 +2,10 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# राजेश रंजन (rajeshkajha@yahoo.com)
+# जी करुणाकर (karunakar@freedomink.org)
+# रविशंकर श्रीवास्तव (raviratlami@gmail.com)
+# राघवन गोपालकृष्णन्  (g.raghavan.g@gmail.com)
 # Sadgamaya <g.raghavan.g@gmail.com>, 2014
 msgid ""
 msgstr ""
@@ -709,14 +713,6 @@ msgstr ""
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"राजेश रंजन (rajeshkajha@yahoo.com)\n"
-"जी करुणाकर (karunakar@freedomink.org)\n"
-"रविशंकर श्रीवास्तव (raviratlami@gmail.com)\n"
-"राघवन गोपालकृष्णन्  (g.raghavan.g@gmail.com)"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/hr.po
+++ b/po/hr.po
@@ -2,7 +2,11 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2009
+# DoDoENT https://launchpad.net/~dodoentertainment
+# Miro Glavić https://launchpad.net/~klek
+# Miroslav Matejaš https://launchpad.net/~silverspace+amd64
+# Saša Teković https://launchpad.net/~hseagle2015
+# nafterburner https://launchpad.net/~nafterburner
 # gogo <trebelnik2@gmail.com>, 2019
 # Ivica  Kolić <ikoli@yahoo.com>, 2014,2016
 # gogo <trebelnik2@gmail.com>, 2019
@@ -726,16 +730,6 @@ msgstr "Odaberi uređaj"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Više"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  DoDoENT https://launchpad.net/~dodoentertainment\n"
-"  Miro Glavić https://launchpad.net/~klek\n"
-"  Miroslav Matejaš https://launchpad.net/~silverspace+amd64\n"
-"  Saša Teković https://launchpad.net/~hseagle2015\n"
-"  nafterburner https://launchpad.net/~nafterburner"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,6 @@
 # Miroslav Matejaš https://launchpad.net/~silverspace+amd64
 # Saša Teković https://launchpad.net/~hseagle2015
 # nafterburner https://launchpad.net/~nafterburner
-# gogo <trebelnik2@gmail.com>, 2019
 # Ivica  Kolić <ikoli@yahoo.com>, 2014,2016
 # gogo <trebelnik2@gmail.com>, 2019
 # Milo Ivir <mail@milotype.de>, 2020.

--- a/po/hu.po
+++ b/po/hu.po
@@ -23,8 +23,7 @@
 # Balázs Meskó <mesko.balazs@fsf.hu>, 2017
 # Falu <info@falu.me>, 2017
 # István Szőllősi <szollosi.istv4n@gmail.com>, 2014,2017
-# KAMI KAMI <kami911@gmail.com>, 2014,2016-2017
-# KAMI KAMI <kami911@gmail.com>, 2019
+# KAMI KAMI <kami911@gmail.com>, 2014,2016-2017,2019
 # Rezső Páder <rezso@rezso.net>, 2014-2015,2017
 # Zoltán Rápolthy <real_zolee@hotmail.com>, 2017
 msgid ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -2,9 +2,26 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Bálint Fekete https://launchpad.net/~kaktusztea
+# Csarlee https://launchpad.net/~karesz-cskr
+# Fox https://launchpad.net/~younfox
+# Gabor Kelemen https://launchpad.net/~kelemeng
+# Janusz https://launchpad.net/~janusz
+# Kántor Dániel https://launchpad.net/~kdani3
+# MBA https://launchpad.net/~mbalazs
+# Muszela Balázs https://launchpad.net/~bazsi86
+# Peter Nagy https://launchpad.net/~antronin
+# Pittmann Tamás https://launchpad.net/~zaivaldi
+# Szenográdi Norbert Péter https://launchpad.net/~sevoir
+# Thomas Martin Klein https://launchpad.net/~kleintamasmarton
+# Thuma Gábor https://launchpad.net/~thuma
+# TÖRÖK Attila https://launchpad.net/~torokati44
+# Valmantas Palikša https://launchpad.net/~walmis
+# Varga Zoltán https://launchpad.net/~wazzeg
+# kavkar https://launchpad.net/~kavkar
+# ricsko https://launchpad.net/~ricsi91
 # Balázs Meskó <mesko.balazs@fsf.hu>, 2017
 # Falu <info@falu.me>, 2017
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # István Szőllősi <szollosi.istv4n@gmail.com>, 2014,2017
 # KAMI KAMI <kami911@gmail.com>, 2014,2016-2017
 # KAMI KAMI <kami911@gmail.com>, 2019
@@ -739,36 +756,6 @@ msgstr "Válasszon eszközt"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Tovább"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"István Szőllősi <szollosi.istv4n@gmail.com>, 2014,2017\n"
-"Rezső Páder <rezso@rezso.net>, 2014-2015,2017\n"
-"Kalman „KAMI” Szalai <kami911@gmail.com>, 2014-2018\n"
-"Balázs Meskó <meskobalazs@gmail.com>, 2017\n"
-"Falu <info@falu.me>, 2017\n"
-"Zoltán Rápolthy <real_zolee@hotmail.com>, 2017\n"
-"\n"
-"Launchpad Contributions:\n"
-"  Bálint Fekete https://launchpad.net/~kaktusztea\n"
-"  Csarlee https://launchpad.net/~karesz-cskr\n"
-"  Fox https://launchpad.net/~younfox\n"
-"  Gabor Kelemen https://launchpad.net/~kelemeng\n"
-"  Janusz https://launchpad.net/~janusz\n"
-"  Kántor Dániel https://launchpad.net/~kdani3\n"
-"  MBA https://launchpad.net/~mbalazs\n"
-"  Muszela Balázs https://launchpad.net/~bazsi86\n"
-"  Peter Nagy https://launchpad.net/~antronin\n"
-"  Pittmann Tamás https://launchpad.net/~zaivaldi\n"
-"  Szenográdi Norbert Péter https://launchpad.net/~sevoir\n"
-"  Thomas Martin Klein https://launchpad.net/~kleintamasmarton\n"
-"  Thuma Gábor https://launchpad.net/~thuma\n"
-"  TÖRÖK Attila https://launchpad.net/~torokati44\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Varga Zoltán https://launchpad.net/~wazzeg\n"
-"  kavkar https://launchpad.net/~kavkar\n"
-"  ricsko https://launchpad.net/~ricsi91"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/id.po
+++ b/po/id.po
@@ -9,10 +9,8 @@
 # Prihantoosa https://launchpad.net/~prihantoosa
 # Andika Triwidada <andika@gmail.com>, 2017,2020
 # Hatta.z, 2014
-# Hatta.z, 2014
 # La Ode Muh. Fadlun Akbar <fadlun.net@gmail.com>, 2015,2017
 # Willy Sudiarto Raharjo <willysr@slackware-id.org>, 2014
-# zk, 2015
 # zk, 2015
 msgid ""
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -2,8 +2,12 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Achmad Kamali https://launchpad.net/~ak12720
+# Hertatijanto Hartono https://launchpad.net/~darkvertex
+# Muhammad Zulfikar https://launchpad.net/~zulfikars
+# Mulia Arifandy Nasution https://launchpad.net/~mul14
+# Prihantoosa https://launchpad.net/~prihantoosa
 # Andika Triwidada <andika@gmail.com>, 2017,2020
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # Hatta.z, 2014
 # Hatta.z, 2014
 # La Ode Muh. Fadlun Akbar <fadlun.net@gmail.com>, 2015,2017
@@ -733,16 +737,6 @@ msgstr "Pilih Perangkat"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Tambahan"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Achmad Kamali https://launchpad.net/~ak12720\n"
-"  Hertatijanto Hartono https://launchpad.net/~darkvertex\n"
-"  Muhammad Zulfikar https://launchpad.net/~zulfikars\n"
-"  Mulia Arifandy Nasution https://launchpad.net/~mul14\n"
-"  Prihantoosa https://launchpad.net/~prihantoosa"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/it.po
+++ b/po/it.po
@@ -44,6 +44,8 @@
 # Marcello Bolognesi, 2014
 # Marco Bartolucci <nap.84@live.it>, 2016
 # Stefano Karapetsas <stefano@karapetsas.com>, 2014
+# Edoardo Facchinelli <silpheel@gmail.com> (3)
+# J. Lavoie <j.lavoie@net-c.ca>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/it.po
+++ b/po/it.po
@@ -2,9 +2,41 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Andrea Grandi https://launchpad.net/~andy80
+# Antonio Piccinno https://launchpad.net/~acquarica
+# Ceceppa https://launchpad.net/~senesealessandro
+# Cubello Antonio https://launchpad.net/~coobox
+# Daniele de Virgilio https://launchpad.net/~erunamo
+# Eros 87 https://launchpad.net/~eros-zanardelli
+# Fabio Parri https://launchpad.net/~parrif-ibb
+# Fabrizio Pisani https://launchpad.net/~fabry
+# Fulvio Ciucci https://launchpad.net/~kitpou
+# Giampaolo Bozzali https://launchpad.net/~g.bozzali
+# Giasone https://launchpad.net/~giasone
+# Giulio Rossetti https://launchpad.net/~giuliorossetti
+# Guybrush88 https://launchpad.net/~erpizzo
+# Lorenzo Zolfanelli https://launchpad.net/~lorenzo-zolfa
+# Luca Carrogu https://launchpad.net/~motoplux
+# Luca Urbini https://launchpad.net/~luca-urbini
+# MeltingShell https://launchpad.net/~meltingshell
+# NeXTWay https://launchpad.net/~dotcom93
+# Nicola Piovesan https://launchpad.net/~piovesannicola
+# Nikopol https://launchpad.net/~aegnor-isilra
+# Paolo Naldini https://launchpad.net/~hattory
+# Plinio Gatto https://launchpad.net/~pliniogatto
+# Riccardo Tritto https://launchpad.net/~riccardo-tritto
+# Roberto https://launchpad.net/~r-calamante
+# Simone Oberti https://launchpad.net/~simone-obo
+# Valmantas Palikša https://launchpad.net/~walmis
+# diei https://launchpad.net/~diei80
+# enubuntu https://launchpad.net/~enubuntu
+# goliat https://launchpad.net/~giulio-rodoni
+# khoma https://launchpad.net/~khoma1985
+# maxubuntu https://launchpad.net/~maxdaurelio
+# musmax https://launchpad.net/~musmax
+# r1348 https://launchpad.net/~req1348
 # Alessandro Volturno <alelvb@inwind.it>, 2019
 # Enrico B. <enricobe@hotmail.com>, 2019
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # Giuseppe Pignataro <rogepix@gmail.com>, 2017-2018
 # l3nn4rt, 2018
 # Dario Di Nucci <linkin88mail@gmail.com>, 2014-2015
@@ -739,44 +771,6 @@ msgstr "Seleziona Dispositivo"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Altro"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Andrea Grandi https://launchpad.net/~andy80\n"
-"  Antonio Piccinno https://launchpad.net/~acquarica\n"
-"  Ceceppa https://launchpad.net/~senesealessandro\n"
-"  Cubello Antonio https://launchpad.net/~coobox\n"
-"  Daniele de Virgilio https://launchpad.net/~erunamo\n"
-"  Eros 87 https://launchpad.net/~eros-zanardelli\n"
-"  Fabio Parri https://launchpad.net/~parrif-ibb\n"
-"  Fabrizio Pisani https://launchpad.net/~fabry\n"
-"  Fulvio Ciucci https://launchpad.net/~kitpou\n"
-"  Giampaolo Bozzali https://launchpad.net/~g.bozzali\n"
-"  Giasone https://launchpad.net/~giasone\n"
-"  Giulio Rossetti https://launchpad.net/~giuliorossetti\n"
-"  Guybrush88 https://launchpad.net/~erpizzo\n"
-"  Lorenzo Zolfanelli https://launchpad.net/~lorenzo-zolfa\n"
-"  Luca Carrogu https://launchpad.net/~motoplux\n"
-"  Luca Urbini https://launchpad.net/~luca-urbini\n"
-"  MeltingShell https://launchpad.net/~meltingshell\n"
-"  NeXTWay https://launchpad.net/~dotcom93\n"
-"  Nicola Piovesan https://launchpad.net/~piovesannicola\n"
-"  Nikopol https://launchpad.net/~aegnor-isilra\n"
-"  Paolo Naldini https://launchpad.net/~hattory\n"
-"  Plinio Gatto https://launchpad.net/~pliniogatto\n"
-"  Riccardo Tritto https://launchpad.net/~riccardo-tritto\n"
-"  Roberto https://launchpad.net/~r-calamante\n"
-"  Simone Oberti https://launchpad.net/~simone-obo\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  diei https://launchpad.net/~diei80\n"
-"  enubuntu https://launchpad.net/~enubuntu\n"
-"  goliat https://launchpad.net/~giulio-rodoni\n"
-"  khoma https://launchpad.net/~khoma1985\n"
-"  maxubuntu https://launchpad.net/~maxdaurelio\n"
-"  musmax https://launchpad.net/~musmax\n"
-"  r1348 https://launchpad.net/~req1348"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,8 +2,10 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Karl Skewes https://launchpad.net/~karl-garagedori
+# Valmantas Palikša https://launchpad.net/~walmis
+# Yuki Kodama https://launchpad.net/~kuy
 # ABE Tsunehiko, 2014-2015,2017
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
 # Mika Kobayashi, 2015
 # Nobuhiro Iwamatsu <iwamatsu@nigauri.org>, 2018-2019
 # OKANO Takayoshi <kano@na.rim.or.jp>, 2015
@@ -735,14 +737,6 @@ msgstr "デバイスを選択"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "もっと"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Karl Skewes https://launchpad.net/~karl-garagedori\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Yuki Kodama https://launchpad.net/~kuy"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/ja.po
+++ b/po/ja.po
@@ -10,6 +10,7 @@
 # Nobuhiro Iwamatsu <iwamatsu@nigauri.org>, 2018-2019
 # OKANO Takayoshi <kano@na.rim.or.jp>, 2015
 # Rockers <sumorock@hotmail.com>, 2018
+# Takuya Ohe <hi@tohe.xyz>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/kk.po
+++ b/po/kk.po
@@ -2,7 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
+# Valmantas Palikša https://launchpad.net/~walmis
+# arruah https://launchpad.net/~arruah
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
@@ -709,13 +710,6 @@ msgstr ""
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  arruah https://launchpad.net/~arruah"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,11 +8,8 @@
 # onlyeriko https://launchpad.net/~onlyeriko
 # Junggyu Bag <bagjunggyu@gmail.com>
 # MATE Desktop Environment Team <https://www.transifex.com/mate/teams/13566/ko/>
-# Seong-ho Cho <darkcircle.0426@gmail.com>, 2014
-# 박정규(Jung-Kyu Park) <bagjunggyu@gmail.com>, 2015
-# 박정규(Jung-Kyu Park) <bagjunggyu@gmail.com>, 2016-2017
+# 박정규(Jung-Kyu Park) <bagjunggyu@gmail.com>, 2015-2017
 # Seong-ho Cho <darkcircle.0426@gmail.com>, 2014,2019
-# Youngbin Han <sukso96100@gmail.com>, 2014
 # Youngbin Han <sukso96100@gmail.com>, 2014
 # 이정희 <daemul72@gmail.com>
 msgid ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -2,8 +2,13 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Elex https://launchpad.net/~mysticzizone
+# Valmantas Palikša https://launchpad.net/~walmis
+# Yoo Duk Nam https://launchpad.net/~yoo2001818
+# onlyeriko https://launchpad.net/~onlyeriko
+# Junggyu Bag <bagjunggyu@gmail.com>
+# MATE Desktop Environment Team <https://www.transifex.com/mate/teams/13566/ko/>
 # Seong-ho Cho <darkcircle.0426@gmail.com>, 2014
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # 박정규(Jung-Kyu Park) <bagjunggyu@gmail.com>, 2015
 # 박정규(Jung-Kyu Park) <bagjunggyu@gmail.com>, 2016-2017
 # Seong-ho Cho <darkcircle.0426@gmail.com>, 2014,2019
@@ -734,18 +739,6 @@ msgstr "장치 선택"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "더 보기"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Elex https://launchpad.net/~mysticzizone\n"
-"Valmantas Palikša https://launchpad.net/~walmis\n"
-"Yoo Duk Nam https://launchpad.net/~yoo2001818\n"
-"onlyeriko https://launchpad.net/~onlyeriko\n"
-"Seong-ho Cho <darkcircle.0426@gmail.com>\n"
-"Junggyu Bag <bagjunggyu@gmail.com>\n"
-"MATE Desktop Environment Team <https://www.transifex.com/mate/teams/13566/ko/"
-">"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/ko.po
+++ b/po/ko.po
@@ -14,6 +14,7 @@
 # Seong-ho Cho <darkcircle.0426@gmail.com>, 2014,2019
 # Youngbin Han <sukso96100@gmail.com>, 2014
 # Youngbin Han <sukso96100@gmail.com>, 2014
+# 이정희 <daemul72@gmail.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/lt.po
+++ b/po/lt.po
@@ -8,6 +8,8 @@
 # Moo, 2015-2019
 # Kornelijus Tvarijanavičius <kornelitvari@protonmail.com>, 2020.
 # Moo <hazap@hotmail.com>, 2020.
+# Džiugas J <dziugas1959@hotmail.com>
+# Andrius Majauskas <komitetas@gmail.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/lt.po
+++ b/po/lt.po
@@ -2,7 +2,6 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# vertėjų-sąrašas
 # Džiugas Grėbliūnas <dziugas.grebliunas@gmail.com>, 2014-2015,2017
 # brennus <jonas.ska@gmail.com>, 2014-2015
 # Moo, 2015-2019

--- a/po/lt.po
+++ b/po/lt.po
@@ -2,8 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# vertėjų-sąrašas
 # Džiugas Grėbliūnas <dziugas.grebliunas@gmail.com>, 2014-2015,2017
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # brennus <jonas.ska@gmail.com>, 2014-2015
 # Moo, 2015-2019
 # Kornelijus Tvarijanavičius <kornelitvari@protonmail.com>, 2020.
@@ -725,10 +725,6 @@ msgstr "Parinkite įrenginį"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Daugiau"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr "vertėjų-sąrašas"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/lv.po
+++ b/po/lv.po
@@ -2,8 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Kristaps https://launchpad.net/~retail
 # duck <voiceofwise1@gmail.com>, 2016
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2009
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
@@ -724,12 +724,6 @@ msgstr "Izvēlēties Iekārtu"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Vairāk"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Kristaps https://launchpad.net/~retail"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/mk.po
+++ b/po/mk.po
@@ -2,6 +2,7 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Арангел Ангов <ufo@linux.net.mk>
 # exoos <mince.lesovski@gmail.com>, 2014
 msgid ""
 msgstr ""
@@ -717,10 +718,6 @@ msgstr "Одбери уред"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Повеќе"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr "Арангел Ангов <ufo@linux.net.mk>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/mr.po
+++ b/po/mr.po
@@ -714,12 +714,6 @@ msgstr "साधन निवडा"
 msgid "More"
 msgstr "अजून"
 
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"translator-credits\n"
-"वैभव दळवी (vaibhav.dlv@gmail.com)"
-
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -727,10 +727,6 @@ msgstr "Pilih Peranti"
 msgid "More"
 msgstr "Lagi"
 
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr "Abuyop <abuyop@gmail.com>"
-
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman merupakan pengurus Bluetooth GTK+"

--- a/po/nb.po
+++ b/po/nb.po
@@ -15,8 +15,7 @@
 # Allan Nordhøy <epost@anotheragency.no>, 2016-2017, 2020.
 # b84df44fb72862b85bae7a669218c6c2, 2019
 # Kenneth Jenssen <kennethjenssen@yahoo.com>, 2016
-# Kim Malmo <berencamlost@msn.com>, 2018
-# Kim Malmo <berencamlost@msn.com>, 2017
+# Kim Malmo <berencamlost@msn.com>, 2017-2018
 # Kjell Cato Heskjestad <cato@heskjestad.xyz>, 2019
 # 87d96f43665dd9fb55eba4603e184cae, 2019
 msgid ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -2,10 +2,18 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Allan Nordhøy <epost@anotheragency.no>
+# Erik E. Seierstad
+# Håvard Havdal
+# Jim Nygård
+# Kenneth Langdalen
+# Kent Vegard Evjen
+# Tommy Mikkelsen
+# Valmantas Palikša
+# Øyvind Øritsland
 # Alexander Jansen <bornxlo@gmail.com>, 2017
 # Allan Nordhøy <epost@anotheragency.no>, 2016-2017, 2020.
 # b84df44fb72862b85bae7a669218c6c2, 2019
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
 # Kenneth Jenssen <kennethjenssen@yahoo.com>, 2016
 # Kim Malmo <berencamlost@msn.com>, 2018
 # Kim Malmo <berencamlost@msn.com>, 2017
@@ -746,19 +754,6 @@ msgstr "Velg enhet"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mer"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Allan Nordhøy <epost@anotheragency.no>\n"
-"Erik E. Seierstad\n"
-"Håvard Havdal\n"
-"Jim Nygård\n"
-"Kenneth Langdalen\n"
-"Kent Vegard Evjen\n"
-"Tommy Mikkelsen\n"
-"Valmantas Palikša\n"
-"Øyvind Øritsland"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/nds.po
+++ b/po/nds.po
@@ -2,7 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
+# Skullmaster https://launchpad.net/~koeritz-jonas
+# Valmantas Palikša https://launchpad.net/~walmis
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"
@@ -702,13 +703,6 @@ msgstr ""
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Skullmaster https://launchpad.net/~koeritz-jonas\n"
-"  Valmantas Palikša https://launchpad.net/~walmis"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/nl.po
+++ b/po/nl.po
@@ -3,7 +3,6 @@
 #
 # Translators:
 # dragnadh, 2017
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
 # infirit <inactive+infirit@transifex.com>, 2014-2015
 # Marcel van den Boer <marcelvdboer@gmail.com>, 2017
 # Nathan Follens, 2015
@@ -724,10 +723,6 @@ msgstr "Selecteer apparaat"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Meer"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr "Creditering vertalers"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,6 +8,7 @@
 # Nathan Follens, 2015
 # Pjotr <pjotrvertaalt@gmail.com>, 2017,2019
 # Sander Sweers <infirit@gmail.com>, 2020.
+# simonborgithub <mail@simonbor.nl>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/oc.po
+++ b/po/oc.po
@@ -1,6 +1,11 @@
 # Occitan translations for blueman package.
 # Copyright (C) 2020 Copyright © 2008 - 2020 blueman project
 # This file is distributed under the same license as the blueman package.
+#
+# Translators:
+# Yannig Marchegay (Kokoyaya) <yannig@marchegay.org>
+# Cédric Valmary<cvalmary@yahoo.fr>
+# Cédric VALMARY (Tot en òc) https://launchpad.net/~cvalmary
 # Christopher Schramm <blueman@cschramm.eu>, 2020.
 # Quentin PAGÈS <quentinantonin@free.fr>, 2020.
 # Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2020.
@@ -705,14 +710,6 @@ msgstr "Seleccionar un periferic"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mai"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Yannig Marchegay (Kokoyaya) <yannig@marchegay.org>\n"
-"Cédric Valmary<cvalmary@yahoo.fr>\n"
-"Launchpad Contributions:\n"
-"Cédric VALMARY (Tot en òc) https://launchpad.net/~cvalmary"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/pl.po
+++ b/po/pl.po
@@ -35,7 +35,6 @@
 # Paweł Bandura <gawelx@gmail.com>, 2015
 # pietrasagh <pietrasagh@gmail.com>, 2018
 # Piotr Drąg <piotrdrag@gmail.com>, 2017-2018
-# Piotr Strębski <strebski@gmail.com>, 2017
 # Piotr Strębski <strebski@gmail.com>, 2015,2017
 # Wiktor Jezioro <wikjezioro@op.pl>, 2015
 # kakiremora <piotrek.pastuszak2003@gmail.com>

--- a/po/pl.po
+++ b/po/pl.po
@@ -2,7 +2,31 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
+# Tłumacze środowiska MATE, 2014-2015, 2017-2018
+# Burak Anıl https://launchpad.net/~abstract-tr39
+# Grubber https://launchpad.net/~tomaq
+# Jerszy https://launchpad.net/~rayman-1996
+# Krzysztof Janowski https://launchpad.net/~n00bystance-gmail
+# Krzysztof Pawłowski https://launchpad.net/~wlochal
+# LordYoghurt https://launchpad.net/~lordyoghurt
+# Marek Dz. https://launchpad.net/~marqss81
+# Mateusz Sz. https://launchpad.net/~mateyko
+# Metzi https://launchpad.net/~mecenaso
+# Michał Pławsiuk (razit.pl) https://launchpad.net/~mp3-10
+# Pangram Design https://launchpad.net/~biuro-pangram
+# Piotr Adamiecki https://launchpad.net/~piotradamiecki
+# Roman Skrzypiński https://launchpad.net/~roman0
+# Szymon Życiński https://launchpad.net/~zycinski
+# Valmantas Palikša https://launchpad.net/~walmis
+# Wiatrak https://launchpad.net/~wiatrak.
+# bfo https://launchpad.net/~bfo-poczta
+# matys https://launchpad.net/~mwilkowski
+# mazdac https://launchpad.net/~mazdac
+# nikt_taki https://launchpad.net/~nikt-taki
+# nv https://launchpad.net/~nv-nv
+# pp/bs https://launchpad.net/~pawprok
+# roffik https://launchpad.net/~roffik
+# spitfire https://launchpad.net/~mieszkoslusarczyk
 # Lukasz Kaminski <inactive+elpikej@transifex.com>, 2017
 # Marcin GTriderXC <gtriderxc@yahoo.com>, 2018
 # Marcin Kralka <marcink96@gmail.com>, 2014
@@ -743,37 +767,6 @@ msgstr "Wybierz urządzenie"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Więcej"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Tłumacze środowiska MATE, 2014-2015, 2017-2018\n"
-"\n"
-"Launchpad Contributions:\n"
-"  Burak Anıl https://launchpad.net/~abstract-tr39\n"
-"  Grubber https://launchpad.net/~tomaq\n"
-"  Jerszy https://launchpad.net/~rayman-1996\n"
-"  Krzysztof Janowski https://launchpad.net/~n00bystance-gmail\n"
-"  Krzysztof Pawłowski https://launchpad.net/~wlochal\n"
-"  LordYoghurt https://launchpad.net/~lordyoghurt\n"
-"  Marek Dz. https://launchpad.net/~marqss81\n"
-"  Mateusz Sz. https://launchpad.net/~mateyko\n"
-"  Metzi https://launchpad.net/~mecenaso\n"
-"  Michał Pławsiuk (razit.pl) https://launchpad.net/~mp3-10\n"
-"  Pangram Design https://launchpad.net/~biuro-pangram\n"
-"  Piotr Adamiecki https://launchpad.net/~piotradamiecki\n"
-"  Roman Skrzypiński https://launchpad.net/~roman0\n"
-"  Szymon Życiński https://launchpad.net/~zycinski\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Wiatrak https://launchpad.net/~wiatrak.\n"
-"  bfo https://launchpad.net/~bfo-poczta\n"
-"  matys https://launchpad.net/~mwilkowski\n"
-"  mazdac https://launchpad.net/~mazdac\n"
-"  nikt_taki https://launchpad.net/~nikt-taki\n"
-"  nv https://launchpad.net/~nv-nv\n"
-"  pp/bs https://launchpad.net/~pawprok\n"
-"  roffik https://launchpad.net/~roffik\n"
-"  spitfire https://launchpad.net/~mieszkoslusarczyk"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/pl.po
+++ b/po/pl.po
@@ -38,6 +38,8 @@
 # Piotr Strębski <strebski@gmail.com>, 2017
 # Piotr Strębski <strebski@gmail.com>, 2015,2017
 # Wiktor Jezioro <wikjezioro@op.pl>, 2015
+# kakiremora <piotrek.pastuszak2003@gmail.com>
+# Szylu <chipolade@gmail.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -2,11 +2,17 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Carlos Monteiro https://launchpad.net/~offbyte
+# Diogo Lavareda https://launchpad.net/~diogolavareda
+# Paulo Pereira https://launchpad.net/~pj-pereira
+# Pedro Saraiva https://launchpad.net/~pdro-saraiva
+# Tiago Silva https://launchpad.net/~tiagosilva
+# mestrini https://launchpad.net/~mestrini
+# Carlos Manuel https://launchpad.net/~crolidge
 # Carlos Moreira, 2014-2015,2017
 # Christopher Schramm <transifex@cschramm.eu>, 2016
 # Carlos Moreira, 2016
 # Diogo Oliveira <diogodesigns@gmail.com>, 2015
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # José Vieira <jvieira33@sapo.pt>, 2017
 # Luis Filipe Teixeira <lufilte@gmail.com>, 2016
 # Luis Neves <luisjneves@gmail.com>, 2015
@@ -727,18 +733,6 @@ msgstr "Selecione Dispositivo"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mais"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Carlos Monteiro https://launchpad.net/~offbyte\n"
-"  Diogo Lavareda https://launchpad.net/~diogolavareda\n"
-"  Paulo Pereira https://launchpad.net/~pj-pereira\n"
-"  Pedro Saraiva https://launchpad.net/~pdro-saraiva\n"
-"  Tiago Silva https://launchpad.net/~tiagosilva\n"
-"  mestrini https://launchpad.net/~mestrini\n"
-"  Carlos Manuel https://launchpad.net/~crolidge"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/pt.po
+++ b/po/pt.po
@@ -9,9 +9,8 @@
 # Tiago Silva https://launchpad.net/~tiagosilva
 # mestrini https://launchpad.net/~mestrini
 # Carlos Manuel https://launchpad.net/~crolidge
-# Carlos Moreira, 2014-2015,2017
+# Carlos Moreira, 2014-2017
 # Christopher Schramm <transifex@cschramm.eu>, 2016
-# Carlos Moreira, 2016
 # Diogo Oliveira <diogodesigns@gmail.com>, 2015
 # José Vieira <jvieira33@sapo.pt>, 2017
 # Luis Filipe Teixeira <lufilte@gmail.com>, 2016

--- a/po/pt.po
+++ b/po/pt.po
@@ -19,6 +19,8 @@
 # Manel Tinoco <maneltinoco@gmail.com>, 2017
 # Rui <xymarior@yandex.com>, 2019
 # ssantos <ssantos@web.de>, 2020.
+# Bruno Portela <brunoportela.email@gmail.com>
+# Manuel Freire <manyace22@gmail.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -731,10 +731,6 @@ msgstr "Selecionar Dispositivo"
 msgid "More"
 msgstr "Mais"
 
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr "Tradutor- créditos"
-
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"
 msgstr "Blueman é um gerenciador de bluetooth do GTK+"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -13,8 +13,7 @@
 # Herick Vinicius <herick.gustavo@gmail.com>, 2017
 # Lucas Dias <lucasdiaas@outlook.com>, 2017
 # Marcelo Ghelman <marcelo.ghelman@gmail.com>, 2014-2017
-# Marcio Andre Padula <padula1000@gmail.com>, 2014
-# Marcio Andre Padula <padula1000@gmail.com>, 2015
+# Marcio Andre Padula <padula1000@gmail.com>, 2014-2015
 # Marcus Vinícius Marques, 2014
 # Samuel Henrique <samueloph@debian.org>, 2015
 # Wagner Marques <wagnermarques00@hotmail.com>, 2015

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -19,6 +19,9 @@
 # Samuel Henrique <samueloph@debian.org>, 2015
 # Wagner Marques <wagnermarques00@hotmail.com>, 2015
 # Wellington Terumi Uemura <wellingtonuemura@gmail.com>, 2020.
+# Samuel Carvalho de Araújo <samuelnegro12345@gmail.com>
+# Lucas Araujo <lucassants2808@gmail.com>
+# Elcio Fernando de Avila Pedrozo <efpedrozo@msn.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/ro.po
+++ b/po/ro.po
@@ -2,9 +2,14 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Adi Roiban https://launchpad.net/~adiroiban
+# Alex Eftimie https://launchpad.net/~alexeftimie
+# Bisericaru Sebastian https://launchpad.net/~tweety
+# Chisu Vasile Marius https://launchpad.net/~111979vasile
+# Ionuț Jula https://launchpad.net/~ionutjula
+# Ovidiu Nitan https://launchpad.net/~nitanovidiu
 # Daniel <danny3@tutanota.com>, 2015-2016
 # Daniel <danny3@tutanota.com>, 2017
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # sorinn <nemes.sorin@gmail.com>, 2014
 # Octi <octi@writeme.com>, 2014
 # sidro <slacky2005@gmail.com>, 2014
@@ -733,19 +738,6 @@ msgstr "Selectați un dispozitiv"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mai multe"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Transifex:\n"
-"Daniel Alămiță <danny3@tutanota.com>\n"
-"Launchpad:\n"
-"  Adi Roiban https://launchpad.net/~adiroiban\n"
-"  Alex Eftimie https://launchpad.net/~alexeftimie\n"
-"  Bisericaru Sebastian https://launchpad.net/~tweety\n"
-"  Chisu Vasile Marius https://launchpad.net/~111979vasile\n"
-"  Ionuț Jula https://launchpad.net/~ionutjula\n"
-"  Ovidiu Nitan https://launchpad.net/~nitanovidiu"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/ro.po
+++ b/po/ro.po
@@ -8,8 +8,7 @@
 # Chisu Vasile Marius https://launchpad.net/~111979vasile
 # Ionuț Jula https://launchpad.net/~ionutjula
 # Ovidiu Nitan https://launchpad.net/~nitanovidiu
-# Daniel <danny3@tutanota.com>, 2015-2016
-# Daniel <danny3@tutanota.com>, 2017
+# Daniel <danny3@tutanota.com>, 2015-2017
 # sorinn <nemes.sorin@gmail.com>, 2014
 # Octi <octi@writeme.com>, 2014
 # sidro <slacky2005@gmail.com>, 2014

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,12 +2,17 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Сергей Воложанин
+# Валек Филиппов <frob@df.ru>
+# Дмитрий Мастрюков <dmitry@taurussoft.org>
+# Андрей Носенко <awn@bcs.zp.ua>
+# Леонид Кантер <leon@asplinux.ru>
+# Александр Сигачёв <ajvol2@gmail.com>
 # Alexei Sorokin <sor.alexei@meowr.ru>, 2014-2015
 # AlexL <loginov.alex.valer@gmail.com>, 2015,2017
 # Andreï Victorovitch Kostyrka, 2018
 # Dmitriy Kulikov <kulikov@dima.perm.ru>, 2017
 # Dmitry Mandryk <dmandryk@gmail.com>, 2015
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # Max Muller <mekatum@gmail.com>, 2017
 # Дмитрий Михирев, 2017
 # Дмитрий Михирев, 2017
@@ -732,17 +737,6 @@ msgstr "Выберите устройство"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Ещё"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Алексей Сорокин <sor.alexei@meowr.ru>\n"
-"Сергей Воложанин\n"
-"Валек Филиппов <frob@df.ru>\n"
-"Дмитрий Мастрюков <dmitry@taurussoft.org>\n"
-"Андрей Носенко <awn@bcs.zp.ua>\n"
-"Леонид Кантер <leon@asplinux.ru>\n"
-"Александр Сигачёв <ajvol2@gmail.com>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/ru.po
+++ b/po/ru.po
@@ -20,6 +20,13 @@
 # павел назаров <nazar12101@gmail.com>, 2015
 # Artem <KovalevArtem.ru@gmail.com>, 2020.
 # koffevar <egor.kafisov@gmail.com>, 2020.
+# Dmitry Kiryanov <nokia_lumia_630_ufa@outlook.com>
+# Alex <theavganec@gmail.com>
+# Serg Bormant <bormant@mail.ru>
+# Alexey Napalkov <flynbit@gmail.com>
+# Mingun <Alexander_Sergey@mail.ru>
+# Artyom <mccoal@hotmail.com>
+# Mihail Iosilevitch <yosik@tutanota.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -15,8 +15,6 @@
 # Dmitry Mandryk <dmandryk@gmail.com>, 2015
 # Max Muller <mekatum@gmail.com>, 2017
 # Дмитрий Михирев, 2017
-# Дмитрий Михирев, 2017
-# павел назаров <nazar12101@gmail.com>, 2015
 # павел назаров <nazar12101@gmail.com>, 2015
 # Artem <KovalevArtem.ru@gmail.com>, 2020.
 # koffevar <egor.kafisov@gmail.com>, 2020.

--- a/po/sk.po
+++ b/po/sk.po
@@ -12,6 +12,7 @@
 # Jose Riha <jose1711@gmail.com>, 2019
 # Pavol Šimo <palo.simo@gmail.com>, 2015
 # Tibor Kaputa <tibbbi2@gmail.com>, 2014
+# Juraj Liso <lisojuraj@gmail.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/sk.po
+++ b/po/sk.po
@@ -2,8 +2,12 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Valmantas Palikša https://launchpad.net/~walmis
+# menganito https://launchpad.net/~igor-kysel
+# milboy https://launchpad.net/~milboys
+# vadimo https://launchpad.net/~michalgejdos-azet
+# xills pills https://launchpad.net/~adamturan
 # Dušan Kazik <prescott66@gmail.com>, 2015,2017,2019
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
 # Ján Ďanovský <dagsoftware@yahoo.com>, 2014-2017
 # Jose Riha <jose1711@gmail.com>, 2019
 # Pavol Šimo <palo.simo@gmail.com>, 2015
@@ -741,16 +745,6 @@ msgstr "Vybrať zariadenie"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Viac"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  menganito https://launchpad.net/~igor-kysel\n"
-"  milboy https://launchpad.net/~milboys\n"
-"  vadimo https://launchpad.net/~michalgejdos-azet\n"
-"  xills pills https://launchpad.net/~adamturan"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/sl.po
+++ b/po/sl.po
@@ -2,6 +2,9 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Matej Urbančič https://launchpad.net/~matej-urban
+# Valmantas Palikša https://launchpad.net/~walmis
+# Damir Jerovšek <damir.jerovsek@ubuntu.si>
 # Damir Jerovšek <jierro@windowslive.com>, 2014
 # Helena S <ele@tutamail.com>, 2017
 # Marko Šterman <marko.chamillionaire@gmail.com>, 2014
@@ -733,14 +736,6 @@ msgstr "Izbor naprave"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Več"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Matej Urbančič https://launchpad.net/~matej-urban\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Damir Jerovšek <damir.jerovsek@ubuntu.si>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/sq.po
+++ b/po/sq.po
@@ -2,6 +2,9 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Elian Myftiu <elian@alblinux.net>
+# Laurent Dhima <laurenti@alblinux.net>
+# Arben Tapia <arbentapia@gmail.com>
 # Ardit Dani <ardit.dani@gmail.com>, 2014,2016
 # Indrit Bashkimi <indrit.bashkimi@gmail.com>, 2015
 msgid ""
@@ -730,13 +733,6 @@ msgstr "Zgjidh pajisjen"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Më shumë"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Elian Myftiu <elian@alblinux.net>, Indrit Bashkimi <indrit.bashkimi@gmail."
-"com>, Laurent Dhima <laurenti@alblinux.net>, Arben Tapia <arbentapia@gmail."
-"com>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/sv.po
+++ b/po/sv.po
@@ -2,9 +2,18 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Andreas Ekholm https://launchpad.net/~arvast
+# Daniel Nylander https://launchpad.net/~yeager
+# Emil Tullstedt https://launchpad.net/~sakjur
+# Fredrik Forsmo https://launchpad.net/~frippe
+# Gruggo https://launchpad.net/~gruggo-
+# Joakim Lundborg https://launchpad.net/~joakim-lundborg
+# Martin Lindhe https://launchpad.net/~martin-unicorn
+# Susanna Björverud https://launchpad.net/~sanna
+# Åskar https://launchpad.net/~olskar
+# Patrik Nilsson <asavar@tzeth.com>
 # Patrik Nilsson <asavartzeth@gmail.com>, 2014
 # Daniel Gullbransen, 2017
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # cb445fb3dfd1fe3c2b9f58ac5638f478, 2015
 # Henrik Mattsson-Mårn <h@reglage.net>, 2016
 # Kristoffer Grundström <hamnisdude@gmail.com>, 2015-2016
@@ -720,23 +729,6 @@ msgstr "Välj enhet"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Mer"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad bidragsgivare:\n"
-"  Andreas Ekholm https://launchpad.net/~arvast\n"
-"  Daniel Nylander https://launchpad.net/~yeager\n"
-"  Emil Tullstedt https://launchpad.net/~sakjur\n"
-"  Fredrik Forsmo https://launchpad.net/~frippe\n"
-"  Gruggo https://launchpad.net/~gruggo-\n"
-"  Joakim Lundborg https://launchpad.net/~joakim-lundborg\n"
-"  Martin Lindhe https://launchpad.net/~martin-unicorn\n"
-"  Susanna Björverud https://launchpad.net/~sanna\n"
-"  Åskar https://launchpad.net/~olskar\n"
-"\n"
-"Transifex bidragsgivare:\n"
-"  Patrik Nilsson <asavar@tzeth.com>"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/sw.po
+++ b/po/sw.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2009
+# MwalimuJini https://launchpad.net/~dude-thony
 # MIRIAM ADHIAMBO OLOO <miriam.cpitalia@gmail.com>, 2016
 msgid ""
 msgstr ""
@@ -706,12 +706,6 @@ msgstr ""
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  MwalimuJini https://launchpad.net/~dude-thony"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/ta.po
+++ b/po/ta.po
@@ -2,7 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
+# Valmantas Palikša https://launchpad.net/~walmis
+# bhuvi https://launchpad.net/~bhuvanesh
 # Kamala Kannan, 2016
 # Mooglie <mooglietech@gmail.com>, 2017
 msgid ""
@@ -713,13 +714,6 @@ msgstr ""
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  bhuvi https://launchpad.net/~bhuvanesh"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/tr.po
+++ b/po/tr.po
@@ -19,7 +19,6 @@
 # Butterfly <gokhanlnx@gmail.com>, 2017
 # Cenk Yıldızlı <goncagul@national.shitposting.agency>, 2019
 # mauron, 2017-2018
-# tarakbumba <tarakbumba@gmail.com>, 2014
 # Oğuz Ersen <oguzersen@protonmail.com>, 2020.
 msgid ""
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -2,10 +2,22 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Berkan Demirci
+# Burak Anıl
+# DenizCakir
+# Emre UGUR
+# Kubilayk
+# Murat Bişkin
+# Osman Tosun
+# Said Tahsin Dane
+# Serdar Delican
+# Serdar KAHYA
+# Valmantas Palikša
+# Yiğit Ateş
+# Oğuz Ersen
 # tarakbumba <tarakbumba@gmail.com>, 2014-2015
 # Butterfly <gokhanlnx@gmail.com>, 2017
 # Cenk Yıldızlı <goncagul@national.shitposting.agency>, 2019
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
 # mauron, 2017-2018
 # tarakbumba <tarakbumba@gmail.com>, 2014
 # Oğuz Ersen <oguzersen@protonmail.com>, 2020.
@@ -718,23 +730,6 @@ msgstr "Aygıt Seç"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Daha Fazla"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Berkan Demirci\n"
-"Burak Anıl\n"
-"DenizCakir\n"
-"Emre UGUR\n"
-"Kubilayk\n"
-"Murat Bişkin\n"
-"Osman Tosun\n"
-"Said Tahsin Dane\n"
-"Serdar Delican\n"
-"Serdar KAHYA\n"
-"Valmantas Palikša\n"
-"Yiğit Ateş\n"
-"Oğuz Ersen"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/uk.po
+++ b/po/uk.po
@@ -14,10 +14,7 @@
 # shcherbet https://launchpad.net/~shcherbet
 # Сергій Матрунчик (SkyMan) https://launchpad.net/~skymanphp
 # Oleh, 2014
-# Микола Ткач <chistomov@gmail.com>, 2019
-# Микола Ткач <chistomov@gmail.com>, 2014-2016
-# Микола Ткач <chistomov@gmail.com>, 2017-2018
-# Микола Ткач <chistomov@gmail.com>, 2017
+# Микола Ткач <chistomov@gmail.com>, 2014-2019
 # Yuri Chornoivan <yurchor@ukr.net>
 msgid ""
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -18,6 +18,7 @@
 # Микола Ткач <chistomov@gmail.com>, 2014-2016
 # Микола Ткач <chistomov@gmail.com>, 2017-2018
 # Микола Ткач <chistomov@gmail.com>, 2017
+# Yuri Chornoivan <yurchor@ukr.net>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -2,7 +2,17 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
+# Микола Ткач <Stuartlittle1970@gmail.com>
+# Andrey https://launchpad.net/~andreysey
+# CrabMan https://launchpad.net/~oleg-min
+# Eugene Babiy https://launchpad.net/~eugene-babiy
+# Knedlyk https://launchpad.net/~yupadmin
+# Nizzzia https://launchpad.net/~nizzzia
+# Serhey Kusyumoff (Сергій Кусюмов) https://launchpad.net/~sergemine
+# Valmantas Palikša https://launchpad.net/~walmis
+# atany https://launchpad.net/~ye-gorshkov
+# shcherbet https://launchpad.net/~shcherbet
+# Сергій Матрунчик (SkyMan) https://launchpad.net/~skymanphp
 # Oleh, 2014
 # Микола Ткач <chistomov@gmail.com>, 2019
 # Микола Ткач <chistomov@gmail.com>, 2014-2016
@@ -742,24 +752,6 @@ msgstr "Оберіть пристрій"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "Додатково"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Інформація про перекладачів:\n"
-"Transifex Contributions:\n"
-"  Микола Ткач <Stuartlittle1970@gmail.com>\n"
-"Launchpad Contributions:\n"
-"  Andrey https://launchpad.net/~andreysey\n"
-"  CrabMan https://launchpad.net/~oleg-min\n"
-"  Eugene Babiy https://launchpad.net/~eugene-babiy\n"
-"  Knedlyk https://launchpad.net/~yupadmin\n"
-"  Nizzzia https://launchpad.net/~nizzzia\n"
-"  Serhey Kusyumoff (Сергій Кусюмов) https://launchpad.net/~sergemine\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  atany https://launchpad.net/~ye-gorshkov\n"
-"  shcherbet https://launchpad.net/~shcherbet\n"
-"  Сергій Матрунчик (SkyMan) https://launchpad.net/~skymanphp"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/vi.po
+++ b/po/vi.po
@@ -2,7 +2,9 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008
+# Bruce Doan https://launchpad.net/~rgv151
+# Valmantas Palikša https://launchpad.net/~walmis
+# huanctv https://launchpad.net/~huanctv
 # Meongu Ng. <meongu@gmail.com>, 2016
 msgid ""
 msgstr ""
@@ -710,14 +712,6 @@ msgstr "Chọn thiết bị"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Bruce Doan https://launchpad.net/~rgv151\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  huanctv https://launchpad.net/~huanctv"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -35,6 +35,7 @@
 # 敏超 马 <mcjoys@163.com>, 2020
 # 玉堂白鹤 <yjwork@qq.com>, 2015
 # Mingcong Bai <jeffbai@aosc.xyz>, 2015
+# Heart & Soul <shenzhe100@126.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,6 +2,30 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
+# Aron Xu https://launchpad.net/~happyaron
+# BiOgErM https://launchpad.net/~biogerm
+# Careone https://launchpad.net/~zzbusagain
+# D4nielfree https://launchpad.net/~d4nielfree
+# Dingar https://launchpad.net/~cndingar
+# EAdam https://launchpad.net/~liuannan
+# GrayWaLL https://launchpad.net/~graywall
+# Heling Yao https://launchpad.net/~hyao
+# Jimhu https://launchpad.net/~huyiwei
+# Kyle WANG https://launchpad.net/~osfans
+# Mu Yang https://launchpad.net/~mu-yang-gmail
+# Valmantas Palikša https://launchpad.net/~walmis
+# Wentao Tang https://launchpad.net/~wisetang
+# Zhang.H https://launchpad.net/~i-zhh
+# ZhangCheng https://launchpad.net/~xxzc
+# crazycode https://launchpad.net/~crazycode08
+# fpoint https://launchpad.net/~fpoint
+# ginus https://launchpad.net/~ginus800615
+# luojie-dune https://launchpad.net/~luojie-dune
+# lyman https://launchpad.net/~lyman
+# sascsy https://launchpad.net/~sascsy
+# yanq.wang https://launchpad.net/~nile-wangyq
+# 丁鑫_XJTU https://launchpad.net/~xgnid
+# 王英华 https://launchpad.net/~wantinghard
 # Aron Xu <Unknown>, 2007
 # shuyu liu <liushuyu011@gmail.com>, 2017
 # Mingcong Bai <jeffbai@aosc.xyz>, 2017
@@ -731,35 +755,6 @@ msgstr "选择设备"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "更多"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Aron Xu https://launchpad.net/~happyaron\n"
-"  BiOgErM https://launchpad.net/~biogerm\n"
-"  Careone https://launchpad.net/~zzbusagain\n"
-"  D4nielfree https://launchpad.net/~d4nielfree\n"
-"  Dingar https://launchpad.net/~cndingar\n"
-"  EAdam https://launchpad.net/~liuannan\n"
-"  GrayWaLL https://launchpad.net/~graywall\n"
-"  Heling Yao https://launchpad.net/~hyao\n"
-"  Jimhu https://launchpad.net/~huyiwei\n"
-"  Kyle WANG https://launchpad.net/~osfans\n"
-"  Mu Yang https://launchpad.net/~mu-yang-gmail\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  Wentao Tang https://launchpad.net/~wisetang\n"
-"  Zhang.H https://launchpad.net/~i-zhh\n"
-"  ZhangCheng https://launchpad.net/~xxzc\n"
-"  crazycode https://launchpad.net/~crazycode08\n"
-"  fpoint https://launchpad.net/~fpoint\n"
-"  ginus https://launchpad.net/~ginus800615\n"
-"  luojie-dune https://launchpad.net/~luojie-dune\n"
-"  lyman https://launchpad.net/~lyman\n"
-"  sascsy https://launchpad.net/~sascsy\n"
-"  yanq.wang https://launchpad.net/~nile-wangyq\n"
-"  丁鑫_XJTU https://launchpad.net/~xgnid\n"
-"  王英华 https://launchpad.net/~wantinghard"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -28,13 +28,12 @@
 # 王英华 https://launchpad.net/~wantinghard
 # Aron Xu <Unknown>, 2007
 # shuyu liu <liushuyu011@gmail.com>, 2017
-# Mingcong Bai <jeffbai@aosc.xyz>, 2017
+# Mingcong Bai <jeffbai@aosc.xyz>, 2015,2017
 # Wylmer Wang, 2014
 # liulitchi <xingzuo88@qq.com>, 2014
 # zhineng404 <zhinengge@gmail.com>, 2019
 # 敏超 马 <mcjoys@163.com>, 2020
 # 玉堂白鹤 <yjwork@qq.com>, 2015
-# Mingcong Bai <jeffbai@aosc.xyz>, 2015
 # Heart & Soul <shenzhe100@126.com>
 msgid ""
 msgstr ""

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -2,7 +2,8 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2009
+# Valmantas Palikša https://launchpad.net/~walmis
+# yanq.wang https://launchpad.net/~nile-wangyq
 # Janfy Tan <janfytan@gmail.com>, 2016
 # Walter Cheuk <wwycheuk@gmail.com>, 2016
 msgid ""
@@ -710,13 +711,6 @@ msgstr ""
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr ""
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"Launchpad Contributions:\n"
-"  Valmantas Palikša https://launchpad.net/~walmis\n"
-"  yanq.wang https://launchpad.net/~nile-wangyq"
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2,7 +2,10 @@
 # This file is distributed under the same license as the blueman package.
 #
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007
+# 黃柏諺 <s8321414@yahoo.com.tw>,2013-14
+# Jose Sun https://launchpad.net/~josesun
+# Toomore https://launchpad.net/~toomore
+# fetag https://launchpad.net/~coolfire
 # Hsiu-Ming Chang <cges30901@gmail.com>, 2019
 # 黃柏諺 <s8321414@gmail.com>, 2015,2017,2019
 # Walter Cheuk <wwycheuk@gmail.com>, 2016-2017
@@ -728,16 +731,6 @@ msgstr "選擇裝置"
 #: blueman/gui/MessageArea.py:38
 msgid "More"
 msgstr "更多"
-
-#: blueman/gui/CommonUi.py:58
-msgid "translator-credits"
-msgstr ""
-"黃柏諺 <s8321414@yahoo.com.tw>,2013-14\n"
-"Launchpad 貢獻者：\n"
-"  Jose Sun https://launchpad.net/~josesun\n"
-"  Toomore https://launchpad.net/~toomore\n"
-"  fetag https://launchpad.net/~coolfire\n"
-"Walter Cheuk <wwycheuk@gmail.com>, 2016."
 
 #: blueman/gui/CommonUi.py:63
 msgid "Blueman is a GTK+ Bluetooth manager"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,10 +7,8 @@
 # Toomore https://launchpad.net/~toomore
 # fetag https://launchpad.net/~coolfire
 # Hsiu-Ming Chang <cges30901@gmail.com>, 2019
-# 黃柏諺 <s8321414@gmail.com>, 2015,2017,2019
+# 黃柏諺 <s8321414@gmail.com>, 2014-2015,2017,2019
 # Walter Cheuk <wwycheuk@gmail.com>, 2016-2017
-# 黃柏諺 <s8321414@gmail.com>, 2014
-# 黃柏諺 <s8321414@gmail.com>, 2019
 # marklin0913da248e4cdada422a <marklin0913@protonmail.com>
 msgid ""
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -11,6 +11,7 @@
 # Walter Cheuk <wwycheuk@gmail.com>, 2016-2017
 # 黃柏諺 <s8321414@gmail.com>, 2014
 # 黃柏諺 <s8321414@gmail.com>, 2019
+# marklin0913da248e4cdada422a <marklin0913@protonmail.com>
 msgid ""
 msgstr ""
 "Project-Id-Version: blueman-project\n"


### PR DESCRIPTION
See #1367 for discussion. I moved the Launchpad translators into the po file headers and added all Weblate translators that contributed only before I activated the plugin that adds them automatically. I think it would be nice to get *all* translators (without discriminating by platform or date of contribution) into the about dialog again but that requires some tooling that picks them up from the headers as maintaining that manually does not sound like an option to me.