### PR TITLE
Improve passkey handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Allow opening device menus via keyboard (Shift+F10 or menu key)
 * Add Ctrl+Q and Ctrl+W accelerators for closing blueman-manager
 * Allow cancelling device connection attempts
+* Improved passkey handling (fixed padding, highlighting, single notifitication)
 
 ### Bugs fixed
 

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -284,7 +284,7 @@ class BluezAgent(DbusService):
         notify_message = _("Pairing request for:") + f"\n{self.get_device_string(device_path)}"
 
         if passkey:
-            notify_message += "\n" + _("Confirm value for authentication:") + f" <b>{passkey}</b>"
+            notify_message += "\n" + _("Confirm value for authentication:") + f" <b>{passkey:06}</b>"
         actions = [("confirm", _("Confirm")), ("deny", _("Deny"))]
 
         self._notification = Notification("Bluetooth", notify_message, 0, actions, on_confirm_action,

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman 2.2\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-11-28 09:27+0100\n"
+"POT-Creation-Date: 2020-12-01 22:59+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -391,60 +391,60 @@ msgstr ""
 msgid "Local Services"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:191
+#: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:202 blueman/main/applet/BluezAgent.py:312
+#: blueman/main/applet/BluezAgent.py:203 blueman/main/applet/BluezAgent.py:319
 msgid "Bluetooth Authentication"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:231
+#: blueman/main/applet/BluezAgent.py:234
 msgid "Enter PIN code for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:246
+#: blueman/main/applet/BluezAgent.py:249
 msgid "Enter passkey for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:256
+#: blueman/main/applet/BluezAgent.py:260
 msgid "Pairing passkey for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:265
+#: blueman/main/applet/BluezAgent.py:271
 msgid "Pairing PIN code for"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:278
+#: blueman/main/applet/BluezAgent.py:284
 msgid "Pairing request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:281
+#: blueman/main/applet/BluezAgent.py:287
 msgid "Confirm value for authentication:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:282
+#: blueman/main/applet/BluezAgent.py:288
 msgid "Confirm"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:282 blueman/main/applet/BluezAgent.py:310
+#: blueman/main/applet/BluezAgent.py:288 blueman/main/applet/BluezAgent.py:317
 msgid "Deny"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:307
+#: blueman/main/applet/BluezAgent.py:314
 msgid "Authorization request for:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:307
+#: blueman/main/applet/BluezAgent.py:314
 msgid "Service:"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:308
+#: blueman/main/applet/BluezAgent.py:315
 msgid "Always accept"
 msgstr ""
 
-#: blueman/main/applet/BluezAgent.py:309
+#: blueman/main/applet/BluezAgent.py:316
 #: blueman/plugins/applet/TransferService.py:130
 msgid "Accept"
 msgstr ""


### PR DESCRIPTION
DisplayPasskey is mainly used for pairing KeyboardOnly devices (a.k.a. Bluetooth keyboards) but might also get called if we are the initiator of a legacy pairing to a KeyboardDisplay device. This improves several aspects of the implementation:

* Add padding to avoid showing incomplete passkeys.
* Use the provided information of how much of the passkey has already been entered to guide the user while typing.
* Avoid adding more and more notifications while typing by closing and thus replacing the previous one.

The implementation assumes that `entered` is at most 5 and `Cancel` gets called when the sixth digit got received. Unfortunately I do not have a KeyboardOnly or pre Bluetooth 2.1 legacy device to test if that's actually the case (... and looking at the kernel source I fear that it depends on drivers / firmware / hardware / remote device... :facepalm:)

Closes #1428