### PR TITLE
Fix discovery state handling

### DIFF
--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -139,9 +139,8 @@ class DeviceList(GenericList):
         if not self.Adapter or self.Adapter.get_object_path() != path:
             return
 
-        if key == "Discovering":
-            if not value and self.discovering:
-                self.stop_discovery()
+        if key == "Discovering" and not value:
+            self.discovering = False
 
         self.emit("adapter-property-changed", self.Adapter, (key, value))
 


### PR DESCRIPTION
#1433 was wrong. The `discovering` property's is not there to represent the discovering state but to control the progress update. When it gets set to False, `update_progress` stops. We cannot use the actual discovering state of the adapter as it might not have been set yet right when we start the progress and we cannot just drop the check as we keep emitting `discovery-progress` events then if the discovery was not stopped by the timeout, so we need such a control property.