### PR TITLE
Handle added adapters in DiscvManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * Fix disconnecting NMDevice
 * Exceptions from asynchronous DBus calls (getting picked up by tools like Apport or ABRT)
+* DiscvManager plugin showed its icon unreliably
 
 ## 2.1.4
 

--- a/blueman/plugins/applet/DiscvManager.py
+++ b/blueman/plugins/applet/DiscvManager.py
@@ -73,6 +73,11 @@ class DiscvManager(AppletPlugin):
         except DBusNoSuchAdapterError:
             self.adapter = None
 
+    def on_adapter_added(self, path: str) -> None:
+        if self.adapter is None:
+            self.init_adapter()
+            self.update_menuitems()
+
     def on_adapter_removed(self, path: str) -> None:
         logging.info(path)
         if self.adapter is None:

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman 2.2\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-11-26 01:14+0100\n"
+"POT-Creation-Date: 2020-11-28 09:27+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2334,7 +2334,7 @@ msgid "Amount of time in seconds discoverable mode will last"
 msgstr ""
 
 #: blueman/plugins/applet/DiscvManager.py:35
-#: blueman/plugins/applet/DiscvManager.py:118
+#: blueman/plugins/applet/DiscvManager.py:123
 msgid "_Make Discoverable"
 msgstr ""
 


### PR DESCRIPTION
I realized that this menu item was constantly missing if blueman-applet started with Bluetooth disabled. The reason is simply that the plugin checks the availability of an adapter when the D-Bus object manager becomes available or when the current adapter gets removed but not if an adapter gets added. It thus only shows the item if an adapter is available already when the object manager becomes available and only until it gets removed.