### PR TITLE
Fix popup menus no rendering

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -167,7 +167,7 @@ class ManagerDeviceList(DeviceList):
                         if self.menu is None:
                             self.menu = ManagerDeviceMenu(self.Blueman)
 
-                        self.menu.popup(None, None, None, None, event.button, event.time)
+                        self.menu.popup_at_pointer(event)
 
     def get_icon_info(self, icon_name, size=48, fallback=True):
         if icon_name is None and not fallback:

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -59,11 +59,11 @@ class ManagerDeviceMenu(Gtk.Menu):
     def __del__(self):
         logging.debug("deleting devicemenu")
 
-    def popup(self, *args):
+    def popup_at_pointer(self, event):
         self.is_popup = True
         self.generate()
 
-        super().popup(*args)
+        super().popup_at_pointer(event)
 
     def clear(self):
         def remove_and_destroy(child):


### PR DESCRIPTION
When right clicking on a device, nothing happens. It turns out the code is in-place to show some rather useful menus. However, popup menus need to have a parent to be drawn:

```
Gdk-Message: 14:55:46.423: Window 0x55ee0e347360 is a temporary window without parent, application will not be able to position it on screen.

(blueman-manager:459528): Gdk-CRITICAL **: 14:55:46.427: gdk_wayland_window_handle_configure_popup: assertion 'impl->transient_for' failed
```

This tiny change fixes the issue. I'm no terribly familiar with Gtk, but some quick research indicates that this seems to be the recommended approach for this for contextual popup menus.

I've tested this and it works fine. Most of the hard work was done TBH.

### Previous behaviour

- Double clicking or right clicking on a device does nothing.

### New behaviour

- Right clicking on a device opens a menu with relevant actions.

### Notes

I actually set out to implement a behaviour so that double-clicking a device would connect to it, but found this menus logic in-place, so though it would make sense to address that instead.

Master has been heavily refactored, so I'm not sure what the behaviour is there. This mostly adds this behaviour / fix to the 2.1 branch.

### Caveats

Right-clicking on a device that's connected shows a `connect` action, rather than `Disconnect`.