### PR TITLE
Improve service interface and Services plugin

### DIFF
--- a/blueman/Service.py
+++ b/blueman/Service.py
@@ -1,8 +1,28 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Callable, List, Set, Collection
 
 from blueman.Sdp import ServiceUUID
 from blueman.bluez.Device import Device
+
+
+class Instance:
+    def __init__(self, name: str, port: int = 0) -> None:
+        self.name = name
+        self.port = port
+
+
+class Action:
+    def __init__(self, title: str, icon: str, plugins: Collection[str], callback: Callable[[], None]) -> None:
+        self.title = title
+        self.icon = icon
+        self.plugins = plugins
+        self.callback = callback
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Action) and self.title == other.title
+
+    def __hash__(self) -> int:
+        return hash(self.title)
 
 
 class Service(ABC):
@@ -45,10 +65,19 @@ class Service(ABC):
 
     @property
     @abstractmethod
-    def connected(self) -> bool:
+    def available(self) -> bool:
         ...
 
     @property
     @abstractmethod
-    def available(self) -> bool:
+    def connectable(self) -> bool:
         ...
+
+    @property
+    @abstractmethod
+    def connected_instances(self) -> List[Instance]:
+        ...
+
+    @property
+    def common_actions(self) -> Set[Action]:
+        return set()

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -48,7 +48,6 @@ class Services(ManagerPlugin, MenuItemsProvider):
         appl = AppletService()
 
         self.has_dun = False
-        serial_items: List[Gtk.MenuItem] = []
 
         def add_menu_item(manager_menu: ManagerDeviceMenu, service: Service) -> None:
             if service.connected:
@@ -61,12 +60,9 @@ class Services(ManagerPlugin, MenuItemsProvider):
                 if service.description:
                     item.props.tooltip_text = service.description
                 item.connect("activate", manager_menu.on_connect, service)
-                if isinstance(service, SerialService):
-                    serial_items.append(item)
-                    if isinstance(service, DialupNetwork):
-                        self.has_dun = True
-                else:
-                    items.append((item, service.priority))
+                if isinstance(service, DialupNetwork):
+                    self.has_dun = True
+                items.append((item, service.priority))
             item.props.sensitive = service.available
             item.show()
 
@@ -102,28 +98,9 @@ class Services(ManagerPlugin, MenuItemsProvider):
                 d.run()
                 d.destroy()
 
-            item = Gtk.SeparatorMenuItem()
-            item.show()
-            serial_items.append(item)
-
             item = create_menuitem(_("Dialup Settings"), "preferences-other")
-            serial_items.append(item)
+            items.append((item, 250))
             item.show()
             item.connect("activate", open_settings, device)
-
-        if len(serial_items) > 1:
-            sub = Gtk.Menu()
-            sub.show()
-
-            item = create_menuitem(_("Serial Ports"), "modem")
-            item.set_submenu(sub)
-            item.show()
-            items.append((item, 90))
-
-            for item in serial_items:
-                sub.append(item)
-        else:
-            for item in serial_items:
-                items.append((item, 80))
 
         return items

--- a/blueman/services/DialupNetwork.py
+++ b/blueman/services/DialupNetwork.py
@@ -1,8 +1,27 @@
+from gettext import gettext as _
+from typing import Set
+
+from blueman.Service import Action
 from blueman.services.meta import SerialService
 from blueman.Sdp import DIALUP_NET_SVCLASS_ID
+from blueman.gui.GsmSettings import GsmSettings
 
 
 class DialupNetwork(SerialService):
     __svclass_id__ = DIALUP_NET_SVCLASS_ID
     __icon__ = "modem"
     __priority__ = 50
+
+    @property
+    def common_actions(self) -> Set[Action]:
+        def open_settings() -> None:
+            d = GsmSettings(self.device['Address'])
+            d.run()
+            d.destroy()
+
+        return {Action(
+            _("Dialup Settings"),
+            "preferences-other",
+            {'PPPSupport', 'NMDUNSupport'},
+            open_settings
+        )}

--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -1,13 +1,14 @@
+from gettext import gettext as _
 import logging
 import os
 import subprocess
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, List
 
 from gi.repository import Gio, GLib
 
 from blueman.bluez.Adapter import Adapter
-from _blueman import create_rfcomm_device, get_rfcomm_channel, RFCOMMError
-from blueman.Service import Service
+from _blueman import create_rfcomm_device, get_rfcomm_channel, RFCOMMError, rfcomm_list
+from blueman.Service import Service, Instance
 from blueman.bluez.Device import Device
 from blueman.main.DBusProxies import Mechanism
 from blueman.Constants import RFCOMM_WATCHER_PATH
@@ -25,8 +26,13 @@ class SerialService(Service):
         return paired
 
     @property
-    def connected(self) -> bool:
-        return False
+    def connectable(self) -> bool:
+        return True
+
+    @property
+    def connected_instances(self) -> List[Instance]:
+        return [Instance(_("Serial Port %s") % "rfcomm%d" % dev["id"], dev["id"]) for dev in rfcomm_list()
+                if dev["dst"] == self.device['Address'] and dev["state"] == "connected"]
 
     def on_file_changed(
         self,

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -13,7 +13,6 @@ blueman/main/Adapter.py
 blueman/main/DBusProxies.py
 blueman/main/Manager.py
 blueman/main/Sendto.py
-blueman/main/Services.py
 blueman/main/NetConf.py
 blueman/main/PulseAudioUtils.py
 blueman/main/PPPConnection.py
@@ -100,6 +99,9 @@ blueman/plugins/MechanismPlugin.py
 blueman/plugins/services/Network.py
 blueman/plugins/services/__init__.py
 blueman/plugins/services/Transfer.py
+blueman/services/DialupNetwork.py
+blueman/services/meta/SerialService.py
+blueman/services/meta/NetworkService.py
 
 
 data/blueman-adapters.desktop.in

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman 2.2\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-12-11 09:20+0100\n"
+"POT-Creation-Date: 2020-12-13 10:31+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1979,21 +1979,17 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:79
+#: blueman/plugins/manager/Services.py:75
 #, python-format
 msgid "Serial Port %s"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:92
+#: blueman/plugins/manager/Services.py:88
 msgid "Renew IP Address"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:109
+#: blueman/plugins/manager/Services.py:101
 msgid "Dialup Settings"
-msgstr ""
-
-#: blueman/plugins/manager/Services.py:118
-msgid "Serial Ports"
 msgstr ""
 
 #: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -387,10 +387,6 @@ msgstr ""
 msgid "Error occurred"
 msgstr ""
 
-#: blueman/main/Services.py:24
-msgid "Local Services"
-msgstr ""
-
 #: blueman/main/applet/BluezAgent.py:192
 #, python-format
 msgid "Pairing request for %s"
@@ -1979,19 +1975,6 @@ msgstr ""
 msgid "Select audio profile for PulseAudio"
 msgstr ""
 
-#: blueman/plugins/manager/Services.py:75
-#, python-format
-msgid "Serial Port %s"
-msgstr ""
-
-#: blueman/plugins/manager/Services.py:88
-msgid "Renew IP Address"
-msgstr ""
-
-#: blueman/plugins/manager/Services.py:101
-msgid "Dialup Settings"
-msgstr ""
-
 #: blueman/plugins/BasePlugin.py:34 blueman/plugins/BasePlugin.py:35
 msgid "Unspecified"
 msgstr ""
@@ -2472,6 +2455,19 @@ msgstr ""
 
 #: blueman/plugins/services/Transfer.py:28
 msgid "Applet's transfer service plugin is disabled"
+msgstr ""
+
+#: blueman/services/DialupNetwork.py:23
+msgid "Dialup Settings"
+msgstr ""
+
+#: blueman/services/meta/SerialService.py:34
+#, python-format
+msgid "Serial Port %s"
+msgstr ""
+
+#: blueman/services/meta/NetworkService.py:51
+msgid "Renew IP Address"
 msgstr ""
 
 #: data/blueman-adapters.desktop.in:4


### PR DESCRIPTION
This is split off from #1414 to get it rolling.

* Remove serial service submenu from device menu

The submenu seems rather pointless and random. It is only used if a DUN and / or multiple serial services are available. In the most usual case it only holds a connect item for the DUN service and the settings item. Disconnect items do not get added to the submenu.

* Replace connected with connectable as it is already misused as "not connectable" (serial services return False even if they are connected as they are still connectable). (Note that "connectable" is independent of "available" as it is used to show disabled connect items).
* Add connected_instances to provide per-service disconnect items.
* Add common_actions to provide actions that shall be shown if any of the services specifies them.

The additions allow to remove service-specific stuff from the Services plugin. An intentional change is that serial port disconnect items now use the service's blueman-serial icon instead of modem.