### PR TITLE
AutoConnect: Run when new adapters become available

### DIFF
--- a/blueman/plugins/applet/AutoConnect.py
+++ b/blueman/plugins/applet/AutoConnect.py
@@ -1,5 +1,5 @@
 from gettext import gettext as _
-from typing import TYPE_CHECKING, Union, Optional
+from typing import TYPE_CHECKING, Union, Optional, Any
 
 from gi.repository import GLib
 
@@ -33,6 +33,10 @@ class AutoConnect(AppletPlugin):
 
     def on_manager_state_changed(self, state: bool) -> None:
         if state:
+            self._run()
+
+    def on_adapter_property_changed(self, path: str, key: str, value: Any) -> None:
+        if key == "Powered" and value:
             self._run()
 
     def _run(self) -> bool:

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman 2.2\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2020-12-13 10:31+0100\n"
+"POT-Creation-Date: 2021-04-14 18:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1989,14 +1989,14 @@ msgid ""
 msgstr ""
 
 #. https://github.com/python/mypy/issues/2608
-#: blueman/plugins/applet/AutoConnect.py:46
+#: blueman/plugins/applet/AutoConnect.py:50
 #: blueman/plugins/applet/ConnectionNotifier.py:21
 #: blueman/plugins/applet/RecentConns.py:219
 #: blueman/plugins/applet/PPPSupport.py:75
 msgid "Connected"
 msgstr ""
 
-#: blueman/plugins/applet/AutoConnect.py:46
+#: blueman/plugins/applet/AutoConnect.py:50
 #, python-format
 msgid "Automatically connected to %(service)s on %(device)s"
 msgstr ""


### PR DESCRIPTION
Triggered when Bluetooth gets unblocked or a new adapter gets added. We do not have to wait for the timer in those situations.

#1466