### PR TITLE
Make StatusIcon plugin unloadable

### DIFF
--- a/blueman/plugins/applet/AuthAgent.py
+++ b/blueman/plugins/applet/AuthAgent.py
@@ -8,7 +8,6 @@ class AuthAgent(AppletPlugin):
     __description__ = _("Provides passkey, authentication services for BlueZ daemon")
     __icon__ = "blueman-pair-symbolic"
     __author__ = "Walmis"
-    __depends__ = ["StatusIcon"]
 
     _agent = None
 

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -42,7 +42,6 @@ class ServiceConnectHandler:
 
 
 class DBusService(AppletPlugin):
-    __depends__ = ["StatusIcon"]
     __unloadable__ = False
     __description__ = _("Provides DBus API for other Blueman components")
     __author__ = "Walmis"

--- a/blueman/plugins/applet/KillSwitch.py
+++ b/blueman/plugins/applet/KillSwitch.py
@@ -37,7 +37,7 @@ class KillSwitch(AppletPlugin, PowerStateHandler, StatusIconVisibilityHandler):
     __description__ = _("Switches Bluetooth killswitch status to match Bluetooth power state. "
                         "Allows turning Bluetooth back on from an icon that shows its status; "
                         "provided it isn't unplugged by the system, or physically.")
-    __depends__ = ["PowerManager", "StatusIcon"]
+    __depends__ = ["PowerManager"]
     __icon__ = "system-shutdown-symbolic"
 
     __gsettings__ = {
@@ -121,7 +121,8 @@ class KillSwitch(AppletPlugin, PowerStateHandler, StatusIconVisibilityHandler):
 
         logging.info(f"State: {self._enabled}")
 
-        self.parent.Plugins.StatusIcon.query_visibility(delay_hiding=not self._hardblocked)
+        if "StatusIcon" in self.parent.Plugins.get_loaded():
+            self.parent.Plugins.StatusIcon.query_visibility(delay_hiding=not self._hardblocked)
         self.parent.Plugins.PowerManager.update_power_state()
 
         return True

--- a/blueman/plugins/applet/NMDUNSupport.py
+++ b/blueman/plugins/applet/NMDUNSupport.py
@@ -11,7 +11,7 @@ from blueman.plugins.applet.DBusService import ServiceConnectHandler
 
 
 class NMDUNSupport(AppletPlugin, ServiceConnectHandler):
-    __depends__ = ["StatusIcon", "DBusService"]
+    __depends__ = ["DBusService"]
     __conflicts__ = ["PPPSupport"]
     __icon__ = "modem-symbolic"
     __author__ = "infirit"

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -26,7 +26,7 @@ class PowerStateHandler:
 
 
 class PowerManager(AppletPlugin, StatusIconProvider):
-    __depends__ = ["StatusIcon", "Menu"]
+    __depends__ = ["Menu"]
     __unloadable__ = True
     __description__ = _("Controls Bluetooth adapter power states")
     __author__ = "Walmis"
@@ -168,13 +168,14 @@ class PowerManager(AppletPlugin, StatusIconProvider):
             for plugin in self.parent.Plugins.get_loaded_plugins(PowerStateListener):
                 plugin.on_power_state_changed(self, new_state)
 
-            if new_state:
-                self.parent.Plugins.StatusIcon.set_tooltip_title(_("Bluetooth Enabled"))
-                self.parent.Plugins.StatusIcon.query_visibility(delay_hiding=True)
-            else:
-                self.parent.Plugins.StatusIcon.set_tooltip_title(_("Bluetooth Disabled"))
-                self.parent.Plugins.StatusIcon.query_visibility()
-            self.parent.Plugins.StatusIcon.icon_should_change()
+            if "StatusIcon" in self.parent.Plugins.get_loaded():
+                if new_state:
+                    self.parent.Plugins.StatusIcon.set_tooltip_title(_("Bluetooth Enabled"))
+                    self.parent.Plugins.StatusIcon.query_visibility(delay_hiding=True)
+                else:
+                    self.parent.Plugins.StatusIcon.set_tooltip_title(_("Bluetooth Disabled"))
+                    self.parent.Plugins.StatusIcon.query_visibility()
+                self.parent.Plugins.StatusIcon.icon_should_change()
 
     def get_bluetooth_status(self) -> bool:
         return self.current_state

--- a/blueman/plugins/applet/StandardItems.py
+++ b/blueman/plugins/applet/StandardItems.py
@@ -17,7 +17,7 @@ from gi.repository import Gtk, Gdk
 
 
 class StandardItems(AppletPlugin, PowerStateListener):
-    __depends__ = ["StatusIcon", "Menu"]
+    __depends__ = ["Menu"]
     __unloadable__ = False
     __description__ = _("Adds standard menu items to the status icon menu")
     __author__ = "walmis"
@@ -53,8 +53,6 @@ class StandardItems(AppletPlugin, PowerStateListener):
 
         self.parent.Plugins.Menu.add(self, 85, text=_("_Plugins"), icon_name="application-x-addon-symbolic",
                                      callback=self.on_plugins)
-
-        self.parent.Plugins.StatusIcon.connect("activate", lambda _status_icon: self.on_devices())
 
     def change_sensitivity(self, sensitive: bool) -> None:
         if 'PowerManager' in self.parent.Plugins.get_loaded():

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -5,7 +5,6 @@ from gi.repository import GObject, GLib, Gio
 from blueman.Functions import launch
 from blueman.main.PluginManager import PluginManager
 from blueman.plugins.AppletPlugin import AppletPlugin
-from blueman.bluemantyping import GSignals
 
 
 class StatusIconImplementationProvider:
@@ -24,11 +23,8 @@ class StatusIconProvider:
 
 
 class StatusIcon(AppletPlugin, GObject.GObject):
-    __gsignals__: GSignals = {'activate': (GObject.SignalFlags.NO_HOOKS, None, ())}
-
-    __unloadable__ = False
     __icon__ = "bluetooth-symbolic"
-    __depends__ = ['Menu']
+    __depends__ = ["StandardItems", "Menu"]
 
     visible = None
 
@@ -58,7 +54,7 @@ class StatusIcon(AppletPlugin, GObject.GObject):
         self._add_dbus_signal("IconNameChanged", "s")
         self._add_dbus_method("GetStatusIconImplementations", (), "as", self._get_status_icon_implementations)
         self._add_dbus_method("GetIconName", (), "s", self._get_icon_name)
-        self._add_dbus_method("Activate", (), "", lambda: self.emit("activate"))
+        self._add_dbus_method("Activate", (), "", self.parent.Plugins.StandardItems.on_devices)
 
     def query_visibility(self, delay_hiding: bool = False, emit: bool = True) -> None:
         if self.parent.Manager.get_adapters() or \


### PR DESCRIPTION
This provides a solution for #1495 / (#949), however, if a user disables the plugin from the UI, there will be no obvious way for him to re-enable it again (GSettings works, of course).