### PR TITLE
Store networking ip, netmask and dhcphandler in gsettings

### DIFF
--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -29,7 +29,7 @@ class Networking(AppletPlugin):
 
     def on_manager_state_changed(self, state: bool) -> None:
         if state:
-            self.update_status()
+            self.set_nap(self.Config["nap-enable"])
 
     def reload_network(self):
         def reply(_obj: Mechanism, _result: None, _user_data: None) -> None:
@@ -65,9 +65,6 @@ class Networking(AppletPlugin):
             self.show_error_dialog(e)
 
     def on_adapter_added(self, path: str) -> None:
-        self.update_status()
-
-    def update_status(self) -> None:
         self.set_nap(self.Config["nap-enable"])
 
     def load_nap_settings(self):

--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -25,29 +25,11 @@ class Networking(AppletPlugin):
         self.Config.connect("changed", self.on_config_changed)
         self._mechanism = Mechanism()
 
-        self.load_nap_settings()
+        self.set_nap(self.Config['nap-enable'])
 
     def on_manager_state_changed(self, state: bool) -> None:
         if state:
             self.set_nap(self.Config["nap-enable"])
-
-    def reload_network(self):
-        def reply(_obj: Mechanism, _result: None, _user_data: None) -> None:
-            pass
-
-        def err(_obj: Mechanism, result: GLib.Error, _user_data: None) -> None:
-            self.show_error_dialog(result)
-
-        m = Mechanism()
-        m.ReloadNetwork(result_handler=reply, error_handler=err)
-
-    def on_unload(self) -> None:
-        for adapter_path in self._registered:
-            s = NetworkServer(obj_path=adapter_path)
-            s.unregister("nap")
-
-        self._registered = {}
-        del self.Config
 
     def enable_network(self):
         try:
@@ -66,11 +48,6 @@ class Networking(AppletPlugin):
 
     def on_adapter_added(self, path: str) -> None:
         self.set_nap(self.Config["nap-enable"])
-
-    def load_nap_settings(self):
-        logging.info("Loading NAP settings")
-
-        self.reload_network()
 
     def on_config_changed(self, config: Config, key: str) -> None:
         if key in ('nap-enable', 'ipaddress', 'dhcphandler'):

--- a/blueman/plugins/mechanism/Network.py
+++ b/blueman/plugins/mechanism/Network.py
@@ -18,7 +18,6 @@ class Network(MechanismPlugin):
     def on_load(self) -> None:
         self.parent.add_method("DhcpClient", ("s",), "s", self._run_dhcp_client, pass_sender=True, is_async=True)
         self.parent.add_method("EnableNetwork", ("s", "s", "s"), "", self._enable_network, pass_sender=True)
-        self.parent.add_method("ReloadNetwork", (), "", self._reload_network, pass_sender=True)
         self.parent.add_method("DisableNetwork", (), "", self._disable_network, pass_sender=True)
 
     def _run_dhcp_client(self, object_path: str, caller: str, ok: Callable[[str], None],
@@ -50,16 +49,6 @@ class Network(MechanismPlugin):
         nc = NetConf.get_default()
         nc.set_ipv4(ip_address, netmask)
         nc.set_dhcp_handler(DHCPDHANDLERS[dhcp_handler])
-        nc.apply_settings()
-
-    def _reload_network(self, caller: str) -> None:
-        nc = NetConf.get_default()
-        if nc.ip4_address is None or nc.ip4_mask is None:
-            nc.ip4_changed = False
-            nc.store()
-            return
-
-        self.confirm_authorization(caller, "org.blueman.network.setup")
         nc.apply_settings()
 
     def _disable_network(self, caller: str) -> None:

--- a/blueman/plugins/services/Network.py
+++ b/blueman/plugins/services/Network.py
@@ -23,8 +23,10 @@ if TYPE_CHECKING:
 
 class Network(ServicePlugin):
     __plugin_info__ = (_("Network"), "network-workgroup")
+    Config = None
 
     def on_load(self, container: Gtk.Box) -> None:
+        self.Config = Config("org.blueman.network")
 
         self._builder = Builder("services-network.ui")
         self.widget = self._builder.get_widget("network_frame", Gtk.Widget)
@@ -74,6 +76,8 @@ class Network(ServicePlugin):
 
                     if not self.Config["nap-enable"]:
                         self.Config["nap-enable"] = True
+                    self.Config['ipaddress'] = net_ip.props.text
+                    self.Config['dhcphandler'] = stype
                 except Exception as e:
                     parent = self.widget.get_toplevel()
                     assert isinstance(parent, Gtk.Container)
@@ -130,8 +134,6 @@ class Network(ServicePlugin):
         return True
 
     def setup_network(self) -> None:
-        self.Config = Config("org.blueman.network")
-
         nap_enable = self._builder.get_widget("nap-enable", Gtk.CheckButton)
         r_dnsmasq = self._builder.get_widget("r_dnsmasq", Gtk.RadioButton)
         r_dhcpd = self._builder.get_widget("r_dhcpd", Gtk.RadioButton)

--- a/blueman/plugins/services/Network.py
+++ b/blueman/plugins/services/Network.py
@@ -9,7 +9,6 @@ from blueman.main.Builder import Builder
 from blueman.plugins.ServicePlugin import ServicePlugin
 from blueman.main.NetConf import NetConf, DnsMasqHandler, DhcpdHandler, UdhcpdHandler
 from blueman.main.Config import Config
-from blueman.main.DBusProxies import Mechanism
 from blueman.main.DBusProxies import AppletService
 from blueman.gui.CommonUi import ErrorDialog
 
@@ -58,7 +57,6 @@ class Network(ServicePlugin):
         if self.on_query_apply_state():
             logging.info("network apply")
 
-            m = Mechanism()
             nap_enable = self._builder.get_widget("nap-enable", Gtk.CheckButton)
             if nap_enable.props.active:
 
@@ -72,8 +70,6 @@ class Network(ServicePlugin):
                 net_ip = self._builder.get_widget("net_ip", Gtk.Entry)
 
                 try:
-                    m.EnableNetwork('(sss)', net_ip.props.text, "255.255.255.0", stype)
-
                     if not self.Config["nap-enable"]:
                         self.Config["nap-enable"] = True
                     self.Config['ipaddress'] = net_ip.props.text
@@ -88,7 +84,6 @@ class Network(ServicePlugin):
                     return
             else:
                 self.Config["nap-enable"] = False
-                m.DisableNetwork()
 
             self.clear_options()
 

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -133,6 +133,19 @@
       <summary></summary>
       <description></description>
     </key>
+    <key type="s" name="ipaddress">
+      <default>"10.231.10.0"</default>
+      <description>The pan1 bridge ip number</description>
+    </key>
+    <key type="s" name="dhcphandler">
+      <choices>
+        <choice value="DnsMasqHandler" />
+        <choice value="DhcpdHandler" />
+        <choice value="UdhcpdHandler" />
+      </choices>
+      <default>"DnsMasqHandler"</default>
+      <description>The dhcpd server for pan1 bridge</description>
+    </key>
   </schema>
   <schema id="org.blueman.plugins.autoconnect" path="/org/blueman/plugins/autoconnect/">
     <key type="a(ss)" name="services">


### PR DESCRIPTION
I started this when I was looking into having NM handle NAP (which it can easily). For that to be possible [1] I had to move were we store ip, netmask and dhcphandler into the user's domain. I have had this sitting for too long and I really like to finish it. I just rebased against current master, not tested but want to put this out here anyway as draft.

The last step it to remove the pickle bits from NetConf.

[1] maybe not technically but having mechanism query and call NM over dbus I thought was not ideal