### PR TITLE
Fix read only filesystem error.

### DIFF
--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -309,7 +309,7 @@ class NetConf:
             return NetConf.default_inst
 
         try:
-            with open("/var/lib/blueman/network.state", "rb") as f:
+            with open("/var/run/blueman/network.state", "rb") as f:
                 obj: "NetConf" = pickle.load(f)
                 if obj.version != class_id:
                     raise Exception
@@ -477,7 +477,7 @@ class NetConf:
 
     # save the instance of this class, requires root
     def store(self) -> None:
-        if not os.path.exists("/var/lib/blueman"):
-            os.mkdir("/var/lib/blueman")
-        with open("/var/lib/blueman/network.state", "wb") as f:
+        if not os.path.exists("/var/run/blueman"):
+            os.mkdir("/var/run/blueman")
+        with open("/var/run/blueman/network.state", "wb") as f:
             pickle.dump(self, f, 2)


### PR DESCRIPTION

![Screenshot_2021-07-01_10-13-47](https://user-images.githubusercontent.com/38860643/124082294-1202d300-da3c-11eb-90e0-f08c7f7a1c8a.png)

We must move /var/lib/blueman to /var/run/blueman

if We mount root as ro, We cannot write into /var/lib/blueman but we can always write /var/run/blueman because /var/run will mount as tmpfs.