### PR TITLE
Improve DNS server handling in DHCP handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New features
 
 * Audio profile switcher in applet menu (@abhijeetviswa)
+* Set router address as DNS server instead of loopback addresses
+* Enable dnsmasq DNS service if possible and add DNS servers otherwise
 
 ### Changes
 


### PR DESCRIPTION
* Set router address as DNS server instead of loopback addresses
* Enable dnsmasq DNS service if possible and add DNS servers otherwise

Based on and includes #1564