### PR TITLE
Fix error message in blueman-mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## master
+
+### Bugs fixed
+
+* Error message in blueman-mechanism
+
 ## 2.2.1
 
 ### Bugs fixed

--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -10,9 +10,6 @@ if TYPE_CHECKING:
     from blueman.main.Applet import BluemanApplet
 
 
-ictheme = Gtk.IconTheme.get_default()
-
-
 class AppletPlugin(BasePlugin):
     __icon__ = "blueman-plugin"
 
@@ -20,7 +17,7 @@ class AppletPlugin(BasePlugin):
         super().__init__()
         self.parent = parent
 
-        if not ictheme.has_icon(self.__class__.__icon__):
+        if not Gtk.IconTheme.get_default().has_icon(self.__class__.__icon__):
             self.__class__.__icon__ = "blueman-plugin"
 
         self._dbus_service = parent.DbusSvc


### PR DESCRIPTION
Gtk.IconTheme.get_default(), triggered by some imports, cannot work in a typical environment that blueman-mechanism is run in and emits an error message.