### PR TITLE
Be quieter about plugin failures on Wayland

### DIFF
--- a/blueman/main/PluginManager.py
+++ b/blueman/main/PluginManager.py
@@ -13,6 +13,7 @@ from blueman.gui.CommonUi import ErrorDialog
 from blueman.main.Config import Config
 from blueman.plugins.BasePlugin import BasePlugin
 from blueman.bluemantyping import GSignals
+from blueman.plugins.errors import PluginException
 
 
 class LoadException(Exception):
@@ -88,6 +89,8 @@ class PluginManager(GObject.GObject):
                 importlib.import_module(self.module_path.__name__ + f".{plugin}")
             except ImportError:
                 logging.error(f"Unable to load plugin module {plugin}", exc_info=True)
+            except PluginException as err:
+                logging.warning(f"Failed to start plugin {plugin}: {err}")
 
         for cls in self.plugin_class.__subclasses__():
             self.__classes[cls.__name__] = cls

--- a/blueman/plugins/Makefile.am
+++ b/blueman/plugins/Makefile.am
@@ -12,6 +12,7 @@ blueman_PYTHON = 	\
 	MechanismPlugin.py	\
 	ManagerPlugin.py	\
 	BasePlugin.py		\
+	errors.py		\
 	__init__.py
 
 CLEANFILES =		\

--- a/blueman/plugins/applet/GameControllerWakelock.py
+++ b/blueman/plugins/applet/GameControllerWakelock.py
@@ -5,6 +5,7 @@ from typing import Any
 from blueman.bluez.Device import Device
 from blueman.Functions import launch
 from blueman.plugins.AppletPlugin import AppletPlugin
+from blueman.plugins.errors import UnsupportedPlatformError
 
 import gi
 gi.require_version('GdkX11', '3.0')
@@ -12,7 +13,7 @@ gi.require_version('Gdk', '3.0')
 from gi.repository import Gdk, GdkX11
 
 if not isinstance(Gdk.Screen.get_default(), GdkX11.X11Screen):
-    raise ImportError('This is not an X11 screen')
+    raise UnsupportedPlatformError('Only X11 platform is supported')
 
 
 class GameControllerWakelock(AppletPlugin):

--- a/blueman/plugins/errors.py
+++ b/blueman/plugins/errors.py
@@ -1,0 +1,6 @@
+class PluginException(Exception):
+    pass
+
+
+class UnsupportedPlatformError(PluginException):
+    pass

--- a/po/blueman.pot
+++ b/po/blueman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blueman 2.2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/blueman-project/blueman/issues\n"
-"POT-Creation-Date: 2021-06-07 08:58+0200\n"
+"POT-Creation-Date: 2021-10-03 00:42-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Accept"
 msgstr ""
 
-#: blueman/main/PluginManager.py:67
+#: blueman/main/PluginManager.py:68
 msgid ""
 "<b>An error has occured while loading a plugin. Please notify the developers "
 "with the content of this message to our </b>\n"
@@ -2446,7 +2446,7 @@ msgstr ""
 msgid "Turn on all adapters"
 msgstr ""
 
-#: blueman/plugins/applet/GameControllerWakelock.py:19
+#: blueman/plugins/applet/GameControllerWakelock.py:20
 msgid ""
 "Temporarily suspends the screensaver when a bluetooth game controller is "
 "connected."


### PR DESCRIPTION
I get the errors from #1461 a lot so I thought I'd try to quiet them a little bit.

There is no sensible way to implement this feature on Wayland atm, so the behavior stays the same. The only difference is the logging, which will change this

```
blueman-applet 13.56.12 ERROR    PluginManager:90 load_plugin: Unable to load plugin module GameControllerWakelock
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/blueman/main/PluginManager.py", line 88, in load_plugin
    importlib.import_module(self.module_path.__name__ + f".{plugin}")
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/lib/python3.9/site-packages/blueman/plugins/applet/GameControllerWakelock.py", line 15, in <module>
    raise ImportError('This is not an X11 screen')
```

to this:

```
blueman-applet 16.40.30 WARNING  PluginManager:92 load_plugin: Failed to start plugin GameControllerWakelock: Only X11 platform is supported
```