### PR TITLE
Fix handling of common service actions

### DIFF
--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Callable
 
 import cairo
 
@@ -83,6 +83,10 @@ class Services(ManagerPlugin, MenuItemsProvider):
             item = create_menuitem(action.title, action.icon)
             items.append(DeviceMenuItem(item, DeviceMenuItem.Group.ACTIONS, priority + 200))
             item.show()
-            item.connect("activate", lambda _: action.callback())
+            item.connect("activate", self._get_activation_handler(action.callback))
 
         return items
+
+    @staticmethod
+    def _get_activation_handler(callback: Callable[[], None]) -> Callable[[Gtk.MenuItem], None]:
+        return lambda _: callback()


### PR DESCRIPTION
If we have multiple common actions (i.e. dialup settings and IP address renewal) we use one of the callbacks for all menu items.