### PR TITLE
Refactor RecentConns

### DIFF
--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -2,7 +2,7 @@ from gettext import gettext as _
 from operator import itemgetter
 import time
 import logging
-from typing import Dict, List, TYPE_CHECKING, Optional, Callable, cast, Union
+from typing import List, TYPE_CHECKING, Optional, Callable, cast, Union
 
 from blueman.bluez.Device import Device
 from blueman.bluez.errors import DBusNoSuchAdapterError
@@ -58,121 +58,53 @@ class RecentConns(AppletPlugin, PowerStateListener):
     _items = None
 
     def on_load(self) -> None:
-        self._adapters: Dict[str, str] = {}
         self.__menuitems: List["MenuItemDict"] = []
 
-        self.item = self.parent.Plugins.Menu.add(self, 52, text=_("Recent _Connections") + "…",
-                                                 icon_name="document-open-recent", submenu_function=self.get_menu)
+        self._item = self.parent.Plugins.Menu.add(self, 52, text=_("Recent _Connections") + "…",
+                                                  icon_name="document-open-recent", submenu_function=self.get_menu)
         self.parent.Plugins.Menu.add(self, 53)
 
-        self.deferred = False
-
-    def _store_state(self) -> None:
-        self.set_option("recent-connections", [
-            {
-                "adapter": item["adapter"],
-                "address": item["address"],
-                "alias": item["alias"],
-                "icon": item["icon"],
-                "name": item["name"],
-                "uuid": item["uuid"],
-                "time": str(item["time"]),
-            } for item in self.items
-        ])
-
-    def change_sensitivity(self, sensitive: bool) -> None:
-        if 'PowerManager' in self.parent.Plugins.get_loaded():
-            power = self.parent.Plugins.PowerManager.get_bluetooth_status()
-        else:
-            power = True
-
-        sensitive = sensitive and \
-            self.parent.Manager is not None and \
-            power and \
-            self.items is not None and \
-            (len(self.items) > 0)
-
-        self.item.set_sensitive(sensitive)
-
     def on_power_state_changed(self, manager: PowerManager, state: bool) -> None:
-        self.change_sensitivity(state)
-        if state and self.deferred:
-            self.deferred = False
-            self.on_manager_state_changed(state)
+        self._rebuild()
 
     def on_unload(self) -> None:
         self.parent.Plugins.Menu.unregister(self)
 
-    def initialize(self) -> None:
-        logging.info("rebuilding menu")
+    def _rebuild(self) -> None:
+        if 'PowerManager' in self.parent.Plugins.get_loaded() and \
+                not self.parent.Plugins.PowerManager.get_bluetooth_status():
+            self._item.set_sensitive(False)
+            return
 
-        self.__menuitems = []
+        self._items = self._get_items()
+
+        if len(self._items) == 0:
+            self._item.set_sensitive(False)
+            return
+
+        self._item.set_sensitive(True)
+
+        self.__menuitems = [self._build_menu_item(item) for item in self._items[:self.get_option("max-items")]]
+
         self.parent.Plugins.Menu.on_menu_changed()
-
-        self.items.sort(key=itemgetter("time"), reverse=True)
-
-        self._items = self.items[0:self.get_option("max-items")]
-        self.items.reverse()
-
-        if len(self.items) == 0:
-            self.change_sensitivity(False)
-        else:
-            self.change_sensitivity(True)
-
-        count = 0
-        for item in self.items:
-            if count < self.get_option("max-items"):
-                self.add_item(item)
-                count += 1
 
     def on_manager_state_changed(self, state: bool) -> None:
         if state:
-            if 'PowerManager' in self.parent.Plugins.get_loaded():
-                if not self.parent.Plugins.PowerManager.get_bluetooth_status():
-                    self.deferred = True
-                    self.item.set_sensitive(False)
-                    return
-
-            self.item.set_sensitive(True)
-            adapters = self.parent.Manager.get_adapters()
-
-            self._adapters = {adapter.get_object_path(): adapter["Address"]
-                              for adapter in adapters}
-
-            for i in self.items:
-                device_path = self._get_device_path(i["adapter"], i["address"])
-                if device_path:
-                    i["device"] = device_path
-
-            self.initialize()
+            self._rebuild()
         else:
-            self.item.set_sensitive(False)
-            return
-
-        self.change_sensitivity(state)
+            self._item.set_sensitive(False)
 
     def on_device_created(self, path: str) -> None:
-        self._items = None
-        self.initialize()
+        self._rebuild()
 
     def on_device_removed(self, path: str) -> None:
-        for item in reversed(self.items):
-            if item['device'] == path:
-                self.items.remove(item)
-                self.initialize()
+        self._rebuild()
 
     def on_adapter_added(self, path: str) -> None:
-        a = self.parent.Manager.get_adapter(path)
-        self._adapters[path] = a["Address"]
-        self.initialize()
+        self._rebuild()
 
     def on_adapter_removed(self, path: str) -> None:
-        if path in self._adapters:
-            del self._adapters[path]
-        else:
-            logging.warning("Adapter not found in list")
-
-        self.initialize()
+        self._rebuild()
 
     def notify(self, object_path: str, uuid: str) -> None:
         device = Device(obj_path=object_path)
@@ -183,32 +115,31 @@ class RecentConns(AppletPlugin, PowerStateListener):
             logging.warning("adapter not found")
             return
 
-        item: "Item" = {
+        item = {
             "adapter": adapter["Address"],
             "address": device['Address'],
             "alias": device['Alias'],
             "icon": device['Icon'],
             "name": ServiceUUID(uuid).name,
             "uuid": uuid,
-            "time": time.time(),
-            "device": object_path,
-            "mitem": None
+            "time": str(time.time()),
         }
 
-        for i in self.items:
+        stored_items = self.get_option("recent-connections")
+
+        for i in stored_items:
             if i["adapter"] == item["adapter"] and \
                     i["address"] == item["address"] and \
                     i["uuid"] == item["uuid"]:
                 i["time"] = item["time"]
+                i["device"] = object_path
+                break
+        else:
+            stored_items.append(item)
 
-                i["device"] = item["device"]
-                self.initialize()
-                return
+        self.set_option("recent-connections", stored_items)
 
-        self.items.append(item)
-        self.initialize()
-
-        self._store_state()
+        self._rebuild()
 
     def on_item_activated(self, item: "Item") -> None:
         logging.info(f"Connect {item['address']} {item['uuid']}")
@@ -234,17 +165,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
 
         self.parent.Plugins.DBusService.connect_service(item["device"], item["uuid"], reply, err)
 
-    def add_item(self, item: "Item") -> None:
-        if item["adapter"] not in self._adapters.values():
-            item["device"] = None
-        elif not item["device"] and item["adapter"] in self._adapters.values():
-            device = self._get_device_path(item["adapter"], (item["address"]))
-            if device is not None:
-                item["device"] = device
-            else:
-                self.items.remove(item)
-                self.initialize()
-
+    def _build_menu_item(self, item: "Item") -> "MenuItemDict":
         mitem: "MenuItemDict" = {
             "text": _("%(service)s on %(device)s") % {"service": item["name"], "device": item["alias"]},
             "markup": True,
@@ -257,8 +178,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
 
         item["mitem"] = mitem
 
-        self.__menuitems.append(mitem)
-        self.parent.Plugins.Menu.on_menu_changed()
+        return mitem
 
     def get_menu(self) -> List["MenuItemDict"]:
         return self.__menuitems
@@ -272,19 +192,11 @@ class RecentConns(AppletPlugin, PowerStateListener):
         device = self.parent.Manager.find_device(address, adapter.get_object_path())
         return device.get_object_path() if device is not None else None
 
-    @property
-    def items(self) -> List["Item"]:
-        if self._items is not None:
-            return self._items
+    def _get_items(self) -> List["Item"]:
+        adapter_addresses = {adapter["Address"] for adapter in self.parent.Manager.get_adapters()}
 
-        items = self.get_option("recent-connections")
-
-        if not items:
-            self._items = []
-            return self._items
-
-        self._items = [
-            {
+        return sorted(
+            ({
                 "adapter": i["adapter"],
                 "address": i["address"],
                 "alias": i["alias"],
@@ -293,11 +205,11 @@ class RecentConns(AppletPlugin, PowerStateListener):
                 "uuid": i["uuid"],
                 "time": float(i["time"]),
                 "device": (self._get_device_path(i["adapter"], i["address"])
-                           if i["adapter"] in self._adapters.values() else None),
+                           if i["adapter"] in adapter_addresses else None),
                 "mitem": None
             }
-            for i in items
-            if i["adapter"] not in self._adapters.values() or self._get_device_path(i["adapter"], i["address"])
-        ]
-
-        return self._items
+                for i in self.get_option("recent-connections")
+                if i["adapter"] not in adapter_addresses or self._get_device_path(i["adapter"], i["address"])),
+            key=itemgetter("time"),
+            reverse=True
+        )


### PR DESCRIPTION
* Rename initialize to _rebuild, include logic to change sensitivity and call whenever necessary
* Rename add_item to _build_menu_item and remove unnecessary logic
* Add on_device_created
* Modify recent-connections options directly in notify and rebuild menu
* Rename items to _get_items and do not cache