### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: apt-get update
-      - run: apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext libglib2.0-dev python-gi-dev libbluetooth-dev
+      - run: apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext libglib2.0-dev python-gi-dev libbluetooth-dev iproute2
       - run: python3 -m pip install cython mypy==0.812 pycairo>=1.16.3
       - run: ./autogen.sh
       - run: python3 -m mypy -p blueman --strict
@@ -74,11 +74,11 @@ jobs:
           - 3.10-rc
     runs-on: ubuntu-latest
     container:
-      image: python:${{ matrix.python }}
+      image: python:${{ matrix.python }}-buster
     steps:
       - uses: actions/checkout@v2
       - run: apt-get update
-      - run: apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext libglib2.0-dev python-gi-dev libbluetooth-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-appindicator3-0.1 gir1.2-nm-1.0 libpulse0 libpulse-mainloop-glib0
+      - run: apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext libglib2.0-dev python-gi-dev libbluetooth-dev iproute2 libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-appindicator3-0.1 gir1.2-nm-1.0 libpulse0 libpulse-mainloop-glib0
       - run: python3 -m pip install cython pygobject
       - run: ./autogen.sh
       - run: make -C module


### PR DESCRIPTION
The default official Python docker images switched to bullseye recently where iproute2 needs to get installed for ./configure to succeed and libappindicator has been replaced with libayatana-appindicator so that the tests will not work. We thus fix them to buster for now.