### PR TITLE
Increase status icon visibility timeout

### DIFF
--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -65,7 +65,7 @@ class StatusIcon(AppletPlugin, GObject.GObject):
             self.set_visible(True, emit)
         elif not self.visibility_timeout:
             if delay_hiding:
-                self.visibility_timeout = GLib.timeout_add(1000, self.on_visibility_timeout)
+                self.visibility_timeout = GLib.timeout_add(2500, self.on_visibility_timeout)
             else:
                 self.set_visible(False, emit)
 


### PR DESCRIPTION
When turning bluetooth on using the applet the tray status icon flickers (disappears the re-appears). This is annoying when a user opens a menu when the visibility is set, the context menu freezes and covers that part of the screen. It cannot be closed only by killing the blueman-applet process.

![Screenshot_2021-12-11_12-47-50](https://user-images.githubusercontent.com/1837125/145679422-16e8a5bd-e2a9-4af2-8a97-c1768cbed34f.png)

It seems to me, that turning the BL on, takes time for the power manager, so I've increased the delay.

```
blueman-applet 14.58.20 INFO     KillSwitch:106 io_event  : killswitch registered 31
blueman-applet 14.58.20 INFO     KillSwitch:122 io_event  : State: True
blueman-applet 14.58.20 INFO     PowerManager:178 update_power_state: off False | foff False | on True | current state True | new state True
<wait 1-2 seconds>
blueman-applet 14.58.21 DEBUG    Manager:42 _on_object_added: /org/bluez/hci0
blueman-applet 14.58.21 INFO     Applet:76 on_adapter_added: Adapter added /org/bluez/hci0
blueman-applet 14.58.21 INFO     RecentConns:107 initialize: rebuilding menu
```
This solves the problem for me.