### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -85,7 +85,7 @@ msgstr "Vorübergehend sichtbar"
 
 #: data/ui/adapters-tab.ui:101
 msgid "<b>Friendly Name</b>"
-msgstr "<b>Freundlicher Name</b>"
+msgstr "<b>Menschenlesbarer Name</b>"
 
 #: data/ui/applet-passkey.ui:8
 msgid "Pairing request"


### PR DESCRIPTION
'Friendly Name' means a human-readable name in contrast to some incomprehensible ID. The current german translation 'Freundlicher Name' does hardly reflect this and is only a literal translation, therefore I propose 'Menschenlesbarer Name' as an alternative.