### PR TITLE
Use a recent automake for release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-20.04
+    container:
+      image: buildpack-deps:bullseye-scm
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-output name=VERSION::${GITHUB_REF#refs/tags/}"
@@ -17,12 +19,13 @@ jobs:
           notes="${notes//$'\r'/'%0D'}"
           echo ::set-output name=NOTES::$notes
         id: notes
+        shell: bash
       - run: '[ -n "${{ steps.notes.outputs.NOTES }}" ] || (echo "Failed to parse changelog" && exit 1)'
       - run: grep --quiet '^AC_INIT(\[blueman\], \[${{ steps.version.outputs.VERSION }}\]' configure.ac || (echo "Did not find expected verson in configure.ac" && exit 1)
       - run: "grep --quiet \"version: '${{ steps.version.outputs.VERSION }}'\" meson.build || (echo 'Did not find expected verson in meson.build' && exit 1)"
       - run: git archive --prefix="blueman-${{ steps.version.outputs.VERSION }}/" HEAD | tar x
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y -qq --no-install-recommends autopoint
+      - run: apt-get update
+      - run: apt-get install -y -qq --no-install-recommends autopoint automake libtool
       - run: NOCONFIGURE=1 ./autogen.sh
         working-directory: "blueman-${{ steps.version.outputs.VERSION }}"
       - run: tar cJf "blueman-${{ steps.version.outputs.VERSION }}.tar.xz" "blueman-${{ steps.version.outputs.VERSION }}"


### PR DESCRIPTION
Otherwise the configure script will not work for Python 3.10.

I already re-built and re-released https://github.com/blueman-project/blueman/releases/tag/2.2.4 with this.