### PR TITLE
Manager: Assign primary-toolbar style to main toolbar

### DIFF
--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -179,6 +179,9 @@
             <property name="homogeneous">True</property>
           </packing>
         </child>
+        <style>
+          <class name="primary-toolbar"/>
+        </style>
       </object>
       <packing>
         <property name="left_attach">0</property>


### PR DESCRIPTION
Most themes render toolbars the same way no matter where the toolbar is located in the window. Some themes style the "primary" toolbar differently though to make it look flush with the titlebar.

Since blueman's toolbar is located just under the menubar/titlebar, it should be styled as "primary-toolbar" to let themes know how to render it.

Here's an example with the Arc theme.

Before:

![image](https://user-images.githubusercontent.com/1138515/154463865-de28911b-6f3a-4f54-920b-1f04cad01844.png)

After:

![image](https://user-images.githubusercontent.com/1138515/154464451-a681ef01-c6e7-4b81-a82a-b11c4c316ac2.png)
