### PR TITLE
Manager: Fix cancel button in send-note dialog

### DIFF
--- a/blueman/plugins/manager/Notes.py
+++ b/blueman/plugins/manager/Notes.py
@@ -17,7 +17,7 @@ from gi.repository import Gtk
 def send_note_cb(dialog: Gtk.Dialog, response_id: int, device_address: str, text_view: Gtk.Entry) -> None:
     text = text_view.get_buffer().props.text
     dialog.destroy()
-    if response_id == Gtk.ResponseType.CANCEL:
+    if response_id == Gtk.ResponseType.REJECT:
         return
 
     date = datetime.datetime.now().strftime('%Y%m%dT%H%M00')


### PR DESCRIPTION
This fixes the cancel button in the send note dialog.

To reproduce the issue:

- Choose a device in the manager
- Send a note
- Press the cancel button

The note is sent instead of being cancelled.

The glade file note.ui defines the cancel button action as a REJECT action. This was misinterpreted in the python source code.