### PR TITLE
meson: add pythoninstalldir option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,12 @@ pkgdatadir = join_paths([prefix, get_option('datadir'), package_name])
 bindir = join_paths([prefix, get_option('bindir')])
 libexecdir = join_paths([prefix, get_option('libexecdir')])
 schemadir = join_paths([datadir, 'glib-2.0', 'schemas'])
-pythondir = join_paths([prefix, python.sysconfig_path('purelib')])
+pythoninstalldir = get_option('pythoninstalldir')
+if pythoninstalldir != ''
+    pythondir = join_paths([prefix, pythoninstalldir])
+else
+    pythondir = join_paths([prefix, python.sysconfig_path('purelib')])
+endif
 
 if get_option('policykit')
     have_polkit = 'True'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,5 +4,6 @@ option('policykit', type: 'boolean', value: true, description: 'Enable policykit
 option('pulseaudio', type: 'boolean', value: true, description: 'Enable PulseAudio support')
 option('systemdsystemunitdir', type: 'string', description: 'Path to systemd system unit dir relative to ${prefix}')
 option('systemduserunitdir', type: 'string', description: 'Path to systemd user unit dir relative to ${prefix}')
+option('pythoninstalldir', type: 'string', description: 'Path to python site-packages dir relative to ${prefix}')
 option('sendto-plugins', type: 'array', choices: ['Caja', 'Nemo', 'Nautilus'], value: ['Caja', 'Nemo', 'Nautilus'], description: 'Install sendto plugins for various filemanagers')
 option('thunar-sendto', type: 'boolean', value: true, description: 'Install Thunar sendto plugin')


### PR DESCRIPTION
In case of cross build, using host python to determine the python
site-packages directory for target is not feasible, add a new option
pythoninstalldir to fix the issue.

Signed-off-by: Chen Qi <Qi.Chen@windriver.com>