### PR TITLE
Decouple battery indication from service presence

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -7,13 +7,14 @@ import os
 
 from blueman.bluez.Battery import Battery
 from blueman.bluez.Device import Device
+from blueman.bluez.errors import BluezDBusException
 from blueman.gui.DeviceList import DeviceList
 from blueman.DeviceClass import get_minor_class, get_major_class, gatt_appearance_to_name
 from blueman.gui.GenericList import ListDataDict
 from blueman.gui.manager.ManagerDeviceMenu import ManagerDeviceMenu
 from blueman.Constants import PIXMAP_PATH
 from blueman.Functions import launch
-from blueman.Sdp import ServiceUUID, OBEX_OBJPUSH_SVCLASS_ID, BATTERY_SERVICE_SVCLASS_ID
+from blueman.Sdp import ServiceUUID, OBEX_OBJPUSH_SVCLASS_ID
 from blueman.gui.GtkAnimation import TreeRowFade, CellFade, AnimBase
 from blueman.main.Config import Config
 from _blueman import ConnInfoReadError, conn_info
@@ -424,9 +425,10 @@ class ManagerDeviceList(DeviceList):
 
         bars = {}
 
-        if device["ServicesResolved"] and any(ServiceUUID(uuid).short_uuid == BATTERY_SERVICE_SVCLASS_ID
-                                              for uuid in device["UUIDs"]):
+        try:
             bars["battery"] = Battery(obj_path=device.get_object_path())["Percentage"]
+        except BluezDBusException:
+            pass
 
         # cinfo init may fail for bluetooth devices version 4 and up
         # FIXME Workaround is horrible and we should show something better

--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -14,9 +14,9 @@ class ConnectionNotifier(AppletPlugin):
 
     def on_device_property_changed(self, path: str, key: str, value: Any) -> None:
         if key == "Connected":
-            device = Device(obj_path=path)
-            if value and "Battery" in self.parent.Plugins.get_loaded() and Battery.applicable(device):
+            if value and "Battery" in self.parent.Plugins.get_loaded() and Battery.applicable(path):
                 return
 
+            device = Device(obj_path=path)
             Notification(device["Alias"], _("Connected") if value else _("Disconnected"),
                          icon_name=device["Icon"]).show()


### PR DESCRIPTION
Up to now we try to read the battery percentage if and only if services are resolved and a battery service is present. That leads to two issues: On one hand there is the edge case where the interface is not provided anyway (due to some BlueZ internal issues), see #1708, on the other hand, the interface might still be there without the service, especially if the experimental battery provider API is used, see #1703.

The easiest solution is a simple try-and-catch, although listening for the interface itself could be the better choice for the applet plugin.