### PR TITLE
UI: Improve look of manager window

### DIFF
--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -71,9 +71,10 @@ class Blueman(Gtk.Application):
             self.window.connect("configure-event", self._on_configure)
 
             self.builder = Builder("manager-main.ui")
+            box = self.builder.get_widget("box", Gtk.Box)
+            self.window.add(box)
 
             grid = self.builder.get_widget("grid", Gtk.Grid)
-            self.window.add(grid)
 
             toolbar = self.builder.get_widget("toolbar", Gtk.Toolbar)
             statusbar = self.builder.get_widget("statusbar", Gtk.Box)
@@ -82,7 +83,7 @@ class Blueman(Gtk.Application):
             self.Plugins.load_plugin()
 
             area = MessageArea()
-            grid.attach(area, 0, 3, 1, 1)
+            grid.attach(area, 0, 1, 1, 1)
 
             self._applethandlerid: Optional[int] = None
 

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -1,102 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
-  <object class="GtkImage" id="im_pair">
+  <object class="GtkBox" id="box">
+    <property name="name">box</property>
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="pixel_size">24</property>
-    <property name="icon_name">dialog-password</property>
-  </object>
-  <object class="GtkImage" id="im_remove">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="pixel_size">24</property>
-    <property name="icon_name">list-remove</property>
-  </object>
-  <object class="GtkImage" id="im_search">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="pixel_size">24</property>
-    <property name="icon_name">edit-find</property>
-  </object>
-  <object class="GtkImage" id="im_send">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="pixel_size">24</property>
-    <property name="icon_name">blueman-send-file</property>
-  </object>
-  <object class="GtkImage" id="im_setup">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="pixel_size">24</property>
-    <property name="icon_name">document-properties</property>
-  </object>
-  <object class="GtkImage" id="im_trust">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="pixel_size">24</property>
-    <property name="icon_name">blueman-trust</property>
-  </object>
-  <object class="GtkGrid" id="grid">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="column_homogeneous">True</property>
+    <property name="can-focus">False</property>
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkMenuBar" id="menu">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkMenuItem" id="item_adapter">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="label" translatable="yes">_Adapter</property>
-            <property name="use_underline">True</property>
+            <property name="use-underline">True</property>
           </object>
         </child>
         <child>
           <object class="GtkMenuItem" id="item_device">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="label" translatable="yes">_Device</property>
-            <property name="use_underline">True</property>
+            <property name="use-underline">True</property>
           </object>
         </child>
         <child>
           <object class="GtkMenuItem" id="item_view">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="label" translatable="yes">_View</property>
-            <property name="use_underline">True</property>
+            <property name="use-underline">True</property>
           </object>
         </child>
         <child>
           <object class="GtkMenuItem" id="item_help">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="label" translatable="yes">_Help</property>
-            <property name="use_underline">True</property>
+            <property name="use-underline">True</property>
           </object>
         </child>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">0</property>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
       </packing>
     </child>
     <child>
       <object class="GtkToolbar" id="toolbar">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkToolButton" id="b_search">
             <property name="visible">True</property>
             <property name="sensitive">False</property>
-            <property name="can_focus">False</property>
-            <property name="tooltip_text" translatable="yes">Search for nearby devices</property>
-            <property name="is_important">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Search for nearby devices</property>
+            <property name="is-important">True</property>
             <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Search</property>
-            <property name="icon_widget">im_search</property>
+            <property name="icon-widget">im_search</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -106,7 +72,7 @@
         <child>
           <object class="GtkSeparatorToolItem" id="sep1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -117,10 +83,10 @@
           <object class="GtkToolButton" id="b_bond">
             <property name="visible">True</property>
             <property name="sensitive">False</property>
-            <property name="can_focus">False</property>
-            <property name="tooltip_text" translatable="yes">Create pairing with the device</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Create pairing with the device</property>
             <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Pair</property>
-            <property name="icon_widget">im_pair</property>
+            <property name="icon-widget">im_pair</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -131,10 +97,10 @@
           <object class="GtkToolButton" id="b_trust">
             <property name="visible">True</property>
             <property name="sensitive">False</property>
-            <property name="can_focus">False</property>
-            <property name="tooltip_text" translatable="yes">Mark/Unmark this device as trusted</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Mark/Unmark this device as trusted</property>
             <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Trust</property>
-            <property name="icon_widget">im_trust</property>
+            <property name="icon-widget">im_trust</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -145,10 +111,10 @@
           <object class="GtkToolButton" id="b_remove">
             <property name="visible">True</property>
             <property name="sensitive">False</property>
-            <property name="can_focus">False</property>
-            <property name="tooltip_text" translatable="yes">Remove this device from the known devices list</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Remove this device from the known devices list</property>
             <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Remove</property>
-            <property name="icon_widget">im_remove</property>
+            <property name="icon-widget">im_remove</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -158,7 +124,7 @@
         <child>
           <object class="GtkSeparatorToolItem" id="sep2">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -168,11 +134,11 @@
         <child>
           <object class="GtkToolButton" id="b_send">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="tooltip_text" translatable="yes">Send file(s) to the device</property>
-            <property name="is_important">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Send file(s) to the device</property>
+            <property name="is-important">True</property>
             <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Send File</property>
-            <property name="icon_widget">im_send</property>
+            <property name="icon-widget">im_send</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -184,74 +150,125 @@
         </style>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">1</property>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
       </packing>
     </child>
     <child>
-      <object class="GtkScrolledWindow" id="scrollview">
+      <!-- n-columns=1 n-rows=3 -->
+      <object class="GtkGrid" id="grid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="vexpand">True</property>
-        <property name="shadow_type">in</property>
+        <property name="can-focus">False</property>
+        <property name="border-width">5</property>
+        <property name="row-spacing">5</property>
+        <property name="column-homogeneous">True</property>
+        <child>
+          <object class="GtkScrolledWindow" id="scrollview">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="vexpand">True</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="statusbar">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">0</property>
+            <property name="homogeneous">True</property>
+            <child>
+              <object class="GtkBox" id="status_data">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="spacing">2</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="status_activity">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">end</property>
+                <property name="valign">center</property>
+                <property name="spacing">2</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">2</property>
+          </packing>
+        </child>
         <child>
           <placeholder/>
         </child>
       </object>
       <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">2</property>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
       </packing>
     </child>
-    <child>
-      <object class="GtkBox" id="statusbar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="homogeneous">True</property>
-        <child>
-          <object class="GtkBox" id="status_data">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">start</property>
-            <property name="valign">center</property>
-            <property name="margin_left">2</property>
-            <property name="spacing">2</property>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="status_activity">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">end</property>
-            <property name="valign">center</property>
-            <property name="margin_right">2</property>
-            <property name="spacing">2</property>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">4</property>
-      </packing>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
+  </object>
+  <object class="GtkImage" id="im_pair">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="pixel-size">24</property>
+    <property name="icon-name">dialog-password</property>
+  </object>
+  <object class="GtkImage" id="im_remove">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="pixel-size">24</property>
+    <property name="icon-name">list-remove</property>
+  </object>
+  <object class="GtkImage" id="im_search">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="pixel-size">24</property>
+    <property name="icon-name">edit-find</property>
+  </object>
+  <object class="GtkImage" id="im_send">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="pixel-size">24</property>
+    <property name="icon-name">blueman-send-file</property>
+  </object>
+  <object class="GtkImage" id="im_setup">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="pixel-size">24</property>
+    <property name="icon-name">document-properties</property>
+  </object>
+  <object class="GtkImage" id="im_trust">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="pixel-size">24</property>
+    <property name="icon-name">blueman-trust</property>
   </object>
 </interface>


### PR DESCRIPTION
- Reduce the Grid column number to 1 (other cols weren't used)
- Put the menubar, toolbar and grid into a Box (this allows to give the grid a border width and spacing without affecting the menubar/toolbar)
- Give the grid 5px border width and spacing (cleaner looking list, status activity is no longer squashed)

![image](https://user-images.githubusercontent.com/1138515/170294745-60eff81a-3931-4c01-a07b-dc617ea1da69.png)
