### PR TITLE
Add Notificaton.set_message

### DIFF
--- a/blueman/gui/Notification.py
+++ b/blueman/gui/Notification.py
@@ -87,6 +87,9 @@ class _NotificationDialog(Gtk.MessageDialog):
         self.connect("enter-notify-event", on_enter)
         self.connect("leave-notify-event", on_leave)
 
+    def set_message(self, message: str) -> None:
+        self.props.secondary_text = message
+
     def dialog_response(self, _dialog: Gtk.Dialog, response: int) -> None:
         if self.callback:
             self.callback(self.actions[response])
@@ -185,6 +188,11 @@ class _NotificationBubble(Gio.DBusProxy):
                 self.add_action(action[0], action[1], actions_cb)
 
         self._capabilities = self.GetCapabilities()
+
+    def set_message(self, message: str) -> None:
+        self._body = message
+        if self._return_id is not None:
+            self.show()
 
     @property
     def server_information(self) -> Tuple[str, str, str, str]:


### PR DESCRIPTION
The method can be used to replace the message especially of already shown notifications. _NotificationBubble.show() does keep track of the notification ID and uses the D-Bus protocol's replacing capabilities, so that we can just re-call it to replace an already shown notification. In case of _NotificationDialog it is sufficient to just set the property, no matter if the dialog is already shown or not.