### PR TITLE
Update instead of delaying connection notifications

### DIFF
--- a/blueman/gui/Notification.py
+++ b/blueman/gui/Notification.py
@@ -90,6 +90,9 @@ class _NotificationDialog(Gtk.MessageDialog):
     def set_message(self, message: str) -> None:
         self.props.secondary_text = message
 
+    def set_notification_icon(self, icon_name: str) -> None:
+        self.set_icon_from_icon_name(icon_name, 48)
+
     def dialog_response(self, _dialog: Gtk.Dialog, response: int) -> None:
         if self.callback:
             self.callback(self.actions[response])
@@ -191,6 +194,11 @@ class _NotificationBubble(Gio.DBusProxy):
 
     def set_message(self, message: str) -> None:
         self._body = message
+        if self._return_id is not None:
+            self.show()
+
+    def set_notification_icon(self, icon_name: str) -> None:
+        self._app_icon = icon_name
         if self._return_id is not None:
             self.show()
 

--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -1,11 +1,12 @@
 import logging
 from gettext import gettext as _
-from typing import Any
+from typing import Any, Optional, Dict, Union
 
 from blueman.bluez.Device import Device
 from blueman.bluez.Battery import Battery
+from blueman.bluez.Manager import Manager
 from blueman.bluez.errors import BluezDBusException
-from blueman.gui.Notification import Notification
+from blueman.gui.Notification import Notification, _NotificationBubble, _NotificationDialog
 from blueman.plugins.AppletPlugin import AppletPlugin
 from gi.repository import GLib
 
@@ -15,26 +16,59 @@ class ConnectionNotifier(AppletPlugin):
     __icon__ = "bluetooth-symbolic"
     __description__ = _("Shows desktop notifications when devices get connected or disconnected.")
 
+    _sig = None
+    _notifications: Dict[str, Union[_NotificationBubble, _NotificationDialog]] = {}
+
+    def on_load(self) -> None:
+        self._manager = Manager()
+        self._sig = self._manager.connect_signal("battery-created", self._on_battery_created)
+
+    def on_unload(self) -> None:
+        if self._sig is not None:
+            self._manager.disconnect_signal(self._sig)
+
     def on_device_property_changed(self, path: str, key: str, value: Any) -> None:
-        def show_notification() -> bool:
-            try:
-                perc = f"{battery['Percentage']}%"
-                icon_name = "battery"
-            except BluezDBusException:
-                perc = None
-                icon_name = device["Icon"]
-                logging.debug("Failed to get battery level")
-
-            txt = f"{_('Connected')} {perc if perc is not None else ''}"
-            Notification(device["Alias"], txt, icon_name=icon_name).show()
-            return False
-
         device = Device(obj_path=path)
         battery = Battery(obj_path=path)
 
         if key == "Connected":
             if value:
-                # FIXME delay is needed for battery info. Most notably xbox one pads #1696
-                GLib.timeout_add_seconds(5, show_notification)
+                try:
+                    perc = battery['Percentage']
+                    icon_name = "battery"
+                except BluezDBusException:
+                    logging.debug("Failed to get battery level")
+                    perc = None
+                    icon_name = device["Icon"]
+
+                self._notifications[path] = notification = Notification(
+                    device["Alias"],
+                    self._get_message(perc),
+                    icon_name=icon_name
+                )
+                notification.show()
+
+                sig = battery.connect_signal("property-changed", self._on_battery_property_changed)
+
+                def disconnect_signal() -> bool:
+                    battery.disconnect_signal(sig)
+                    return False
+                GLib.timeout_add_seconds(5, disconnect_signal)
             else:
                 Notification(device["Alias"], _('Disconnected'), icon_name=device["Icon"]).show()
+
+    def _get_message(self, battery_percentage: Optional[str]) -> str:
+        if battery_percentage is None:
+            return _('Connected')
+        else:
+            return f"{_('Connected')} {battery_percentage}%"
+
+    def _on_battery_created(self, _manager: Manager, obj_path: str) -> None:
+        battery = Battery(obj_path=obj_path)
+        self._on_battery_property_changed(battery, "Percentage", battery["Percentage"], obj_path)
+
+    def _on_battery_property_changed(self, _battery: Battery, key: str, value: Any, path: str) -> None:
+        if key == "Percentage":
+            notification = self._notifications[path]
+            if notification:
+                notification.set_message(self._get_message(value))

--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -72,3 +72,4 @@ class ConnectionNotifier(AppletPlugin):
             notification = self._notifications[path]
             if notification:
                 notification.set_message(self._get_message(value))
+                notification.set_notification_icon("battery")


### PR DESCRIPTION
I really don't like the generic delay of 5 seconds for all connection notifications. This is a quick draft to show instant notifications and update them with battery levels for up to five seconds instead.

It works fine in a quick test, however, when the device just got connected, it does not have the battery (percentage) yet, so that line 37 always fails. `_on_battery_created` does update the message as expected but this breaks the icon logic as the battery icon will never be used. Not sure if a way to update the icon is the way to go there or not. I also could not actually test the `property-changed` signal.