### PR TITLE
Use make distcheck to provide tarball(s)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,18 +2,18 @@ on: pull_request
 
 jobs:
   releasebuild:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
-      - run: sudo apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext cython libglib2.0-dev python3-dev python-gi-dev libbluetooth-dev
-      - run: ./autogen.sh
+      - run: sudo apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext cython3 libglib2.0-dev python3-dev python-gi-dev libbluetooth-dev
+      - run: CYTHONEXEC=cython3 ./autogen.sh
       - run: make
-      - run: make distcheck
+      - run: CYTHONEXEC=cython3 make distcheck
       - run: sudo make install
 
   mesonbuild:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
@@ -51,7 +51,7 @@ jobs:
           - 3.9
           - "3.10"
           - 3.11-rc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: python:${{ matrix.python }}
     steps:
@@ -74,7 +74,7 @@ jobs:
           - 3.8
           - 3.9
           - "3.10"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: python:${{ matrix.python }}
     steps:

--- a/.github/workflows/potfile.yml
+++ b/.github/workflows/potfile.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   update-pot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
-      - run: sudo apt-get install -y -qq --no-install-recommends autopoint gettext cython libglib2.0-dev python-gi-dev libbluetooth-dev
-      - run: ./autogen.sh
+      - run: sudo apt-get install -y -qq --no-install-recommends autopoint gettext cython3 libglib2.0-dev python-gi-dev libbluetooth-dev
+      - run: CYTHONEXEC=cython3 ./autogen.sh
       - run: make -C po blueman.pot-update
       - uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,10 @@ jobs:
       - run: '[ -n "${{ steps.notes.outputs.NOTES }}" ] || (echo "Failed to parse changelog" && exit 1)'
       - run: grep --quiet '^AC_INIT(\[blueman\], \[${{ steps.version.outputs.VERSION }}\]' configure.ac || (echo "Did not find expected verson in configure.ac" && exit 1)
       - run: "grep --quiet \"version: '${{ steps.version.outputs.VERSION }}'\" meson.build || (echo 'Did not find expected verson in meson.build' && exit 1)"
-      - run: git archive --prefix="blueman-${{ steps.version.outputs.VERSION }}/" HEAD | tar x
       - run: sudo apt-get update
-      - run: sudo apt-get install -y -qq --no-install-recommends autopoint
-      - run: NOCONFIGURE=1 ./autogen.sh
-        working-directory: "blueman-${{ steps.version.outputs.VERSION }}"
-      - run: tar cJf "blueman-${{ steps.version.outputs.VERSION }}.tar.xz" "blueman-${{ steps.version.outputs.VERSION }}"
-      - run: tar czf "blueman-${{ steps.version.outputs.VERSION }}.tar.gz" "blueman-${{ steps.version.outputs.VERSION }}"
+      - run: sudo apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext cython libglib2.0-dev python3-dev python-gi-dev libbluetooth-dev
+      - run: ./autogen.sh
+      - run: make distcheck
       - uses: softprops/action-gh-release@v1
         with:
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-output name=VERSION::${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/weblate.yml
+++ b/.github/workflows/weblate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ(2.61)
 AC_INIT([blueman], [2.3], [https://github.com/blueman-project/blueman/issues])
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_MACRO_DIRS([m4])
-AM_INIT_AUTOMAKE([foreign dist-xz])
+AM_INIT_AUTOMAKE([1.16.3 foreign dist-xz])
 
 AM_MAINTAINER_MODE([enable])
 AC_PROG_CC


### PR DESCRIPTION
Not sure how you tested this before..

The problem with the current approach is that it can easily miss including automake files that are in the dev package. For example the 2.3 tarball from the release job are broken as it does not include the gsettings automake parts.

ps: I uploaded 2 new files which pas distcheck.