### PR TITLE
Use ubuntu-22.04 for all jobs that run autogen.sh

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,18 +2,18 @@ on: pull_request
 
 jobs:
   releasebuild:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
-      - run: sudo apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext cython libglib2.0-dev python3-dev python-gi-dev libbluetooth-dev
-      - run: ./autogen.sh
+      - run: sudo apt-get install -y -qq --no-install-recommends automake autoconf libtool autopoint gettext cython3 libglib2.0-dev python3-dev python-gi-dev libbluetooth-dev
+      - run: CYTHONEXEC=cython3 ./autogen.sh
       - run: make
-      - run: make distcheck
+      - run: CYTHONEXEC=cython3 make distcheck
       - run: sudo make install
 
   mesonbuild:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
@@ -47,7 +47,7 @@ jobs:
           - 3.9
           - "3.10"
           - 3.11-rc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: python:${{ matrix.python }}
     steps:
@@ -68,7 +68,7 @@ jobs:
           - 3.8
           - 3.9
           - "3.10"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: python:${{ matrix.python }}
     steps:

--- a/.github/workflows/potfile.yml
+++ b/.github/workflows/potfile.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   update-pot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
-      - run: sudo apt-get install -y -qq --no-install-recommends autopoint gettext cython libglib2.0-dev python-gi-dev libbluetooth-dev
-      - run: ./autogen.sh
+      - run: sudo apt-get install -y -qq --no-install-recommends autopoint gettext cython3 libglib2.0-dev python-gi-dev libbluetooth-dev
+      - run: CYTHONEXEC=cython3 ./autogen.sh
       - run: make -C po blueman.pot-update
       - uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: echo "::set-output name=VERSION::${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/weblate.yml
+++ b/.github/workflows/weblate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
A more recent version of automake is required for Python 3.10 compatibility.