### PR TITLE
Networking: Don't load if nap is not enabled

### DIFF
--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -32,6 +32,9 @@ class Networking(AppletPlugin):
             self.update_status()
 
     def load_nap_settings(self) -> None:
+        if not self.Config["nap-enabled"]:
+            return
+
         logging.info("Loading NAP settings")
 
         def reply(_obj: Mechanism, _result: None, _user_data: None) -> None:


### PR DESCRIPTION
It *may* cause errors to show even when no bluetooth is available.
see #1759 for refference.