### PR TITLE
Recent connections menu is missing in lxqt-panel

### DIFF
--- a/blueman/main/indicators/StatusNotifierItem.py
+++ b/blueman/main/indicators/StatusNotifierItem.py
@@ -37,10 +37,9 @@ class MenuService(DbusService):
             return self._revision, (0, {}, self._render_menu(self._items, 1, self._render_submenu))
         else:
             item = self._items[parent_id - 1]
-            if "submenu" in item:
+            if "submenu" in item and _recursion_depth != 0:
                 return self._revision, (parent_id, self._render_item(item), self._render_submenu(item, parent_id ))
-            else:
-                return self._revision, (parent_id, self._render_item(item), [])
+            return self._revision, (parent_id, self._render_item(item), [])
 
     def _render_submenu(self, item: "MenuItemDict", idx: int) -> List[GLib.Variant]:
         if "submenu" in item:

--- a/blueman/main/indicators/StatusNotifierItem.py
+++ b/blueman/main/indicators/StatusNotifierItem.py
@@ -38,7 +38,7 @@ class MenuService(DbusService):
         else:
             item = self._items[parent_id - 1]
             if "submenu" in item and _recursion_depth != 0:
-                return self._revision, (parent_id, self._render_item(item), self._render_submenu(item, parent_id ))
+                return self._revision, (parent_id, self._render_item(item), self._render_submenu(item, parent_id))
             return self._revision, (parent_id, self._render_item(item), [])
 
     def _render_submenu(self, item: "MenuItemDict", idx: int) -> List[GLib.Variant]:

--- a/blueman/main/indicators/StatusNotifierItem.py
+++ b/blueman/main/indicators/StatusNotifierItem.py
@@ -36,7 +36,11 @@ class MenuService(DbusService):
         if parent_id == 0:
             return self._revision, (0, {}, self._render_menu(self._items, 1, self._render_submenu))
         else:
-            return self._revision, (parent_id, self._render_item(self._items[parent_id - 1]), [])
+            item = self._items[parent_id - 1]
+            if "submenu" in item:
+                return self._revision, (parent_id, {}, self._render_submenu(item, parent_id ))
+            else:
+                return self._revision, (parent_id, self._render_item(item), [])
 
     def _render_submenu(self, item: "MenuItemDict", idx: int) -> List[GLib.Variant]:
         if "submenu" in item:

--- a/blueman/main/indicators/StatusNotifierItem.py
+++ b/blueman/main/indicators/StatusNotifierItem.py
@@ -38,7 +38,7 @@ class MenuService(DbusService):
         else:
             item = self._items[parent_id - 1]
             if "submenu" in item:
-                return self._revision, (parent_id, {}, self._render_submenu(item, parent_id ))
+                return self._revision, (parent_id, self._render_item(item), self._render_submenu(item, parent_id ))
             else:
                 return self._revision, (parent_id, self._render_item(item), [])
 


### PR DESCRIPTION
In lxqt-panel.  GetLayout is called twice.  Once with parent_id = 0, then parent_id = 7(recent connections).  But it doesn't rebuild the recent connection submenu only the menu item.
I am using lxqt-panel v1.1.0