### PR TITLE
Add emblem for connected state

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -258,15 +258,16 @@ class ManagerDeviceList(DeviceList):
 
         return icon_info
 
-    def make_device_icon(self, icon_info: Gtk.IconInfo, is_paired: bool = False, is_trusted: bool = False,
-                         is_blocked: bool = False) -> cairo.Surface:
+    def _make_device_icon(self, icon_info: Gtk.IconInfo, is_paired: bool, is_connected: bool, is_trusted: bool,
+                          is_blocked: bool) -> cairo.Surface:
         window = self.get_window()
         scale = self.get_scale_factor()
         target = icon_info.load_surface(window)
         ctx = cairo.Context(target)
 
-        if is_paired:
-            _icon_info = self.get_icon_info("blueman-paired-emblem", 16, False)
+        if is_connected or is_paired:
+            icon = "blueman-connected-emblem" if is_connected else "blueman-paired-emblem"
+            _icon_info = self.get_icon_info(icon, 16, False)
             assert _icon_info is not None
             paired_surface = _icon_info.load_surface(window)
             ctx.set_source_surface(paired_surface, 1 / scale, 1 / scale)
@@ -644,8 +645,9 @@ class ManagerDeviceList(DeviceList):
                        tree_iter: Gtk.TreeIter, data: Optional[str]) -> None:
         tree_iter = model.convert_iter_to_child_iter(tree_iter)
         if data is None:
-            row = self.get(tree_iter, "icon_info", "trusted", "paired", "blocked")
-            surface = self.make_device_icon(row["icon_info"], row["paired"], row["trusted"], row["blocked"])
+            row = self.get(tree_iter, "icon_info", "paired", "connected", "trusted", "blocked")
+            surface = self._make_device_icon(row["icon_info"], row["paired"],
+                                             row["connected"], row["trusted"], row["blocked"])
             cell.set_property("surface", surface)
         else:
             window = self.get_window()

--- a/data/icons/hicolor/scalable/emblems/Makefile.am
+++ b/data/icons/hicolor/scalable/emblems/Makefile.am
@@ -5,8 +5,9 @@ context = emblems
 iconsdir = $(themedir)/$(size)/$(context)
 
 icons_DATA =			\
-	blueman-blocked-emblem.svg  \
-	blueman-paired-emblem.svg   \
+	blueman-blocked-emblem.svg    \
+	blueman-connected-emblem.svg  \
+	blueman-paired-emblem.svg     \
 	blueman-trusted-emblem.svg
 
 EXTRA_DIST = $(icons_DATA)

--- a/data/icons/hicolor/scalable/emblems/blueman-connected-emblem.svg
+++ b/data/icons/hicolor/scalable/emblems/blueman-connected-emblem.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 32 32"
+   id="svg8"
+   sodipodi:docname="blueman-connected-emblem.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2048"
+     inkscape:window-height="1071"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="18.649941"
+     inkscape:cx="-3.0026905"
+     inkscape:cy="16.407559"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid839" />
+  </sodipodi:namedview>
+  <rect
+     x="3.5"
+     y="3.5"
+     width="25"
+     height="25"
+     rx="2"
+     ry="2"
+     color="#000000"
+     fill="#8bbe43"
+     overflow="visible"
+     id="rect2"
+     style="opacity:1;fill:#4db8db;fill-opacity:1;stroke-width:0.925926" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.35;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 5.5,3 C 4.123649,3 3,4.1236486 3,5.5 v 21 C 3,27.876351 4.123649,29 5.5,29 h 21 C 27.876351,29 29,27.876351 29,26.5 V 5.5 C 29,4.1236486 27.876351,3 26.5,3 Z m 0,1 h 21 C 27.339649,4 28,4.6603514 28,5.5 v 21 C 28,27.339649 27.339649,28 26.5,28 H 5.5 C 4.660351,28 4,27.339649 4,26.5 V 5.5 C 4,4.6603514 4.660351,4 5.5,4 Z"
+     id="rect2-6"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 15.999994,8.395 c -3.140626,0 -6.2859372,1.1203111 -8.6343744,3.370311 l -0.5953129,0.576563 c -0.4781256,0.454687 -0.4921872,1.214062 -0.0375,1.692187 0.00468,0.0047 0.014064,0.01406 0.018756,0.01876 L 10.1875,17.488754 c 0.05624,0.08906 0.121874,0.173438 0.20625,0.248438 0.4875,0.445313 1.246876,0.407813 1.696876,-0.08437 l 0.595311,-0.65625 c 1.532813,-1.682812 4.992189,-1.795312 6.628126,0 l 0.6,0.65625 c 0.445311,0.492189 1.204687,0.529689 1.696874,0.08437 0.07969,-0.075 0.140626,-0.154687 0.196876,-0.24375 l 3.440624,-3.440625 c 0.0047,-0.0047 0.01406,-0.01406 0.01876,-0.01876 0.454687,-0.478125 0.440626,-1.2375 -0.0375,-1.692187 L 24.634374,11.765311 C 22.285937,9.5153111 19.140626,8.395 16,8.395 Z m 0,2.446874 c 2.428126,0 4.851563,0.796874 6.675,2.390625 l -1.860937,1.860937 c -1.326563,-1.284375 -3.098437,-1.903125 -4.851563,-1.889062 -1.753126,0.01406 -3.496874,0.65625 -4.771874,1.89375 L 9.324994,13.232499 c 1.823437,-1.593751 4.246874,-2.390625 6.675,-2.390625 z m 0,7.1625 c -0.614063,0 -1.228126,0.234374 -1.696874,0.703125 -0.9375,0.9375 -0.9375,2.456249 0,3.393749 0.9375,0.9375 2.456248,0.9375 3.393748,0 0.9375,-0.9375 0.9375,-2.456249 0,-3.393749 -0.468748,-0.468751 -1.082811,-0.703125 -1.696874,-0.703125 z m 0,0"
+     fill="#2e3434"
+     fill-opacity="0.34902"
+     id="path169"
+     style="fill:#004a6b;fill-opacity:1;stroke-width:1.2" />
+  <path
+     d="m 15.999994,9.5948867 c -3.140626,0 -6.2859372,1.1203113 -8.6343744,3.3703113 l -0.5953128,0.576563 c -0.4781256,0.454687 -0.4921872,1.214063 -0.0375,1.692187 0.00468,0.0047 0.014064,0.01406 0.018756,0.01876 L 10.1875,18.688641 c 0.05624,0.08906 0.121874,0.173439 0.20625,0.248439 0.4875,0.445312 1.246876,0.407812 1.696876,-0.08437 l 0.595311,-0.65625 c 1.532813,-1.682813 4.992189,-1.795313 6.628126,0 l 0.6,0.65625 c 0.445311,0.492188 1.204687,0.529688 1.696874,0.08437 0.07969,-0.075 0.140626,-0.154688 0.196876,-0.24375 l 3.440624,-3.440626 c 0.0047,-0.0047 0.01406,-0.01406 0.01876,-0.01876 0.454687,-0.478124 0.440626,-1.2375 -0.0375,-1.692187 L 24.634374,12.965198 C 22.285937,10.715198 19.140626,9.5948867 16,9.5948867 Z m 0,2.4468743 c 2.428126,0 4.851563,0.796874 6.675,2.390625 l -1.860937,1.860938 c -1.326563,-1.284376 -3.098437,-1.903126 -4.851563,-1.889063 -1.753126,0.01406 -3.496874,0.65625 -4.771874,1.89375 L 9.324994,14.432386 c 1.823437,-1.593751 4.246874,-2.390625 6.675,-2.390625 z m 0,7.1625 c -0.614063,0 -1.228126,0.234374 -1.696874,0.703125 -0.9375,0.9375 -0.9375,2.456249 0,3.393749 0.9375,0.9375 2.456248,0.9375 3.393748,0 0.9375,-0.9375 0.9375,-2.456249 0,-3.393749 -0.468748,-0.468751 -1.082811,-0.703125 -1.696874,-0.703125 z m 0,0"
+     fill="#2e3434"
+     fill-opacity="0.34902"
+     id="path169-3"
+     style="opacity:0.2;fill:#004a6b;fill-opacity:1;stroke-width:1.2" />
+</svg>


### PR DESCRIPTION
This could solve the problem mentioned in #1642 as an alternative to the #1620 concept.

I think it's fair to just use the spot of the "paired" emblem and override it with the "connected" emblem. It's not very distinguishable right now, though. One might probably want a different color for it. 

The icon's content is basically stolen from Adwaita.