### PR TITLE
Drop auto-power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Hide recent connections associated with unavailable adapters
 * Store network configuration in GSettings instead of /var/lib/blueman/network.state.
 * Replace custom MessageArea widget with regular Gtk.InfoBar
+* Drop auto-power feature. BlueZ now has the AutoEnable setting for even better auto-powering.
 
 ### Bugs fixed
 

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -82,20 +82,6 @@ def check_bluetooth_status(message: str, exitfunc: Callable[[], Any]) -> None:
     if not applet.GetBluetoothStatus():
         print('Failed to enable bluetooth')
         exitfunc()
-        return
-
-    config = Gio.Settings(schema_id="org.blueman.plugins.powermanager")
-    if config["auto-power-on"] is None:
-        d = Gtk.MessageDialog(
-            type=Gtk.MessageType.QUESTION, icon_name="blueman",
-            text=_("Shall bluetooth get enabled automatically?"))
-        d.add_button(_("Yes"), Gtk.ResponseType.YES)
-        d.add_button(_("No"), Gtk.ResponseType.NO)
-
-        resp = d.run()
-        d.destroy()
-
-        config["auto-power-on"] = resp == Gtk.ResponseType.YES
 
 
 def launch(

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -32,20 +32,6 @@ class PowerManager(AppletPlugin, StatusIconProvider):
     __author__ = "Walmis"
     __icon__ = "gnome-power-manager-symbolic"
 
-    __gsettings__ = {
-        "schema": "org.blueman.plugins.powermanager",
-        "path": None
-    }
-
-    __options__ = {
-        "auto-power-on": {
-            "type": bool,
-            "default": True,
-            "name": _("Auto power-on"),
-            "desc": _("Automatically power on adapters")
-        }
-    }
-
     class State(Enum):
         ON = 2
         OFF = 1
@@ -75,11 +61,7 @@ class PowerManager(AppletPlugin, StatusIconProvider):
     def on_manager_state_changed(self, state: bool) -> None:
         if state:
             def timeout() -> bool:
-                self.adapter_state = self.get_adapter_state()
-                if self.get_option("auto-power-on"):
-                    self.request_power_state(True, force=True)
-                else:
-                    self.request_power_state(self.adapter_state)
+                self.request_power_state(self.get_adapter_state())
                 return False
 
             GLib.timeout_add(1000, timeout)

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -158,13 +158,6 @@
       <description>A list of services to connect to stored as tuples with the address and the UUID</description>
     </key>
   </schema>
-  <schema id="org.blueman.plugins.powermanager" path="/org/blueman/plugins/powermanager/">
-    <key type="mb" name="auto-power-on">
-        <default>nothing</default>
-        <summary>Automatically power on adapters</summary>
-        <description></description>
-    </key>
-  </schema>
   <schema id="org.blueman.plugins.recentconns" path="/org/blueman/plugins/recentconns/">
     <key type="i" name="max-items">
       <default>6</default>


### PR DESCRIPTION
I think this feature does more harm than good nowadays.

BlueZ introduced a similar `AutoEnable` option in 5.35. At least Debian and its derivatives enable it by default. Distros that love upstream configurations like Arch Linux did not but [BlueZ 5.65 finally changed the default](https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?id=180cf09933b2d8eb03972c8638063429fe5fece5).

Compared to `AutoEnable` `auto-power` has some non-desirable differences in behavior: At least it does not cover suspend and resume, see #1555, and together with the `KillSwitch` plugin it overrides killswitches as the plugin tries to unblock them when powering is requested.