### PR TITLE
Do not re-use dbusmenu item identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Replace custom MessageArea widget with regular Gtk.InfoBar
 * Drop auto-power feature. BlueZ now has the AutoEnable setting for even better auto-powering.
 * Do not use pointless link quality value
+* Do not re-use dbusmenu item identifiers; avoids issues at least with gnome-shell-extension-appindicator.
 
 ### Bugs fixed
 

--- a/blueman/plugins/applet/Menu.py
+++ b/blueman/plugins/applet/Menu.py
@@ -5,7 +5,6 @@ from typing import List, Union, Iterable, Dict, Optional, Callable, \
 from gi.repository import GLib
 
 from blueman.plugins.AppletPlugin import AppletPlugin
-from operator import attrgetter
 
 if TYPE_CHECKING:
     from typing_extensions import TypedDict
@@ -18,7 +17,10 @@ if TYPE_CHECKING:
         tooltip: Optional[str]
         callback: Callable[[], None]
 
-    class MenuItemDict(SubmenuItemDict, total=False):
+    class MenuItemDictBase(SubmenuItemDict):
+        id: int
+
+    class MenuItemDict(MenuItemDictBase, total=False):
         submenu: Iterable["SubmenuItemDict"]
 
 
@@ -57,30 +59,30 @@ class MenuItem:
     def visible(self) -> bool:
         return self._visible
 
-    def _iter_base(self) -> Iterator[Tuple[str, Union[str, bool]]]:
+    def _iter_base(self) -> Iterator[Tuple[str, Union[int, str, bool]]]:
+        yield "id", self.priority
         for key in ['text', 'markup', 'icon_name', 'tooltip', 'sensitive']:
             value = getattr(self, '_' + key)
             if value is not None:
                 yield key, value
 
-    def __iter__(self) -> Iterator[Tuple[str, Union[str, bool, List[Dict[str, Union[str, bool]]]]]]:
+    def __iter__(self) -> Iterator[Tuple[str, Union[int, str, bool, List[Dict[str, Union[int, str, bool]]]]]]:
         yield from self._iter_base()
-        submenu = list(self.submenu_items)
+        submenu = self.submenu_items
         if submenu:
             yield 'submenu', [dict(item) for item in submenu]
 
     @property
-    def submenu_items(self) -> Iterable["SubmenuItem"]:
+    def submenu_items(self) -> List["SubmenuItem"]:
         if not self._submenu_function:
-            return
+            return []
         submenu_items = self._submenu_function()
         if not submenu_items:
-            return
-        for item in submenu_items:
-            assert not set(item.keys()) - {'text', 'markup', 'icon_name', 'tooltip', 'callback', 'sensitive'}
-            yield SubmenuItem(self._menu_plugin, self._owner, 0, item.get('text'), item.get('markup', False),
-                              item.get('icon_name'), item.get('tooltip'), item.get('callback'), None, True,
-                              item.get('sensitive', True))
+            return []
+        return [SubmenuItem(self._menu_plugin, self._owner, 0, item.get('text'), item.get('markup', False),
+                            item.get('icon_name'), item.get('tooltip'), item.get('callback'), None, True,
+                            item.get('sensitive', True))
+                for item in submenu_items]
 
     def set_text(self, text: str, markup: bool = False) -> None:
         self._text = text
@@ -105,7 +107,7 @@ class MenuItem:
 
 
 class SubmenuItem(MenuItem):
-    def __iter__(self) -> Iterator[Tuple[str, Union[str, bool]]]:
+    def __iter__(self) -> Iterator[Tuple[str, Union[int, str, bool]]]:
         yield from self._iter_base()
 
 
@@ -116,16 +118,11 @@ class Menu(AppletPlugin):
     __unloadable__ = False
 
     def on_load(self) -> None:
-        self.__plugins_loaded = False
-
-        self.__menuitems: List[MenuItem] = []
+        self.__menuitems: Dict[int, MenuItem] = {}
 
         self._add_dbus_signal("MenuChanged", "aa{sv}")
         self._add_dbus_method("GetMenu", (), "aa{sv}", self._get_menu)
         self._add_dbus_method("ActivateMenuItem", ("ai",), "", self._activate_menu_item)
-
-    def __sort(self) -> None:
-        self.__menuitems.sort(key=attrgetter('priority'))
 
     def add(self, owner: AppletPlugin, priority: int, text: Optional[str] = None, markup: bool = False,
             icon_name: Optional[str] = None, tooltip: Optional[str] = None,
@@ -134,33 +131,33 @@ class Menu(AppletPlugin):
             visible: bool = True, sensitive: bool = True) -> MenuItem:
         item = MenuItem(self, owner, priority, text, markup, icon_name, tooltip, callback, submenu_function, visible,
                         sensitive)
-        self.__menuitems.append(item)
-        if self.__plugins_loaded:
-            self.__sort()
+        self.__menuitems[item.priority] = item
         self.on_menu_changed()
         return item
 
     def unregister(self, owner: AppletPlugin) -> None:
-        for item in reversed(self.__menuitems):
+        for item in list(self.__menuitems.values()):
             if item.owner == owner:
-                self.__menuitems.remove(item)
+                del self.__menuitems[item.priority]
         self.on_menu_changed()
-
-    def on_plugins_loaded(self) -> None:
-        self.__plugins_loaded = True
-        self.__sort()
 
     def on_menu_changed(self) -> None:
         self._emit_dbus_signal("MenuChanged", self._get_menu())
 
     def _get_menu(self) -> List[Dict[str, GLib.Variant]]:
-        return self._prepare_menu(dict(item) for item in self.__menuitems if item.visible)
+        return self._prepare_menu(dict(self.__menuitems[key])
+                                  for key in sorted(self.__menuitems.keys())
+                                  if self.__menuitems[key].visible)
 
-    def _prepare_menu(self, data: Iterable[Mapping[str, Union[str, bool, Iterable[Mapping[str, Union[str, bool]]]]]]) \
+    def _prepare_menu(self, data: Iterable[Mapping[str, Union[int, str, bool,
+                                                              Iterable[Mapping[str, Union[int, str, bool]]]]]]) \
             -> List[Dict[str, GLib.Variant]]:
         return [{k: self._build_variant(v) for k, v in item.items()} for item in data]
 
-    def _build_variant(self, value: Union[str, bool, Iterable[Mapping[str, Union[str, bool]]]]) -> GLib.Variant:
+    def _build_variant(self, value: Union[int, str, bool,
+                                          Iterable[Mapping[str, Union[int, str, bool]]]]) -> GLib.Variant:
+        if isinstance(value, int):
+            return GLib.Variant("i", value)
         if isinstance(value, str):
             return GLib.Variant("s", value)
         if isinstance(value, bool):
@@ -168,8 +165,8 @@ class Menu(AppletPlugin):
         return GLib.Variant("aa{sv}", self._prepare_menu(value))
 
     def _activate_menu_item(self, indexes: Sequence[int]) -> None:
-        node = [item for item in self.__menuitems if item.visible][indexes[0]]
+        node = self.__menuitems[indexes[0]]
         for index in list(indexes)[1:]:
-            node = [item for item in node.submenu_items if item.visible][index]
+            node = node.submenu_items[index]
         if node.callback:
             node.callback()

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -38,7 +38,7 @@ class PowerManager(AppletPlugin, StatusIconProvider):
         OFF_FORCED = 0
 
     def on_load(self) -> None:
-        self.item = self.parent.Plugins.Menu.add(self, 0, text=_("<b>Turn Bluetooth _Off</b>"), markup=True,
+        self.item = self.parent.Plugins.Menu.add(self, 1, text=_("<b>Turn Bluetooth _Off</b>"), markup=True,
                                                  icon_name="bluetooth-disabled-symbolic",
                                                  tooltip=_("Turn off all adapters"),
                                                  callback=self.on_bluetooth_toggled)

--- a/blueman/plugins/applet/PulseAudioProfile.py
+++ b/blueman/plugins/applet/PulseAudioProfile.py
@@ -10,7 +10,7 @@ from blueman.Sdp import (AUDIO_SINK_SVCLASS_ID, AUDIO_SOURCE_SVCLASS_ID,
 if TYPE_CHECKING:
     from blueman.bluez.Device import Device
     from blueman.main.PulseAudioUtils import CardInfo, CardProfileInfo
-    from blueman.plugins.applet.Menu import MenuItem, MenuItemDict
+    from blueman.plugins.applet.Menu import MenuItem, SubmenuItemDict
 
 
 class AudioProfiles(AppletPlugin):
@@ -58,8 +58,8 @@ class AudioProfiles(AppletPlugin):
                 self.on_activate_profile(device, profile)
             return _wrapper
 
-        def _generate_profiles_menu(info: "CardInfo") -> List["MenuItemDict"]:
-            items: List["MenuItemDict"] = []
+        def _generate_profiles_menu(info: "CardInfo") -> List["SubmenuItemDict"]:
+            items: List["SubmenuItemDict"] = []
             if not info:
                 return items
             for profile in info["profiles"]:

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -12,7 +12,7 @@ from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.plugins.applet.PowerManager import PowerManager, PowerStateListener
 
 if TYPE_CHECKING:
-    from blueman.plugins.applet.Menu import MenuItemDict
+    from blueman.plugins.applet.Menu import SubmenuItemDict
 
     from typing_extensions import TypedDict
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     class Item(_ItemBase):
         time: float
         device: str
-        mitem: Optional[MenuItemDict]
+        mitem: Optional[SubmenuItemDict]
 
     class StoredIcon(_ItemBase):
         time: str
@@ -58,7 +58,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
     _items = None
 
     def on_load(self) -> None:
-        self.__menuitems: List["MenuItemDict"] = []
+        self.__menuitems: List["SubmenuItemDict"] = []
 
         self._item = self.parent.Plugins.Menu.add(self, 52, text=_("Recent _Connections") + "…",
                                                   icon_name="document-open-recent-symbolic",
@@ -166,8 +166,8 @@ class RecentConns(AppletPlugin, PowerStateListener):
 
         self.parent.Plugins.DBusService.connect_service(item["device"], item["uuid"], reply, err)
 
-    def _build_menu_item(self, item: "Item") -> "MenuItemDict":
-        mitem: "MenuItemDict" = {
+    def _build_menu_item(self, item: "Item") -> "SubmenuItemDict":
+        mitem: "SubmenuItemDict" = {
             "text": _("%(service)s on %(device)s") % {"service": item["name"], "device": item["alias"]},
             "markup": True,
             "icon_name": item["mitem"]["icon_name"] if item["mitem"] is not None else item["icon"],
@@ -181,7 +181,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
 
         return mitem
 
-    def get_menu(self) -> List["MenuItemDict"]:
+    def get_menu(self) -> List["SubmenuItemDict"]:
         return self.__menuitems
 
     def _get_device_path(self, adapter_path: str, address: str) -> Optional[str]:


### PR DESCRIPTION
Re-using identifiers e.g. for separator and standard menu items triggers bugs at least in gnome-shell-extension-appindicator (#1845).

As a workaround we can just use the toplevel items' priority values instead of sequential identifiers to get unique identifiers for all items.

To do that the MenuItem's priority value gets added as `id` to the MenuItemDict serialization and picked up by the IndicatorInterface implementations. Note that the semantics of the first argument ot the MenuItemActivator change accordingly.