### PR TITLE
Configure sonarcloud paths

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,2 @@
+sonar.sources=blueman
+sonar.tests=test


### PR DESCRIPTION
By default Sonarcloud includes our test directory as standard sources. Defining it as test sources hopefully saves us from pointless findings like hardcoded, potentially vulnerable paths and repeated strings.