### PR TITLE
Implement com.canonical.dbusmenu.AboutToShow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Bugs fixed
 
 * Issues with NM PANU connections of equally named devices
+* Submenus in KDE Plasma tray
 
 ## 2.3.1
 

--- a/blueman/main/indicators/StatusNotifierItem.py
+++ b/blueman/main/indicators/StatusNotifierItem.py
@@ -21,6 +21,7 @@ class MenuService(DbusService):
 
         self.add_method("GetLayout", ("i", "i", "as"), ("u", "(ia{sv}av)"), self._get_layout)
         self.add_method("Event", ("i", "s", "v", "u"), (), self._on_event)
+        self.add_method("AboutToShow", ("i",), ("b",), lambda _: self._revision > self._revision_advertised)
 
         self.add_method("GetGroupProperties", ("ai", "as"), ("a(ia{sv})",),
                         lambda ids, props: [(idx, self._render_item(item)) for idx, item in self._iterate_items()


### PR DESCRIPTION
KDE Plasma expects this method to be implemented. Otherwise it just does not show submenus.

Closes #1856