### PR TITLE
Fix per-device applet menu items

### DIFF
--- a/blueman/plugins/applet/DisconnectItems.py
+++ b/blueman/plugins/applet/DisconnectItems.py
@@ -35,8 +35,8 @@ class DisconnectItems(AppletPlugin):
             self._render()
 
     def _render(self) -> None:
-        for device in self.parent.Manager.get_devices():
+        for idx, device in enumerate(self.parent.Manager.get_devices()):
             if device["Connected"]:
-                self._menu.add(self, 25, text=_("Disconnect %s") % device["Alias"],
+                self._menu.add(self, (25, idx), text=_("Disconnect %s") % device["Alias"],
                                icon_name="bluetooth-disconnected-symbolic",
                                callback=lambda dev=device: dev.disconnect())

--- a/blueman/plugins/applet/PulseAudioProfile.py
+++ b/blueman/plugins/applet/PulseAudioProfile.py
@@ -77,7 +77,7 @@ class AudioProfiles(AppletPlugin):
             return items
 
         info = self._devices[device['Address']]
-        menu = self._menu.add(self, 42, _("Audio Profiles for %s") % device['Alias'],
+        menu = self._menu.add(self, (42, info["index"]), _("Audio Profiles for %s") % device['Alias'],
                               icon_name="audio-card-symbolic",
                               submenu_function=lambda: _generate_profiles_menu(info))
         self._device_menus[device['Address']] = menu


### PR DESCRIPTION
With #1847 priorities are expected to be unique. Otherwise the items get merged into one, so that there is only one disconnect and only one audio profile item as no explicit sub-indexes got added there.

Fixes #1861