### PR TITLE
Do dbus activation like Gedit

### DIFF
--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     parser = parser = create_parser()
     parser.add_argument("--socket-id", dest="socket_id", action="store", type=int, metavar="ID")
     parser.add_argument("adapter", nargs="?", metavar="ADAPTER NAME")
-    args = parser.parse_args()
+    args, other_args = parser.parse_known_args()
 
     if args.LEVEL.upper() == "DEBUG":
         log_level = logging.DEBUG
@@ -42,4 +42,4 @@ if __name__ == '__main__':
     set_proc_title()
 
     app = blueman_adapters = BluemanAdapters(args.adapter, args.socket_id)
-    app.run()
+    app.run(other_args)

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -19,7 +19,7 @@ from blueman.main.Applet import BluemanApplet
 
 if __name__ == '__main__':
     parser = create_parser()
-    args = parser.parse_args()
+    args, other_args = parser.parse_known_args()
 
     if args.LEVEL.upper() == "DEBUG":
         log_level = logging.DEBUG
@@ -38,4 +38,4 @@ if __name__ == '__main__':
 
     set_proc_title()
     app = BluemanApplet()
-    app.run()
+    app.run(other_args)

--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -19,7 +19,7 @@ from blueman.Functions import set_proc_title, create_parser, create_logger
 
 if __name__ == '__main__':
     parser = create_parser()
-    args = parser.parse_args()
+    args, others = parser.parse_known_args()
 
     if args.LEVEL.upper() == "DEBUG":
         log_level = logging.DEBUG
@@ -38,4 +38,4 @@ if __name__ == '__main__':
 
     app = Blueman()
     set_proc_title()
-    app.run()
+    app.run(others)

--- a/apps/blueman-services.in
+++ b/apps/blueman-services.in
@@ -21,7 +21,7 @@ from blueman.main.Services import BluemanServices
 
 if __name__ == '__main__':
     parser = create_parser()
-    args = parser.parse_args()
+    args, other_ags = parser.parse_known_args()
 
     if args.LEVEL.upper() == "DEBUG":
         log_level = logging.DEBUG
@@ -41,4 +41,4 @@ if __name__ == '__main__':
     setup_icon_path()
     set_proc_title()
     app = BluemanServices()
-    app.run()
+    app.run(other_ags)

--- a/apps/blueman-tray.in
+++ b/apps/blueman-tray.in
@@ -18,7 +18,7 @@ from blueman.main.Tray import BluemanTray
 
 if __name__ == '__main__':
     parser = create_parser()
-    args = parser.parse_args()
+    args, other_args = parser.parse_known_args()
 
     if args.LEVEL.upper() == "DEBUG":
         log_level = logging.DEBUG
@@ -37,4 +37,4 @@ if __name__ == '__main__':
 
     set_proc_title()
     app = BluemanTray()
-    app.run()
+    app.run(other_args)

--- a/data/configs/blueman-applet.service.in
+++ b/data/configs/blueman-applet.service.in
@@ -4,4 +4,4 @@ Description=Bluetooth management applet
 [Service]
 Type=dbus
 BusName=org.blueman.Applet
-ExecStart=@BINDIR@/blueman-applet
+ExecStart=@BINDIR@/blueman-applet --gapplication-service

--- a/data/configs/blueman-manager.service.in
+++ b/data/configs/blueman-manager.service.in
@@ -4,4 +4,4 @@ Description=Bluetooth Manager
 [Service]
 Type=dbus
 BusName=org.blueman.Manager
-ExecStart=@BINDIR@/blueman-manager
+ExecStart=@BINDIR@/blueman-manager --gapplication-service


### PR DESCRIPTION
There are plenty of GtkApplication apps that are dbus activatable, basically all of gnome. Gedit and other Gnome apps do it like this so let's copy it. Maybe this helps with missing DISPLAY variable (:eyes:) but this is how it supposed to be done anyway so here we go.

I added this only for the actual Gio/GtkApplications