### PR TITLE
Fix menuitem serialization

### DIFF
--- a/blueman/plugins/applet/Menu.py
+++ b/blueman/plugins/applet/Menu.py
@@ -159,12 +159,12 @@ class Menu(AppletPlugin):
         return [{k: self._build_variant(v) for k, v in item.items()} for item in data]
 
     def _build_variant(self, value: Union[int, str, bool, Iterable[Mapping[str, Union[str, bool]]]]) -> GLib.Variant:
+        if isinstance(value, bool):
+            return GLib.Variant("b", value)
         if isinstance(value, int):
             return GLib.Variant("i", value)
         if isinstance(value, str):
             return GLib.Variant("s", value)
-        if isinstance(value, bool):
-            return GLib.Variant("b", value)
         return GLib.Variant("aa{sv}", self._prepare_menu(value))
 
     def _activate_menu_item(self, indexes: Sequence[int]) -> None:


### PR DESCRIPTION
#1847 added an integer type check in front of the boolean type check and as booleans are a subset of integers in Python boolean values not get serialized as integers as well. This does not break anything as the resulting integer values just get used as boolean but SonarCloud catches the dead code (now; I do not know why it did not earlier...).