### PR TITLE
Improve handling for new StatusNotifierWatcher

### DIFF
--- a/blueman/main/Tray.py
+++ b/blueman/main/Tray.py
@@ -38,8 +38,7 @@ class BluemanTray(Gio.Application):
         for indicator_name in applet.GetStatusIconImplementations():
             indicator_class = getattr(import_module('blueman.main.indicators.' + indicator_name), indicator_name)
             try:
-                self.indicator = indicator_class(
-                    applet.GetIconName(), self._activate_menu_item, self._activate_status_icon)
+                self.indicator = indicator_class(self, applet.GetIconName())
                 break
             except IndicatorNotAvailable:
                 logging.info(f'Indicator "{indicator_name}" is not available')
@@ -58,10 +57,10 @@ class BluemanTray(Gio.Application):
         logging.debug("Applet shutdown or not available at startup")
         self.quit()
 
-    def _activate_menu_item(self, *indexes: int) -> None:
+    def activate_menu_item(self, *indexes: int) -> None:
         AppletService().ActivateMenuItem('(ai)', indexes)
 
-    def _activate_status_icon(self) -> None:
+    def activate_status_icon(self) -> None:
         AppletService().Activate()
 
     def on_signal(self, _applet: AppletService, _sender_name: str, signal_name: str, args: GLib.Variant) -> None:

--- a/blueman/main/indicators/GtkStatusIcon.py
+++ b/blueman/main/indicators/GtkStatusIcon.py
@@ -2,6 +2,7 @@ from typing import Callable, Iterable, TYPE_CHECKING, overload, cast, Optional, 
 
 import gi
 
+from blueman.main.Tray import BluemanTray
 from blueman.main.indicators.IndicatorInterface import IndicatorInterface
 
 gi.require_version("Gtk", "3.0")
@@ -14,12 +15,7 @@ if TYPE_CHECKING:
     from blueman.plugins.applet.Menu import MenuItemDict, SubmenuItemDict
 
     class MenuItemActivator(Protocol):
-        @overload
-        def __call__(self, idx: int) -> None:
-            ...
-
-        @overload
-        def __call__(self, idx: int, subid: int) -> None:
+        def __call__(self, *idx: int) -> None:
             ...
 
 
@@ -60,13 +56,12 @@ def build_menu(items: Iterable[Tuple[int, "SubmenuItemDict"]], activate: Callabl
 
 
 class GtkStatusIcon(IndicatorInterface):
-    def __init__(self, icon_name: str, on_activate_menu_item: "MenuItemActivator",
-                 on_activate_status_icon: Callable[[], None]) -> None:
-        self._on_activate = on_activate_menu_item
+    def __init__(self, tray: BluemanTray, icon_name: str) -> None:
+        self._on_activate = tray.activate_menu_item
         self.indicator = Gtk.StatusIcon(icon_name=icon_name)
         self.indicator.set_title('blueman')
         self.indicator.connect('popup-menu', self.on_popup_menu)
-        self.indicator.connect('activate', lambda _status_icon: on_activate_status_icon())
+        self.indicator.connect('activate', lambda _status_icon: tray.activate_status_icon())
         self._tooltip_title = ""
         self._tooltip_text = ""
         self._menu: Optional[Gtk.Menu] = None


### PR DESCRIPTION
Earlier we just re-registered our item when a new StatusNotifierWatcher showed up but there are actually three cases where this happens:

* In case the watcher got replaced. This is what #1801 actually targeted and works fine for.
* Initially if a watcher is available. This means we actually register the item twice: Directly from within the constructor and from the handler. Does not hurt but is unnecessary.
* In case a watcher actually just showed up. In this case, we are already using the GtkStatusItem fallback, though, and this thus leads to two icons, see #1870.

Instead of re-registering, this change causes blueman-tray to reload if a watcher appears after we failed to register the item or a watcher appears for the second time.