### PR TITLE
ManagerDeviceMenu: Do not assume all instances have been generated

### DIFF
--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -100,6 +100,8 @@ class ManagerDeviceMenu(Gtk.Menu):
     def set_op(self, device: Device, message: str) -> None:
         ManagerDeviceMenu.__ops__[device.get_object_path()] = message
         for inst in ManagerDeviceMenu.__instances__:
+            if not hasattr(inst, "SelectedDevice"):
+                return
             logging.info(f"op: regenerating instance {inst}")
             if inst.SelectedDevice == self.SelectedDevice and not (inst.is_popup and not inst.props.visible):
                 inst.generate()
@@ -113,6 +115,8 @@ class ManagerDeviceMenu(Gtk.Menu):
     def unset_op(self, device: Device) -> None:
         del ManagerDeviceMenu.__ops__[device.get_object_path()]
         for inst in ManagerDeviceMenu.__instances__:
+            if not hasattr(inst, "SelectedDevice"):
+                return
             logging.info(f"op: regenerating instance {inst}")
             if inst.SelectedDevice == self.SelectedDevice and not (inst.is_popup and not inst.props.visible):
                 inst.generate()


### PR DESCRIPTION
If the right click instance has never been used and the user double clicks to connect it will not have a SelectedDevice yet.