### PR TITLE
Fix dependencies on StatusIcon plugin

### DIFF
--- a/blueman/plugins/applet/PulseAudioProfile.py
+++ b/blueman/plugins/applet/PulseAudioProfile.py
@@ -14,8 +14,7 @@ if TYPE_CHECKING:
 
 
 class AudioProfiles(AppletPlugin):
-    __depends__ = ["StatusIcon", "Menu"]
-    __unloadable__ = False
+    __depends__ = ["Menu"]
     __description__ = _("Adds audio profile selector to the status icon menu")
     __author__ = "Abhijeet Viswa"
 

--- a/blueman/plugins/applet/StatusNotifierItem.py
+++ b/blueman/plugins/applet/StatusNotifierItem.py
@@ -9,7 +9,6 @@ from blueman.plugins.applet.StatusIcon import StatusIconImplementationProvider
 class StatusNotifierItem(AppletPlugin, StatusIconImplementationProvider):
     __description__ = _("Provides a StatusNotifierItem to show a statusicon")
     __icon__ = "bluetooth-symbolic"
-    __depends__ = ['StatusIcon']
 
     def on_query_status_icon_implementation(self) -> Tuple[str, int]:
         return "StatusNotifierItem", 20


### PR DESCRIPTION
AudioProfiles and StatusNotifierItem do not actually depend on it. They are rather pointless without a status icon but they do work. Also there is no point in not making AudioProfiles unloadable (the default). This makes #1496 actually work.