### PR TITLE
Define relevant plugin types for BluemanApplet.Plugins

### DIFF
--- a/blueman/main/Applet.py
+++ b/blueman/main/Applet.py
@@ -1,4 +1,7 @@
-from typing import Any
+from gi.repository import Gio, GLib
+import logging
+import signal
+from typing import Any, cast
 
 from blueman.Functions import *
 from blueman.bluez.Manager import Manager
@@ -8,9 +11,12 @@ import blueman.plugins.applet
 from blueman.main.PluginManager import PersistentPluginManager
 from blueman.main.DbusService import DbusService
 from blueman.plugins.AppletPlugin import AppletPlugin
-from gi.repository import Gio, GLib
-import logging
-import signal
+from blueman.plugins.applet.DBusService import DBusService
+from blueman.plugins.applet.Menu import Menu
+from blueman.plugins.applet.PowerManager import PowerManager
+from blueman.plugins.applet.RecentConns import RecentConns
+from blueman.plugins.applet.StandardItems import StandardItems
+from blueman.plugins.applet.StatusIcon import StatusIcon
 
 
 class BluemanApplet(Gio.Application):
@@ -40,7 +46,7 @@ class BluemanApplet(Gio.Application):
                                    Gio.BusType.SESSION)
         self.DbusSvc.register()
 
-        self.Plugins = PersistentPluginManager(AppletPlugin, blueman.plugins.applet, self)
+        self.Plugins = Plugins(self)
         self.Plugins.load_plugin()
 
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
@@ -100,3 +106,32 @@ class BluemanApplet(Gio.Application):
         logging.info(f"Device removed {path}")
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
             plugin.on_device_removed(path)
+
+
+class Plugins(PersistentPluginManager):
+    def __init__(self, applet: BluemanApplet):
+        super().__init__(AppletPlugin, blueman.plugins.applet, applet)
+
+    @property
+    def DBusService(self) -> DBusService:
+        return cast(DBusService, self._plugins["DBusService"])
+
+    @property
+    def Menu(self) -> Menu:
+        return cast(Menu, self._plugins["Menu"])
+
+    @property
+    def PowerManager(self) -> PowerManager:
+        return cast(PowerManager, self._plugins["PowerManager"])
+
+    @property
+    def RecentConns(self) -> RecentConns:
+        return cast(RecentConns, self._plugins["RecentConns"])
+
+    @property
+    def StandardItems(self) -> StandardItems:
+        return cast(StandardItems, self._plugins["StandardItems"])
+
+    @property
+    def StatusIcon(self) -> StatusIcon:
+        return cast(StatusIcon, self._plugins["StatusIcon"])

--- a/blueman/plugins/applet/DisconnectItems.py
+++ b/blueman/plugins/applet/DisconnectItems.py
@@ -1,5 +1,5 @@
 from gettext import gettext as _
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, cast, Callable
 
 from blueman.plugins.AppletPlugin import AppletPlugin
 
@@ -39,4 +39,4 @@ class DisconnectItems(AppletPlugin):
             if device["Connected"]:
                 self._menu.add(self, (25, idx), text=_("Disconnect %s") % device["Alias"],
                                icon_name="bluetooth-disconnected-symbolic",
-                               callback=lambda dev=device: dev.disconnect())
+                               callback=cast(Callable[[], None], lambda dev=device: dev.disconnect()))

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -9,6 +9,7 @@ from blueman.bluez.errors import DBusNoSuchAdapterError
 from blueman.gui.Notification import Notification
 from blueman.Sdp import ServiceUUID
 from blueman.plugins.AppletPlugin import AppletPlugin
+from blueman.plugins.applet.Menu import MenuItem
 from blueman.plugins.applet.PowerManager import PowerManager, PowerStateListener
 
 if TYPE_CHECKING:
@@ -182,7 +183,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
 
     def _rebuild_menu(self) -> None:
         menu: "Menu" = self.parent.Plugins.Menu
-        self._mitems = []
+        self._mitems: List[MenuItem] = []
         menu.unregister(self)
         menu.add(self, 52, text=_("Recent _Connections"), icon_name="document-open-recent-symbolic",
                  sensitive=False, callback=lambda: None)

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -28,7 +28,7 @@ class StatusIcon(AppletPlugin, GObject.GObject):
 
     visible = None
 
-    visibility_timeout = None
+    visibility_timeout: Optional[int] = None
 
     _implementations = None
 


### PR DESCRIPTION
This is rather ugly, especially as it breaks the dynamic nature of the PluginManager and involves a cast, but it is definitely an improvement as it would have caught #1887 early (would need backporting to 2-3-stable for that of course - RecentConns is ugly).

There might be some generic way of defining this, like `__getattr__(self, key: Literal[_T]) -> _T` but I did not find a way to actually express something like "literal name matching a typevar's value".