### PR TITLE
List devices and battery levels in status icon tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Enable dnsmasq DNS service if possible and add DNS servers otherwise
 * Reconfigure DHCP service on local nameserver changes
 * Support for systemd-resolved for getting nameservers for NAP clients
+* List connected devices in status icon tooltip
 
 ### Changes
 

--- a/blueman/bluez/Battery.py
+++ b/blueman/bluez/Battery.py
@@ -1,5 +1,14 @@
+from blueman.bluez.AnyBase import AnyBase
+
 from blueman.bluez.Base import Base
+
+_INTERFACE = "org.bluez.Battery1"
 
 
 class Battery(Base):
-    _interface_name = "org.bluez.Battery1"
+    _interface_name = _INTERFACE
+
+
+class AnyBattery(AnyBase):
+    def __init__(self) -> None:
+        super().__init__(_INTERFACE)

--- a/blueman/main/BatteryWatcher.py
+++ b/blueman/main/BatteryWatcher.py
@@ -1,0 +1,29 @@
+import weakref
+from typing import Callable
+
+from blueman.bluez.Battery import Battery, AnyBattery
+from blueman.bluez.Manager import Manager
+
+
+class BatteryWatcher:
+    def __init__(self, callback: Callable[[str, int], None]) -> None:
+        super().__init__()
+        manager = Manager()
+        weakref.finalize(
+            self,
+            manager.disconnect_signal,
+            manager.connect_signal(
+                "battery-created",
+                lambda _manager, obj_path: callback(obj_path, Battery(obj_path=obj_path)["Percentage"])
+            )
+        )
+
+        any_battery = AnyBattery()
+        weakref.finalize(
+            self,
+            any_battery.disconnect_signal,
+            any_battery.connect_signal(
+                "property-changed",
+                lambda _any_battery, key, value, path: callback(path, value) if key == "Percentage" else None
+            )
+        )

--- a/blueman/main/Makefile.am
+++ b/blueman/main/Makefile.am
@@ -20,7 +20,8 @@ blueman_PYTHON = \
 	Services.py \
 	Tray.py \
 	DBusProxies.py \
-	NetworkManager.py
+	NetworkManager.py \
+	BatteryWatcher.py
 
 if HAVE_PULSEAUDIO
 blueman_PYTHON += PulseAudioUtils.py

--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -2,11 +2,9 @@ from gettext import gettext as _
 from typing import Any, Dict, Union
 
 from blueman.bluez.Device import Device
-from blueman.bluez.Battery import Battery
-from blueman.bluez.Manager import Manager
 from blueman.gui.Notification import Notification, _NotificationBubble, _NotificationDialog
+from blueman.main.BatteryWatcher import BatteryWatcher
 from blueman.plugins.AppletPlugin import AppletPlugin
-from gi.repository import GLib
 
 
 class ConnectionNotifier(AppletPlugin):
@@ -14,22 +12,17 @@ class ConnectionNotifier(AppletPlugin):
     __icon__ = "bluetooth-symbolic"
     __description__ = _("Shows desktop notifications when devices get connected or disconnected.")
 
-    _sig = None
     _notifications: Dict[str, Union[_NotificationBubble, _NotificationDialog]] = {}
 
     def on_load(self) -> None:
-        self._manager = Manager()
-        self._sig = self._manager.connect_signal("battery-created", self._on_battery_created)
+        self._battery_watcher = BatteryWatcher(self._on_battery_update)
 
     def on_unload(self) -> None:
-        if self._sig is not None:
-            self._manager.disconnect_signal(self._sig)
+        del self._battery_watcher
 
     def on_device_property_changed(self, path: str, key: str, value: Any) -> None:
-        device = Device(obj_path=path)
-        battery = Battery(obj_path=path)
-
         if key == "Connected":
+            device = Device(obj_path=path)
             if value:
                 self._notifications[path] = notification = Notification(
                     device.display_name,
@@ -37,23 +30,11 @@ class ConnectionNotifier(AppletPlugin):
                     icon_name=device["Icon"]
                 )
                 notification.show()
-
-                sig = battery.connect_signal("property-changed", self._on_battery_property_changed)
-
-                def disconnect_signal() -> bool:
-                    battery.disconnect_signal(sig)
-                    return False
-                GLib.timeout_add_seconds(5, disconnect_signal)
             else:
                 Notification(device.display_name, _('Disconnected'), icon_name=device["Icon"]).show()
 
-    def _on_battery_created(self, _manager: Manager, obj_path: str) -> None:
-        battery = Battery(obj_path=obj_path)
-        self._on_battery_property_changed(battery, "Percentage", battery["Percentage"], obj_path)
-
-    def _on_battery_property_changed(self, _battery: Battery, key: str, value: Any, path: str) -> None:
-        if key == "Percentage":
-            notification = self._notifications[path]
-            if notification:
-                notification.set_message(f"{_('Connected')} {value}%")
-                notification.set_notification_icon("battery")
+    def _on_battery_update(self, path: str, value: int) -> None:
+        notification = self._notifications[path]
+        if notification:
+            notification.set_message(f"{_('Connected')} {value}%")
+            notification.set_notification_icon("battery")


### PR DESCRIPTION
Issues: `BatteryWatcher`'s users expect it to get destroyed and for that `BatteryWatcher` expect the `Manager` and `Battery` objects to get destroyed. The latter requires #1908 to actually happen and for `Manager` it does not work due to the `self`-references it passes to its signal handlers to be able to call its `emit` method. I'm not sure if and how that could get resolved.

Apart from that I'm not sure how good the idea of using that Unicode symbol actually is... :sweat_smile: