### PR TITLE
Strip surrounding whitespace from device names

### DIFF
--- a/blueman/bluez/Device.py
+++ b/blueman/bluez/Device.py
@@ -32,6 +32,11 @@ class Device(Base):
     ) -> None:
         self._call('Disconnect', reply_handler=reply_handler, error_handler=error_handler)
 
+    @property
+    def display_name(self) -> str:
+        alias: str = self["Alias"]
+        return alias.strip()
+
 
 class AnyDevice(AnyBase):
     def __init__(self) -> None:

--- a/blueman/gui/DeviceSelectorList.py
+++ b/blueman/gui/DeviceSelectorList.py
@@ -39,7 +39,7 @@ class DeviceSelectorList(DeviceList):
     def row_setup_event(self, tree_iter: Gtk.TreeIter, device: Device) -> None:
         self.row_update_event(tree_iter, "Trusted", device['Trusted'])
         self.row_update_event(tree_iter, "Paired", device['Paired'])
-        self.row_update_event(tree_iter, "Alias", device['Alias'])
+        self.row_update_event(tree_iter, "Alias", device.display_name)
         self.row_update_event(tree_iter, "Icon", device['Icon'])
 
     def row_update_event(self, tree_iter: Gtk.TreeIter, key: str, value: Any) -> None:

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -351,9 +351,9 @@ class ManagerDeviceList(DeviceList):
             description = get_major_class(device['Class'])
 
         icon_info = self.get_icon_info(device["Icon"], 48, False)
-        caption = self.make_caption(device['Alias'], description, device['Address'])
+        caption = self.make_caption(device.display_name, description, device['Address'])
 
-        self.set(tree_iter, caption=caption, icon_info=icon_info, alias=device['Alias'], objpush=has_objpush)
+        self.set(tree_iter, caption=caption, icon_info=icon_info, alias=device.display_name, objpush=has_objpush)
 
         try:
             self.row_update_event(tree_iter, "Trusted", device['Trusted'])

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -255,7 +255,7 @@ class Blueman(Gtk.Application):
     def bond(device: Device) -> None:
         def error_handler(e: Exception) -> None:
             logging.exception(e)
-            message = f"Pairing failed for:\n{device['Alias']} ({device['Address']})"
+            message = f"Pairing failed for:\n{device.display_name} ({device['Address']})"
             Notification('Bluetooth', message, icon_name="blueman").show()
 
         device.pair(error_handler=error_handler)

--- a/blueman/main/NetworkManager.py
+++ b/blueman/main/NetworkManager.py
@@ -202,7 +202,7 @@ class NMDUNConnection(NMConnectionBase):
             return
 
         conn = NM.SimpleConnection()
-        conn_id = f"blueman dun for {self.device['Alias']}"
+        conn_id = f"blueman dun for {self.device.display_name}"
         conn_uuid = str(uuid.uuid4())
 
         conn_sett = NM.SettingConnection(type='bluetooth', id=conn_id, uuid=conn_uuid, autoconnect=False)

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -124,7 +124,7 @@ class Sender(Gtk.Dialog):
         self.client.connect('session-failed', self.on_session_failed)
 
         logging.info(f"Sending to {device['Address']}")
-        self.l_dest.props.label = device['Alias']
+        self.l_dest.props.label = device.display_name
 
         # Stop discovery if discovering and let adapter settle for a second
         if self.adapter["Discovering"]:

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -96,7 +96,7 @@ class BluezAgent(DbusService):
 
     def get_device_string(self, device_path: str) -> str:
         device = Device(obj_path=device_path)
-        return f"<b>{escape(device['Alias'])}</b> ({device['Address']})"
+        return f"<b>{escape(device.display_name)}</b> ({device['Address']})"
 
     @overload
     def ask_passkey(self, dialog_msg: str, is_numeric: "Literal[True]", device_path: str, ok: Callable[[int], None],

--- a/blueman/plugins/applet/AutoConnect.py
+++ b/blueman/plugins/applet/AutoConnect.py
@@ -48,7 +48,7 @@ class AutoConnect(AppletPlugin):
             def reply(dev: Optional[Device] = device, service_name: str = ServiceUUID(uuid).name) -> None:
                 assert isinstance(dev, Device)  # https://github.com/python/mypy/issues/2608
                 Notification(_("Connected"), _("Automatically connected to %(service)s on %(device)s") %
-                             {"service": service_name, "device": dev["Alias"]},
+                             {"service": service_name, "device": dev.display_name},
                              icon_name=dev["Icon"]).show()
 
             def err(_reason: Union[Exception, str]) -> None:

--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -32,7 +32,7 @@ class ConnectionNotifier(AppletPlugin):
         if key == "Connected":
             if value:
                 self._notifications[path] = notification = Notification(
-                    device["Alias"],
+                    device.display_name,
                     _('Connected'),
                     icon_name=device["Icon"]
                 )
@@ -45,7 +45,7 @@ class ConnectionNotifier(AppletPlugin):
                     return False
                 GLib.timeout_add_seconds(5, disconnect_signal)
             else:
-                Notification(device["Alias"], _('Disconnected'), icon_name=device["Icon"]).show()
+                Notification(device.display_name, _('Disconnected'), icon_name=device["Icon"]).show()
 
     def _on_battery_created(self, _manager: Manager, obj_path: str) -> None:
         battery = Battery(obj_path=obj_path)

--- a/blueman/plugins/applet/DisconnectItems.py
+++ b/blueman/plugins/applet/DisconnectItems.py
@@ -37,6 +37,6 @@ class DisconnectItems(AppletPlugin):
     def _render(self) -> None:
         for idx, device in enumerate(self.parent.Manager.get_devices()):
             if device["Connected"]:
-                self._menu.add(self, (25, idx), text=_("Disconnect %s") % device["Alias"],
+                self._menu.add(self, (25, idx), text=_("Disconnect %s") % device.display_name,
                                icon_name="bluetooth-disconnected-symbolic",
                                callback=cast(Callable[[], None], lambda dev=device: dev.disconnect()))

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -151,7 +151,7 @@ class Dialog:
             for m in plugin.monitors:
                 if d == m.device["Address"]:
                     titer = self.liststore.append(
-                        [d, self.get_caption(m.device["Alias"], m.device["Address"]),
+                        [d, self.get_caption(m.device.display_name, m.device["Address"]),
                          _("Connected:") + " " + m.interface, m])
                     if self.cb_device.get_active() == -1:
                         self.cb_device.set_active_iter(titer)
@@ -164,7 +164,7 @@ class Dialog:
                     if device is None:
                         pass
                     else:
-                        name = self.get_caption(device["Alias"], device["Address"])
+                        name = self.get_caption(device.display_name, device["Address"])
 
                 self.liststore.append([d, name, _("Not Connected"), None])
             added = False
@@ -263,12 +263,12 @@ class Dialog:
             (val,) = self.liststore.get(titer, 0)
 
             if val == monitor.device["Address"]:
-                self.liststore.set(titer, 1, self.get_caption(monitor.device["Alias"], monitor.device["Address"]), 2,
-                                   _("Connected:") + " " + monitor.interface, 3, monitor)
+                caption = self.get_caption(monitor.device.display_name, monitor.device["Address"])
+                self.liststore.set(titer, 1, caption, 2, _("Connected:") + " " + monitor.interface, 3, monitor)
                 return
 
         self.liststore.append(
-            [monitor.device["Address"], self.get_caption(monitor.device["Alias"], monitor.device["Address"]),
+            [monitor.device["Address"], self.get_caption(monitor.device.display_name, monitor.device["Address"]),
              _("Connected:") + " " + monitor.interface, monitor]
         )
 
@@ -278,8 +278,8 @@ class Dialog:
             (val,) = self.liststore.get(titer, 0)
 
             if val == monitor.device["Address"]:
-                self.liststore.set(titer, 1, self.get_caption(monitor.device["Alias"], monitor.device["Address"]), 2,
-                                   _("Not Connected"), 3, None)
+                caption = self.get_caption(monitor.device.display_name, monitor.device["Address"])
+                self.liststore.set(titer, 1, caption, 2, _("Not Connected"), 3, None)
                 return
 
 

--- a/blueman/plugins/applet/PPPSupport.py
+++ b/blueman/plugins/applet/PPPSupport.py
@@ -71,7 +71,8 @@ class Connection:
             plugin.on_ppp_connected(self.service.device, rfcomm_dev, result)
 
         msg = _("Successfully connected to <b>DUN</b> service on <b>%(0)s.</b>\n"
-                "Network is now available through <b>%(1)s</b>") % {"0": self.service.device['Alias'], "1": result}
+                "Network is now available through <b>%(1)s</b>") % \
+            {"0": self.service.device.display_name, "1": result}
 
         Notification(_("Connected"), msg, icon_name="network-wireless-symbolic").show()
 

--- a/blueman/plugins/applet/PulseAudioProfile.py
+++ b/blueman/plugins/applet/PulseAudioProfile.py
@@ -76,7 +76,7 @@ class AudioProfiles(AppletPlugin):
             return items
 
         info = self._devices[device['Address']]
-        menu = self._menu.add(self, (42, info["index"]), _("Audio Profiles for %s") % device['Alias'],
+        menu = self._menu.add(self, (42, info["index"]), _("Audio Profiles for %s") % device.display_name,
                               icon_name="audio-card-symbolic",
                               submenu_function=lambda: _generate_profiles_menu(info))
         self._device_menus[device['Address']] = menu

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -119,7 +119,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
         item = {
             "adapter": adapter["Address"],
             "address": device['Address'],
-            "alias": device['Alias'],
+            "alias": device.display_name,
             "icon": device['Icon'],
             "name": ServiceUUID(uuid).name,
             "uuid": uuid,

--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -62,11 +62,11 @@ class SerialManager(AppletPlugin, RFCOMMConnectedListener):
         if SERIAL_PORT_SVCLASS_ID == service.short_uuid:
             Notification(_("Serial port connected"),
                          _("Serial port service on device <b>%s</b> now will be available via <b>%s</b>") % (
-                         device['Alias'], port),
+                         device.display_name, port),
                          icon_name="blueman-serial").show()
 
             self.call_script(device['Address'],
-                             device['Alias'],
+                             device.display_name,
                              service.name,
                              service.short_uuid,
                              port)

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -110,7 +110,7 @@ class Agent(DbusService):
             adapter = self._applet.Manager.get_adapter()
             device = self._applet.Manager.find_device(address, adapter.get_object_path())
             assert device is not None
-            name = device["Alias"]
+            name = device.display_name
             trusted = device["Trusted"]
         except Exception as e:
             logging.exception(e)


### PR DESCRIPTION
I encountered an interesting device that has a trailing CR on its Name and default Alias, causing weird looking empty lines at least in our device list and the status icon menu items. Of course there could be more such garbage (like control characters somewhere in the middle of a name), but stripping surrounding whitespace in all places where an Alias shows up in UI seems like a low hanging fruit here.

![shivr](https://user-images.githubusercontent.com/464848/197341206-c1c051b8-b5ad-4b88-8198-9dd99154579d.png)