### PR TITLE
Use GAction where possible

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -81,7 +81,7 @@ class ManagerDeviceList(DeviceList):
         self.Config.connect('changed', self._on_settings_changed)
         # Set the correct sorting
         self._on_settings_changed(self.Config, "sort-by")
-        self._on_settings_changed(self.Config, "sort-type")
+        self._on_settings_changed(self.Config, "sort-descending")
 
         self.connect("query-tooltip", self.tooltip_query)
         self.tooltip_row: Optional[Gtk.TreePath] = None
@@ -103,14 +103,13 @@ class ManagerDeviceList(DeviceList):
         self.filter.set_visible_func(self.filter_func)
 
     def _on_settings_changed(self, settings: Gio.Settings, key: str) -> None:
-        if key in ('sort-by', 'sort-order'):
+        if key in ('sort-by', 'sort-descending'):
             sort_by = settings['sort-by']
-            sort_order = settings['sort-order']
 
-            if sort_order == 'ascending':
-                sort_type = Gtk.SortType.ASCENDING
-            else:
+            if settings['sort-descending']:
                 sort_type = Gtk.SortType.DESCENDING
+            else:
+                sort_type = Gtk.SortType.ASCENDING
 
             column_id = self.ids.get(sort_by)
 

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -187,7 +187,7 @@ class ManagerMenu:
     def _simple_actions(self, action: Gio.Action, _val: Optional[Any]) -> None:
         name = action.get_name()
         if name == "report":
-            launch(f"xdg-open {WEBSITE}/issues")
+            launch(f"xdg-open {WEBSITE}/issues", system=True)
         elif name == "services":
             launch("blueman-services", name=_("Service Preferences"))
         elif name == "search":

--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -25,7 +25,6 @@ class ManagerToolbar:
         self.blueman.List.connect("adapter-property-changed", self.on_adapter_property_changed)
 
         self.b_search = blueman.builder.get_widget("b_search", Gtk.ToolButton)
-        self.b_search.connect("clicked", lambda button: blueman.inquiry())
 
         self.b_bond = blueman.builder.get_widget("b_bond", Gtk.ToolButton)
         self.b_bond.connect("clicked", self.on_action, self.blueman.bond)

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -1,7 +1,7 @@
 import logging
 import signal
 from gettext import gettext as _
-from typing import Optional, Any, Tuple
+from typing import Optional, Any, Tuple, Callable
 
 from blueman.bluez.Adapter import Adapter
 from blueman.bluez.Device import Device
@@ -179,6 +179,19 @@ class Blueman(Gtk.Application):
         if event.x != x or event.y != y or event.width != width or event.height != height:
             self.Config["window-properties"] = [event.width, event.height, event.x, event.y]
         return False
+
+    def register_settings_action(self, name: str) -> None:
+        action = self.Config.create_action(name)
+        self.add_action(action)
+
+    def register_action(self, name: str, callback: Callable[[Gio.Action, Optional[Any]], None],
+                        vtype: Optional[GLib.VariantType] = None) -> None:
+        if name in self.list_actions():
+            logging.error(f"{name} already exists")
+        else:
+            action = Gio.SimpleAction.new(name, vtype)
+            action.connect("activate", callback)
+            self.add_action(action)
 
     def on_adapter_changed(self, lst: ManagerDeviceList, adapter: str) -> None:
         if adapter is not None:

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -44,13 +44,9 @@
       <summary>Sort device list</summary>
       <description>Sort the device list by column, possible values are timestamp and alias</description>
     </key>
-    <key type="s" name="sort-order">
-      <choices>
-        <choice value="ascending"/>
-        <choice value="descending"/>
-      </choices>
-      <default>"ascending"</default>
-      <summary>Sort ascending or descending</summary>
+    <key type="b" name="sort-descending">
+      <default>false</default>
+      <summary>Sort descending</summary>
     </key>
     <key type="b" name="hide-unnamed">
       <summary>Hide devices with no name</summary>

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -295,6 +295,7 @@
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Search for nearby devices</property>
                 <property name="is-important">True</property>
+                <property name="action-name">app.search</property>
                 <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Search</property>
                 <property name="icon-name">edit-find-symbolic</property>
               </object>

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -2,42 +2,37 @@
 <!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
-  <object class="GtkImage" id="ib_more_icon">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">dialog-information</property>
-  </object>
-  <object class="GtkImage" id="im_exit">
+  <object class="GtkImage" id="i_exit">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="icon-name">application-exit-symbolic</property>
   </object>
-  <object class="GtkImage" id="im_help">
+  <object class="GtkImage" id="i_help">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="icon-name">help-about-symbolic</property>
   </object>
-  <object class="GtkImage" id="im_plugins">
+  <object class="GtkImage" id="i_plugins">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="icon-name">application-x-addon-symbolic</property>
   </object>
-  <object class="GtkImage" id="im_prefs">
+  <object class="GtkImage" id="i_prefs">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="icon-name">document-properties-symbolic</property>
   </object>
-  <object class="GtkImage" id="im_report">
+  <object class="GtkImage" id="i_report">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="icon-name">dialog-warning-symbolic</property>
   </object>
-  <object class="GtkImage" id="im_search">
+  <object class="GtkImage" id="i_search">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="icon-name">edit-find-symbolic</property>
   </object>
-  <object class="GtkImage" id="im_services">
+  <object class="GtkImage" id="i_services">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="icon-name">document-properties-symbolic</property>
@@ -63,54 +58,57 @@
                 <property name="label" translatable="yes">_Adapter</property>
                 <property name="use-underline">True</property>
                 <child type="submenu">
-                  <object class="GtkMenu">
+                  <object class="GtkMenu" id="adapter_menu">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="search_item">
+                      <object class="GtkImageMenuItem" id="adapter_search">
                         <property name="label" translatable="yes">_Search</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.search</property>
                         <property name="use-underline">True</property>
-                        <property name="image">im_search</property>
+                        <property name="image">i_search</property>
                         <property name="use-stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkSeparatorMenuItem">
+                      <object class="GtkSeparatorMenuItem" id="adapter_sep1">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkSeparatorMenuItem">
+                      <object class="GtkSeparatorMenuItem" id="adapter_sep2">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="prefs_item">
+                      <object class="GtkImageMenuItem" id="adapter_prefs">
                         <property name="label" translatable="yes">_Preferences</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.preferences</property>
                         <property name="use-underline">True</property>
-                        <property name="image">im_prefs</property>
+                        <property name="image">i_prefs</property>
                         <property name="use-stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkSeparatorMenuItem">
+                      <object class="GtkSeparatorMenuItem" id="adapter_sep3">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="exit_item">
+                      <object class="GtkImageMenuItem" id="adapter_exit">
                         <property name="label" translatable="yes">_Exit</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.exit</property>
                         <property name="use-underline">True</property>
-                        <property name="image">im_exit</property>
+                        <property name="image">i_exit</property>
                         <property name="use-stock">False</property>
                       </object>
                     </child>
@@ -138,47 +136,44 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <child>
-                      <object class="GtkCheckMenuItem" id="show_tb_item">
+                      <object class="GtkCheckMenuItem" id="view_toolbar">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.show-toolbar</property>
                         <property name="label" translatable="yes">Show _Toolbar</property>
                         <property name="use-underline">True</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkCheckMenuItem" id="show_sb_item">
+                      <object class="GtkCheckMenuItem" id="view_statusbar">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.show-statusbar</property>
                         <property name="label" translatable="yes">Show _Statusbar</property>
                         <property name="use-underline">True</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkCheckMenuItem" id="hide_unnamed_item">
+                      <object class="GtkCheckMenuItem" id="view_hideunnamed">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.hide-unnamed</property>
                         <property name="label" translatable="yes">Hide _unnamed devices</property>
                         <property name="use-underline">True</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkSeparatorMenuItem">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="sort_by_item">
+                      <object class="GtkMenuItem" id="view_sort">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">S_ort By</property>
                         <property name="use-underline">True</property>
                         <child type="submenu">
-                          <object class="GtkMenu">
+                          <object class="GtkMenu" id="sort_submenu">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <child>
-                              <object class="GtkRadioMenuItem" id="sort_name_item">
+                              <object class="GtkRadioMenuItem" id="sort_name">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">_Name</property>
@@ -187,25 +182,26 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkRadioMenuItem" id="sort_added_item">
+                              <object class="GtkRadioMenuItem" id="sort_added">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">_Added</property>
                                 <property name="use-underline">True</property>
                                 <property name="draw-as-radio">True</property>
-                                <property name="group">sort_name_item</property>
+                                <property name="group">sort_name</property>
                               </object>
                             </child>
                             <child>
-                              <object class="GtkSeparatorMenuItem">
+                              <object class="GtkSeparatorMenuItem" id="sort_sep">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                               </object>
                             </child>
                             <child>
-                              <object class="GtkCheckMenuItem" id="sort_descending_item">
+                              <object class="GtkCheckMenuItem" id="sort_type">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <property name="action-name">app.sort-descending</property>
                                 <property name="label" translatable="yes">_Descending</property>
                                 <property name="use-underline">True</property>
                               </object>
@@ -215,22 +211,24 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="plugins_item">
+                      <object class="GtkImageMenuItem" id="view_plugins">
                         <property name="label" translatable="yes">_Plugins</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.plugins</property>
                         <property name="use-underline">True</property>
-                        <property name="image">im_plugins</property>
+                        <property name="image">i_plugins</property>
                         <property name="use-stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="services_item">
+                      <object class="GtkImageMenuItem" id="view_services">
                         <property name="label" translatable="yes">_Local Services</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.services</property>
                         <property name="use-underline">True</property>
-                        <property name="image">im_services</property>
+                        <property name="image">i_services</property>
                         <property name="use-stock">False</property>
                       </object>
                     </child>
@@ -245,32 +243,34 @@
                 <property name="label" translatable="yes">_Help</property>
                 <property name="use-underline">True</property>
                 <child type="submenu">
-                  <object class="GtkMenu">
+                  <object class="GtkMenu" id="help_submenu">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="report">
+                      <object class="GtkImageMenuItem" id="help_report">
                         <property name="label" translatable="yes">_Report a Problem</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.report</property>
                         <property name="use-underline">True</property>
-                        <property name="image">im_report</property>
+                        <property name="image">i_report</property>
                         <property name="use-stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkSeparatorMenuItem" id="sep_help">
+                      <object class="GtkSeparatorMenuItem" id="help_sep">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="help">
+                      <object class="GtkImageMenuItem" id="help_help">
                         <property name="label" translatable="yes">_Help</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="action-name">app.help</property>
                         <property name="use-underline">True</property>
-                        <property name="image">im_help</property>
+                        <property name="image">i_help</property>
                         <property name="use-stock">False</property>
                       </object>
                     </child>
@@ -582,7 +582,6 @@
                     <property name="label" translatable="yes">More</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
-                    <property name="image">ib_more_icon</property>
                     <property name="relief">none</property>
                   </object>
                   <packing>
@@ -646,5 +645,40 @@
         </child>
       </object>
     </child>
+  </object>
+  <object class="GtkImage" id="im_exit">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">application-exit-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_help">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">help-about-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_plugins">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">application-x-addon-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_prefs">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-properties-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_report">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-warning-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_search">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-find-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_services">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-properties-symbolic</property>
   </object>
 </interface>

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -320,6 +320,7 @@
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Create pairing with the device</property>
+                <property name="action-name">app.bond</property>
                 <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Pair</property>
                 <property name="icon-name">blueman-pair-symbolic</property>
               </object>
@@ -334,12 +335,13 @@
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Mark/Unmark this device as trusted</property>
+                <property name="action-name">app.trust</property>
                 <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Trust</property>
                 <property name="icon-name">blueman-trust-symbolic</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="homogeneous">True</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -348,6 +350,7 @@
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Remove this device from the known devices list</property>
+                <property name="action-name">app.remove</property>
                 <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Remove</property>
                 <property name="icon-name">list-remove-symbolic</property>
               </object>
@@ -369,15 +372,17 @@
             <child>
               <object class="GtkToolButton" id="b_send">
                 <property name="visible">True</property>
+                <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Send file(s) to the device</property>
                 <property name="is-important">True</property>
+                <property name="action-name">app.sendfile</property>
                 <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Send File</property>
                 <property name="icon-name">blueman-send-symbolic</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="homogeneous">True</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <style>


### PR DESCRIPTION
Eventually we will need to drop the current menu's for something else. In preparation I wanted to move all "regular" menuitem callbacks to GAction as pretty much all replacements will use them . Sadly RadioMenuItems don't work with GAction :disappointed:.

I think it would be good to do as much as possible so marked it for review. Also included accelerators for closing windows and apps.