### PR TITLE
Bump version to an alpha

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.61)
 
-AC_INIT([blueman], [2.3.1], [https://github.com/blueman-project/blueman/issues])
+AC_INIT([blueman], [2.4-alpha], [https://github.com/blueman-project/blueman/issues])
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([1.16.3 foreign dist-xz])

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'blueman', 'c',
-    version: '2.3.1',
+    version: '2.4-alpha',
     license: 'GPL3',
     meson_version: '>=0.50.0',
     default_options: 'b_lundef=false'


### PR DESCRIPTION
I was properly confused when I looked at the version in blueman being 2.3 while I was (almost) certain I was using the a git build from a couple days ago. Happy to change it to something else if alpha is not right.