### PR TITLE
blueman-manager: Handle device removal events gracefully

### DIFF
--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -172,7 +172,8 @@ class DeviceList(GenericList):
     def device_remove_event(self, device: Device) -> None:
         logging.debug(device)
         tree_iter = self.find_device(device)
-        assert tree_iter is not None
+        if tree_iter is None:
+            return
 
         if self.compare(self.selected(), tree_iter):
             self.emit("device-selected", None, None)


### PR DESCRIPTION
As seen in https://bugzilla.redhat.com/show_bug.cgi?id=2148624, it looks like at least our fader can cause the device removal event to get handled multiple times, so that the tree_iter might actually be gone and the assertion causes an exception. If there is no tree_iter, there is nothing left that we could or should do, so we can just return.