### PR TITLE
ManagerDeviceList: emit device-selected once on device removal

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -301,7 +301,6 @@ class ManagerDeviceList(DeviceList):
 
     def __fader_finished(self, device: Device) -> None:
         super().device_remove_event(device)
-        self.emit("device-selected", None, None)
 
     @staticmethod
     def make_caption(name: str, klass: str, address: str) -> str:


### PR DESCRIPTION
I noticed the devicemenu going insensitive and the buttons on the toolbar changing while no selection changed.