### PR TITLE
Handle rfcomm_list failing

### DIFF
--- a/blueman/plugins/applet/SerialManager.py
+++ b/blueman/plugins/applet/SerialManager.py
@@ -6,7 +6,7 @@ from blueman.gui.Notification import Notification
 from blueman.Sdp import SERIAL_PORT_SVCLASS_ID
 from blueman.plugins.applet.DBusService import RFCOMMConnectedListener
 from blueman.services.Functions import get_services
-from _blueman import rfcomm_list
+from _blueman import rfcomm_list, RFCOMMError
 from subprocess import Popen
 import logging
 import os
@@ -129,7 +129,11 @@ class SerialManager(AppletPlugin, RFCOMMConnectedListener):
         if not serial_services:
             return
 
-        active_ports = [rfcomm['id'] for rfcomm in rfcomm_list() if rfcomm['dst'] == device['Address']]
+        try:
+            active_ports = [rfcomm['id'] for rfcomm in rfcomm_list() if rfcomm['dst'] == device['Address']]
+        except RFCOMMError as e:
+            logging.error(f"rfcomm_list failed with: {e}")
+            return
 
         for port in active_ports:
             name = f"/dev/rfcomm{port:d}"

--- a/blueman/services/meta/SerialService.py
+++ b/blueman/services/meta/SerialService.py
@@ -27,11 +27,22 @@ class SerialService(Service):
 
     @property
     def connectable(self) -> bool:
+        try:
+            rfcomm_list()
+        except RFCOMMError:
+            return False
+
         return True
 
     @property
     def connected_instances(self) -> List[Instance]:
-        return [Instance(_("Serial Port %s") % "rfcomm%d" % dev["id"], dev["id"]) for dev in rfcomm_list()
+        try:
+            lst = rfcomm_list()
+        except RFCOMMError as e:
+            logging.error(e)
+            return []
+
+        return [Instance(_("Serial Port %s") % "rfcomm%d" % dev["id"], dev["id"]) for dev in lst
                 if dev["dst"] == self.device['Address'] and dev["state"] == "connected"]
 
     def on_file_changed(

--- a/module/_blueman.pyx
+++ b/module/_blueman.pyx
@@ -141,7 +141,7 @@ def rfcomm_list():
 
     res = get_rfcomm_list(&dl)
     if res < 0:
-        raise Exception, ERR[res]
+        raise RFCOMMError(ERR[res])
 
     devs = []
     for 0 <= i < dl.dev_num:


### PR DESCRIPTION
Just quick draft so we can discuss if we need to display something to the user or not. And logging the exception may be too much, perhaps just the error message with or without the error number?