### PR TITLE
Move widget creation to UI file and give stats enough space to grow and shrink

### DIFF
--- a/blueman/gui/manager/ManagerStats.py
+++ b/blueman/gui/manager/ManagerStats.py
@@ -33,40 +33,13 @@ class ManagerStats:
         self.up_speed = SpeedCalc()
         self.down_speed = SpeedCalc()
 
-        self.im_upload = Gtk.Image(icon_name="blueman-up-inactive", pixel_size=16,
-                                   halign=Gtk.Align.END, valign=Gtk.Align.CENTER,
-                                   tooltip_text=_("Data activity indication"))
-        self.im_download = Gtk.Image(icon_name="blueman-down-inactive", pixel_size=16,
-                                     halign=Gtk.Align.END, valign=Gtk.Align.CENTER,
-                                     tooltip_text=_("Data activity indication"))
-        self.down_rate = Gtk.Label(halign=Gtk.Align.END, valign=Gtk.Align.CENTER,
-                                   tooltip_text=_("Total data received and rate of transmission"))
-        self.down_rate.show()
+        self.im_upload = blueman.builder.get_widget("im_upload", Gtk.Image)
+        self.im_download = blueman.builder.get_widget("im_download", Gtk.Image)
+        self.down_rate = blueman.builder.get_widget("label_down_rate", Gtk.Label)
+        self.up_rate = blueman.builder.get_widget("label_up_rate", Gtk.Label)
 
-        self.up_rate = Gtk.Label(halign=Gtk.Align.END, valign=Gtk.Align.CENTER,
-                                 tooltip_text=_("Total data sent and rate of transmission"))
-        self.up_rate.show()
+        self.hbox = blueman.builder.get_widget("status_activity", Gtk.Box)
 
-        self.uparrow = Gtk.Image(icon_name="go-up-symbolic", pixel_size=16,
-                                 halign=Gtk.Align.END, valign=Gtk.Align.CENTER,
-                                 tooltip_text=_("Total data sent and rate of transmission"))
-        self.downarrow = Gtk.Image(icon_name="go-down-symbolic", pixel_size=16,
-                                   halign=Gtk.Align.END, valign=Gtk.Align.CENTER,
-                                   tooltip_text=_("Total data received and rate of transmission"))
-
-        self.hbox = hbox = blueman.builder.get_widget("status_activity", Gtk.Box)
-
-        hbox.pack_start(self.uparrow, False, False, 0)
-        hbox.pack_start(self.up_rate, False, False, 0)
-
-        hbox.pack_start(self.downarrow, False, False, 0)
-        hbox.pack_start(self.down_rate, False, False, 0)
-
-        hbox.pack_start(Gtk.Separator(orientation=Gtk.Orientation.VERTICAL), False, False, 0)
-
-        hbox.pack_start(self.im_upload, False, False, 0)
-        hbox.pack_start(self.im_download, False, False, 0)
-        hbox.show_all()
         self.on_adapter_changed(blueman.List, blueman.List.get_adapter_path())
 
         self.up_blinker = Animation(self.im_upload, ["blueman-up-inactive", "blueman-up-active"])

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -7,6 +7,41 @@
     <property name="can-focus">False</property>
     <property name="icon-name">dialog-information</property>
   </object>
+  <object class="GtkImage" id="im_exit">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">application-exit-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_help">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">help-about-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_plugins">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">application-x-addon-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_prefs">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-properties-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_report">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-warning-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_search">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-find-symbolic</property>
+  </object>
+  <object class="GtkImage" id="im_services">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-properties-symbolic</property>
+  </object>
   <object class="GtkApplicationWindow" id="manager_window">
     <property name="can-focus">False</property>
     <property name="icon-name">blueman</property>
@@ -23,14 +58,70 @@
             <child>
               <object class="GtkMenuItem" id="item_adapter">
                 <property name="visible">True</property>
+                <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_Adapter</property>
                 <property name="use-underline">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkImageMenuItem" id="search_item">
+                        <property name="label" translatable="yes">_Search</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="image">im_search</property>
+                        <property name="use-stock">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="prefs_item">
+                        <property name="label" translatable="yes">_Preferences</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="image">im_prefs</property>
+                        <property name="use-stock">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="exit_item">
+                        <property name="label" translatable="yes">_Exit</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="image">im_exit</property>
+                        <property name="use-stock">False</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="item_device">
                 <property name="visible">True</property>
+                <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_Device</property>
                 <property name="use-underline">True</property>
@@ -42,6 +133,109 @@
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_View</property>
                 <property name="use-underline">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="show_tb_item">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Show _Toolbar</property>
+                        <property name="use-underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="show_sb_item">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Show _Statusbar</property>
+                        <property name="use-underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="hide_unnamed_item">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Hide _unnamed devices</property>
+                        <property name="use-underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="sort_by_item">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">S_ort By</property>
+                        <property name="use-underline">True</property>
+                        <child type="submenu">
+                          <object class="GtkMenu">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <child>
+                              <object class="GtkRadioMenuItem" id="sort_name_item">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">_Name</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-as-radio">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkRadioMenuItem" id="sort_added_item">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">_Added</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-as-radio">True</property>
+                                <property name="group">sort_name_item</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSeparatorMenuItem">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckMenuItem" id="sort_descending_item">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">_Descending</property>
+                                <property name="use-underline">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="plugins_item">
+                        <property name="label" translatable="yes">_Plugins</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="image">im_plugins</property>
+                        <property name="use-stock">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="services_item">
+                        <property name="label" translatable="yes">_Local Services</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="image">im_services</property>
+                        <property name="use-stock">False</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child>
@@ -50,6 +244,38 @@
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_Help</property>
                 <property name="use-underline">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkImageMenuItem" id="report">
+                        <property name="label" translatable="yes">_Report a Problem</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="image">im_report</property>
+                        <property name="use-stock">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem" id="sep_help">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="help">
+                        <property name="label" translatable="yes">_Help</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="image">im_help</property>
+                        <property name="use-stock">False</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -206,7 +206,95 @@
                 <property name="halign">end</property>
                 <property name="spacing">2</property>
                 <child>
-                  <placeholder/>
+                  <object class="GtkImage" id="im_arrow_up">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes">Total data sent and rate of transmission</property>
+                    <property name="icon-name">go-up-symbolic</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label_up_rate">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes">Total data sent and rate of transmission</property>
+                    <property name="label" translatable="yes">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
+                    <property name="use-markup">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkImage" id="im_arrow_down">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes">Total data received and rate of transmission</property>
+                    <property name="icon-name">go-down-symbolic</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label_down_rate">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes">Total data received and rate of transmission</property>
+                    <property name="label" translatable="yes">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
+                    <property name="use-markup">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSeparator">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkImage" id="im_upload">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes">Data activity indication</property>
+                    <property name="icon-name">blueman-up-inactive</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkImage" id="im_download">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes">Data activity indication</property>
+                    <property name="icon-name">blueman-down-inactive</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">6</property>
+                  </packing>
                 </child>
               </object>
               <packing>

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -455,7 +455,7 @@
                       <object class="GtkLabel" id="label_up_rate">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
+                        <property name="label">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
                         <property name="use-markup">True</property>
                       </object>
                       <packing>
@@ -496,7 +496,7 @@
                       <object class="GtkLabel" id="label_down_rate">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
+                        <property name="label">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
                         <property name="use-markup">True</property>
                       </object>
                       <packing>

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkImage" id="ib_more_icon">
@@ -204,59 +204,87 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="spacing">2</property>
                 <child>
-                  <object class="GtkImage" id="im_arrow_up">
+                  <object class="GtkBox">
+                    <property name="width-request">140</property>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="tooltip-text" translatable="yes">Total data sent and rate of transmission</property>
-                    <property name="icon-name">go-up-symbolic</property>
+                    <child>
+                      <object class="GtkImage" id="im_arrow_up">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
+                        <property name="icon-name">go-up-symbolic</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_up_rate">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
+                    <property name="padding">2</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="label_up_rate">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="tooltip-text" translatable="yes">Total data sent and rate of transmission</property>
-                    <property name="label" translatable="yes">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
-                    <property name="use-markup">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkImage" id="im_arrow_down">
+                  <object class="GtkBox">
+                    <property name="width-request">140</property>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="tooltip-text" translatable="yes">Total data received and rate of transmission</property>
-                    <property name="icon-name">go-down-symbolic</property>
+                    <child>
+                      <object class="GtkImage" id="im_arrow_down">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
+                        <property name="icon-name">go-down-symbolic</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_down_rate">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
+                    <property name="padding">2</property>
                     <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label_down_rate">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="tooltip-text" translatable="yes">Total data received and rate of transmission</property>
-                    <property name="label" translatable="yes">&lt;span size="small"&gt;0.0KB &lt;i&gt;0.0 b/s&lt;/i&gt;&lt;/span&gt;</property>
-                    <property name="use-markup">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
@@ -275,6 +303,8 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="tooltip-text" translatable="yes">Data activity indication</property>
+                    <property name="margin-start">2</property>
+                    <property name="margin-end">2</property>
                     <property name="icon-name">blueman-up-inactive</property>
                   </object>
                   <packing>
@@ -288,6 +318,8 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="tooltip-text" translatable="yes">Data activity indication</property>
+                    <property name="margin-start">2</property>
+                    <property name="margin-end">2</property>
                     <property name="icon-name">blueman-down-inactive</property>
                   </object>
                   <packing>


### PR DESCRIPTION
Before it would jump back and forth depending on the rate. It is still possible for it to grow when enough data is transferred but no jumpy stats every couple of seconds.
![image](https://user-images.githubusercontent.com/3465730/216441099-b2c29a05-279f-4e65-bf59-e7b67ee75e85.png)

edit: gave it a bit more space, hopefully this is enough for it to never jump even when a lot of data has transferred.