### PR TITLE
Allow blueman-applet to be controller by systemctl --user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changes
 
+* Allow blueman-applet to be controlled by systemd (systemctl --user). The autostart desktopfile still has priority over this and will have to be removed.
 * Raise minimum Python version to 3.8
 * Raise minumum Gtk+ version to 3.24
 * Hide recent connections associated with unavailable adapters

--- a/data/configs/blueman-applet.service.in
+++ b/data/configs/blueman-applet.service.in
@@ -1,7 +1,11 @@
 [Unit]
 Description=Bluetooth management applet
+PartOf=graphical-session.target
 
 [Service]
 Type=dbus
 BusName=org.blueman.Applet
 ExecStart=@BINDIR@/blueman-applet
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Not entirely sure how this van be enabled by default but for now just make it possible.