### PR TITLE
StandardItems: Do not close blueman-manager on activate via applet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Do not use pointless link quality value
 * Recent connections in toplevel applet menu
 * Never hide keyboard and combos, see #1954 for more info
+* Do not close blueman-manager from applet
 
 ## 2.3.5
 

--- a/blueman/main/DBusProxies.py
+++ b/blueman/main/DBusProxies.py
@@ -51,7 +51,7 @@ class ManagerService(ProxyBase):
                          object_path="/org/blueman/Manager",
                          flags=Gio.DBusProxyFlags.DO_NOT_AUTO_START_AT_CONSTRUCTION)
 
-    def _activate(self) -> None:
+    def activate(self) -> None:
         try:
             param = GLib.Variant('(a{sv})', ({},))
             self.call_sync("Activate", param, Gio.DBusCallFlags.NONE, -1, None)
@@ -78,9 +78,3 @@ class ManagerService(ProxyBase):
 
         param = GLib.Variant('(sava{sv})', (name, [], {}))
         self.call('ActivateAction', param, Gio.DBusCallFlags.NONE, -1, None, call_finish)
-
-    def startstop(self) -> None:
-        if self.get_name_owner() is None:
-            self._activate()
-        else:
-            self._call_action("Quit")

--- a/blueman/plugins/applet/StandardItems.py
+++ b/blueman/plugins/applet/StandardItems.py
@@ -76,7 +76,7 @@ class StandardItems(AppletPlugin, PowerStateListener):
 
     def on_devices(self) -> None:
         m = ManagerService()
-        m.startstop()
+        m.activate()
 
     def on_adapters(self) -> None:
         launch("blueman-adapters", name=_("Adapter Preferences"))


### PR DESCRIPTION
This is inconsistent with the other blueman application and can be confusing.