### PR TITLE
Allow to toggle the Bluetooth status from the manager menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Support for systemd-resolved for getting nameservers for NAP clients
 * List connected devices in status icon tooltip
 * Support for nautilus 43 and later
+* Allow to toggle the Bluetooth status from the manager menu
 
 ### Changes
 

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -54,6 +54,13 @@ class DBusService(AppletPlugin):
         self._add_dbus_method("DisconnectService", ("o", "s", "d"), "", self._disconnect_service, is_async=True)
         self._add_dbus_method("OpenPluginDialog", (), "", self._open_plugin_dialog)
 
+        self._add_dbus_signal("PluginsChanged", "")
+        self.parent.Plugins.connect("plugin-loaded", lambda *args: self._plugins_changed())
+        self.parent.Plugins.connect("plugin-unloaded", lambda *args: self._plugins_changed())
+
+    def _plugins_changed(self) -> None:
+        self._emit_dbus_signal("PluginsChanged")
+
     def connect_service(self, object_path: str, uuid: str, ok: Callable[[], None],
                         err: Callable[[Union[BluezDBusException, "NMConnectionError",
                                              RFCOMMError, GLib.Error, str]], None]) -> None:

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -22,6 +22,11 @@
     <property name="can-focus">False</property>
     <property name="icon-name">application-x-addon-symbolic</property>
   </object>
+  <object class="GtkImage" id="im_power">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">bluetooth-disabled-symbolic</property>
+  </object>
   <object class="GtkImage" id="im_prefs">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -58,7 +63,7 @@
             <child>
               <object class="GtkMenuItem" id="item_adapter">
                 <property name="visible">True</property>
-                <property name="sensitive">False</property>
+                <property name="sensitive">True</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_Adapter</property>
                 <property name="use-underline">True</property>
@@ -69,7 +74,7 @@
                     <child>
                       <object class="GtkImageMenuItem" id="search_item">
                         <property name="label" translatable="yes">_Search</property>
-                        <property name="visible">True</property>
+                        <property name="visible">False</property>
                         <property name="can-focus">False</property>
                         <property name="use-underline">True</property>
                         <property name="image">im_search</property>
@@ -91,10 +96,26 @@
                     <child>
                       <object class="GtkImageMenuItem" id="prefs_item">
                         <property name="label" translatable="yes">_Preferences</property>
-                        <property name="visible">True</property>
+                        <property name="visible">False</property>
                         <property name="can-focus">False</property>
                         <property name="use-underline">True</property>
                         <property name="image">im_prefs</property>
+                        <property name="use-stock">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="power_item">
+                        <property name="label" translatable="yes">Turn Bluetooth _On</property>
+                        <property name="visible">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="image">im_power</property>
                         <property name="use-stock">False</property>
                       </object>
                     </child>

--- a/stubs/gi/repository/Gtk.pyi
+++ b/stubs/gi/repository/Gtk.pyi
@@ -7864,6 +7864,11 @@ class ListBoxRow(Bin, Actionable):
 class MenuItem(Bin, Actionable, Activatable):
     bin: Bin
 
+    class _Props(Bin._Props):
+        label: typing.Optional[str]
+
+    props: _Props
+
     def __init__(self,
         *,
         label: str = "",


### PR DESCRIPTION
This also does not disable the whole "Adapter" menu, so that the exit item is now reachable when powerd off.

Closes #2044