### PR TITLE
Adapt sendto extension for recent nautilus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Reconfigure DHCP service on local nameserver changes
 * Support for systemd-resolved for getting nameservers for NAP clients
 * List connected devices in status icon tooltip
+* Support for nautilus 43 and later
 
 ### Changes
 

--- a/sendto/blueman_sendto.py.in
+++ b/sendto/blueman_sendto.py.in
@@ -32,7 +32,9 @@ class BluemanSendtoExtension(GObject.GObject, @FILEMANAGER@.MenuProvider):
             if not launched:
                 print("*** Failed to launch program ***")
 
-    def get_file_items(self, window, files):
+    def get_file_items(self, *args):
+        files = args[-1]
+
         if len(files) == 0:
             return
 
@@ -53,5 +55,5 @@ class BluemanSendtoExtension(GObject.GObject, @FILEMANAGER@.MenuProvider):
         return [item]
 
     # stub to avoid potential warning (nautilus throws fit)
-    def get_background_items(self, window, file):
+    def get_background_items(self, *args):
         return []


### PR DESCRIPTION
nautilus 0.43 / nautilus-python 4.0 dropped the window argument:

https://gitlab.gnome.org/GNOME/nautilus/-/commit/bc55ff7599ef7f5acc6e9b648765fdb45b56431c

https://gitlab.gnome.org/GNOME/nautilus-python/-/commit/fac72de53ba7a102b22b64976bc49f68c97c23f7

Closes #2134