### PR TITLE
Improve PluginDialog

### DIFF
--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -112,9 +112,7 @@ class PluginDialog(Gtk.ApplicationWindow):
 
         self.icon = builder.get_widget("icon", Gtk.Image)
         self.author_txt = builder.get_widget("author_txt", Gtk.Label)
-        self.depends_hdr = builder.get_widget("depends_hdr", Gtk.Widget)
         self.depends_txt = builder.get_widget("depends_txt", Gtk.Label)
-        self.conflicts_hdr = builder.get_widget("conflicts_hdr", Gtk.Widget)
         self.conflicts_txt = builder.get_widget("conflicts_txt", Gtk.Label)
         self.plugin_name = builder.get_widget("name", Gtk.Label)
 
@@ -205,20 +203,14 @@ class PluginDialog(Gtk.ApplicationWindow):
         self.description.props.label = cls.__description__
 
         if cls.__depends__:
-            self.depends_hdr.props.visible = True
-            self.depends_txt.props.visible = True
             self.depends_txt.props.label = ", ".join(cls.__depends__)
         else:
-            self.depends_hdr.props.visible = False
-            self.depends_txt.props.visible = False
+            self.depends_txt.props.label = _("No dependencies")
 
         if cls.__conflicts__:
-            self.conflicts_hdr.props.visible = True
-            self.conflicts_txt.props.visible = True
             self.conflicts_txt.props.label = ", ".join(cls.__conflicts__)
         else:
-            self.conflicts_hdr.props.visible = False
-            self.conflicts_txt.props.visible = False
+            self.conflicts_txt.props.label = _("No conflicts")
 
         if cls.is_configurable() and name in self.applet.Plugins.get_loaded():
             self.b_prefs.props.sensitive = True

--- a/data/ui/applet-plugins-widget.ui
+++ b/data/ui/applet-plugins-widget.ui
@@ -107,7 +107,7 @@
               <object class="GtkGrid" id="content">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="row-spacing">12</property>
+                <property name="row-spacing">2</property>
                 <child>
                   <object class="GtkLabel" id="description">
                     <property name="width-request">360</property>

--- a/data/ui/applet-plugins-widget.ui
+++ b/data/ui/applet-plugins-widget.ui
@@ -33,7 +33,7 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="valign">start</property>
-        <property name="margin-start">6</property>
+        <property name="margin-start">10</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
         <child>
@@ -92,6 +92,7 @@
       <object class="GtkScrolledWindow" id="main_scrolled_window">
         <property name="visible">True</property>
         <property name="can-focus">True</property>
+        <property name="margin-start">10</property>
         <property name="margin-end">6</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>

--- a/data/ui/applet-plugins-widget.ui
+++ b/data/ui/applet-plugins-widget.ui
@@ -115,6 +115,7 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="valign">start</property>
+                    <property name="vexpand">True</property>
                     <property name="label" translatable="yes">Not specified</property>
                     <property name="use-markup">True</property>
                     <property name="wrap">True</property>
@@ -175,6 +176,7 @@
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkLabel" id="depends_hdr">
+                        <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>

--- a/data/ui/applet-plugins-widget.ui
+++ b/data/ui/applet-plugins-widget.ui
@@ -103,7 +103,7 @@
             <property name="can-focus">False</property>
             <property name="shadow-type">none</property>
             <child>
-              <!-- n-columns=1 n-rows=7 -->
+              <!-- n-columns=1 n-rows=4 -->
               <object class="GtkGrid" id="content">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -127,14 +127,41 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="author_hdr">
+                  <object class="GtkBox" id="authorbox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Author:&lt;/b&gt;</property>
-                    <property name="use-markup">True</property>
-                    <property name="wrap">True</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkLabel" id="author_hdr">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Author:&lt;/b&gt;</property>
+                        <property name="use-markup">True</property>
+                        <property name="wrap">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="author_txt">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="label" translatable="yes">Unknown</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
@@ -142,13 +169,40 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="author_txt">
+                  <object class="GtkBox" id="dependsbox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <property name="label" translatable="yes">Unknown</property>
-                    <property name="use-markup">True</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkLabel" id="depends_hdr">
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Depends on:&lt;/b&gt;</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="depends_txt">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="label">dependlist</property>
+                        <property name="use-markup">True</property>
+                        <property name="wrap">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
@@ -156,58 +210,43 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="depends_hdr">
+                  <object class="GtkBox" id="conflictsbox">
+                    <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Depends on:&lt;/b&gt;</property>
-                    <property name="use-markup">True</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkLabel" id="conflicts_hdr">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Conflicts with:&lt;/b&gt;</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="conflicts_txt">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="label">conflictlist</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
                     <property name="top-attach">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="depends_txt">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <property name="label">dependlist</property>
-                    <property name="use-markup">True</property>
-                    <property name="wrap">True</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">4</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="conflicts_hdr">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Conflicts with:&lt;/b&gt;</property>
-                    <property name="use-markup">True</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">5</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="conflicts_txt">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <property name="label">conflictlist</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">6</property>
                   </packing>
                 </child>
               </object>

--- a/data/ui/applet-plugins-widget.ui
+++ b/data/ui/applet-plugins-widget.ui
@@ -103,25 +103,11 @@
             <property name="can-focus">False</property>
             <property name="shadow-type">none</property>
             <child>
-              <!-- n-columns=1 n-rows=8 -->
+              <!-- n-columns=1 n-rows=7 -->
               <object class="GtkGrid" id="content">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="row-spacing">12</property>
-                <child>
-                  <object class="GtkLabel" id="plugin_description_label">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Plugin description:&lt;/b&gt;</property>
-                    <property name="use-markup">True</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
                 <child>
                   <object class="GtkLabel" id="description">
                     <property name="width-request">360</property>
@@ -136,7 +122,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">1</property>
+                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
@@ -151,7 +137,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">2</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
@@ -165,7 +151,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">3</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
@@ -178,7 +164,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">4</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
@@ -187,12 +173,13 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="valign">start</property>
+                    <property name="label">dependlist</property>
                     <property name="use-markup">True</property>
                     <property name="wrap">True</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">5</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
@@ -206,7 +193,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">6</property>
+                    <property name="top-attach">5</property>
                   </packing>
                 </child>
                 <child>
@@ -215,10 +202,11 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="valign">start</property>
+                    <property name="label">conflictlist</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">7</property>
+                    <property name="top-attach">6</property>
                   </packing>
                 </child>
               </object>

--- a/data/ui/applet-plugins-widget.ui
+++ b/data/ui/applet-plugins-widget.ui
@@ -119,6 +119,7 @@
                     <property name="use-markup">True</property>
                     <property name="wrap">True</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>


### PR DESCRIPTION
The main change is that the author, conflicts and depends moved to the bottom and arranged horizontal. This also makes space to perhaps show the settings instead of having button to switch.

Before
![image](https://github.com/blueman-project/blueman/assets/3465730/9645c675-cd72-43ed-bfeb-880a5071e6f3)

After
![image](https://github.com/blueman-project/blueman/assets/3465730/2ac5d7dc-3b9a-460b-b913-4ceb26685cf3)
