### PR TITLE
Listbox for plugindialog

### DIFF
--- a/data/ui/applet-plugins-widget.ui
+++ b/data/ui/applet-plugins-widget.ui
@@ -19,7 +19,16 @@
         <property name="hscrollbar-policy">never</property>
         <property name="shadow-type">in</property>
         <child>
-          <placeholder/>
+          <object class="GtkViewport">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkListBox" id="plugin_listbox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+            </child>
+          </object>
         </child>
       </object>
       <packing>

--- a/stubs/gi/repository/GObject.pyi
+++ b/stubs/gi/repository/GObject.pyi
@@ -70,6 +70,8 @@ class Object():
     qdata: GLib.Data
     ref_count: builtins.int
 
+    __gtype__: GType
+
     def bind_property(self, source_property: builtins.str, target: Object, target_property: builtins.str, flags: BindingFlags) -> Binding: ...
 
     def bind_property_full(self, source_property: builtins.str, target: Object, target_property: builtins.str, flags: BindingFlags, transform_to: Closure, transform_from: Closure) -> Binding: ...


### PR DESCRIPTION
I still see some weirdness with enabling/disabling plugins but I suspect I messed up my gsettings in the process. Putting it out here as a possible option to use for blueman-manager's device list.

The idea here is that we make our own widget in the factory function and then optionally bind the GObject property to widgets. Then updating the `GObject` property will automatically update the UI. The plugin dialog is not very dynamic and used stateful `SimpleAction` for the checkbox but binding the enabled property is also an option.

mypy was very unhappy so some of the typing annotation looks weird and I had to cast the `PluginItem` properties to convince it.

The other option is to use `ListBoxRows` and insert them manually into the `ListBox`.