### PR TITLE
Respect adapter power state in manager

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -5,6 +5,7 @@ import logging
 import cairo
 import os
 
+from blueman.bluez.Adapter import Adapter
 from blueman.bluez.Battery import Battery
 from blueman.bluez.Device import Device
 from blueman.bluez.Manager import Manager
@@ -242,7 +243,7 @@ class ManagerDeviceList(DeviceList):
             if self.menu.show_generic_connect_calc(row["device"]['UUIDs']):
                 if row["connected"]:
                     self.menu.disconnect_service(row["device"])
-                else:
+                elif Adapter(obj_path=row["device"]["Adapter"])["Powered"]:
                     self.menu.connect_service(row["device"])
 
         if event.type == Gdk.EventType.BUTTON_PRESS and cast(Gdk.EventButton, event).button == 3:

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -56,6 +56,8 @@ class ManagerMenu:
         item_unnamed = blueman.builder.get_widget("hide_unnamed_item", Gtk.CheckMenuItem)
         self.blueman.Config.bind("hide-unnamed", item_unnamed, "active", Gio.SettingsBindFlags.DEFAULT)
 
+        self.device_menu: Optional[ManagerDeviceMenu] = None
+
         self._sort_alias_item = blueman.builder.get_widget("sort_name_item", Gtk.CheckMenuItem)
         self._sort_timestamp_item = blueman.builder.get_widget("sort_added_item", Gtk.CheckMenuItem)
 
@@ -104,8 +106,6 @@ class ManagerMenu:
 
         for adapter in self._manager.get_adapters():
             self.on_adapter_added(None, adapter.get_object_path())
-
-        self.device_menu: Optional[ManagerDeviceMenu] = None
 
         self.Config.connect("changed", self._on_settings_changed)
         self._sort_alias_item.connect("activate", self._on_sorting_changed, "alias")
@@ -229,6 +229,9 @@ class ManagerMenu:
         self._update_power()
 
     def _update_power(self) -> None:
+        if self.device_menu is not None:
+            self.device_menu.generate()
+
         if any(adapter["Powered"] for (_, adapter) in self.adapter_items.values()):
             self.Search.props.visible = True
             self._adapter_settings.props.visible = True

--- a/blueman/plugins/manager/Info.py
+++ b/blueman/plugins/manager/Info.py
@@ -116,7 +116,12 @@ def show_info(device: Device, parent: Gtk.Window) -> None:
 
 
 class Info(ManagerPlugin, MenuItemsProvider):
-    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[DeviceMenuItem]:
+    def on_request_menu_items(
+        self,
+        manager_menu: ManagerDeviceMenu,
+        device: Device,
+        _powered: bool,
+    ) -> List[DeviceMenuItem]:
         item = create_menuitem(_("_Info"), "dialog-information-symbolic")
         item.props.tooltip_text = _("Show device information")
         _window = manager_menu.get_toplevel()

--- a/blueman/plugins/manager/Notes.py
+++ b/blueman/plugins/manager/Notes.py
@@ -47,7 +47,15 @@ def send_note(device: Device, parent: Gtk.ApplicationWindow) -> None:
 
 
 class Notes(ManagerPlugin, MenuItemsProvider):
-    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[DeviceMenuItem]:
+    def on_request_menu_items(
+        self,
+        manager_menu: ManagerDeviceMenu,
+        device: Device,
+        powered: bool,
+    ) -> List[DeviceMenuItem]:
+        if not powered:
+            return []
+
         item = create_menuitem(_("Send _note"), "dialog-information-symbolic")
         item.props.tooltip_text = _("Send a text note")
         assert isinstance(manager_menu.Blueman.window, Gtk.ApplicationWindow)

--- a/blueman/plugins/manager/PulseAudioProfile.py
+++ b/blueman/plugins/manager/PulseAudioProfile.py
@@ -110,7 +110,12 @@ class PulseAudioProfile(ManagerPlugin, MenuItemsProvider):
             item.set_submenu(sub)
             item.show()
 
-    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[DeviceMenuItem]:
+    def on_request_menu_items(
+        self,
+        manager_menu: ManagerDeviceMenu,
+        device: Device,
+        _powered: bool,
+    ) -> List[DeviceMenuItem]:
         audio_source = False
         for uuid in device['UUIDs']:
             if ServiceUUID(uuid).short_uuid in (AUDIO_SOURCE_SVCLASS_ID, AUDIO_SINK_SVCLASS_ID):

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -39,21 +39,27 @@ class Services(ManagerPlugin, MenuItemsProvider):
 
         return target
 
-    def on_request_menu_items(self, manager_menu: ManagerDeviceMenu, device: Device) -> List[DeviceMenuItem]:
+    def on_request_menu_items(
+        self,
+        manager_menu: ManagerDeviceMenu,
+        device: Device,
+        powered: bool,
+    ) -> List[DeviceMenuItem]:
         items: List[DeviceMenuItem] = []
         appl = AppletService()
 
         services = get_services(device)
 
-        connectable_services = [service for service in services if service.connectable]
-        for service in connectable_services:
-            item: Gtk.MenuItem = create_menuitem(service.name, service.icon)
-            if service.description:
-                item.props.tooltip_text = service.description
-            item.connect("activate", lambda _item: manager_menu.connect_service(service.device, service.uuid))
-            items.append(DeviceMenuItem(item, DeviceMenuItem.Group.CONNECT, service.priority))
-            item.props.sensitive = service.available
-            item.show()
+        if powered:
+            connectable_services = [service for service in services if service.connectable]
+            for service in connectable_services:
+                item: Gtk.MenuItem = create_menuitem(service.name, service.icon)
+                if service.description:
+                    item.props.tooltip_text = service.description
+                item.connect("activate", lambda _item: manager_menu.connect_service(service.device, service.uuid))
+                items.append(DeviceMenuItem(item, DeviceMenuItem.Group.CONNECT, service.priority))
+                item.props.sensitive = service.available
+                item.show()
 
         connected_services = [service for service in services if service.connected_instances]
         for service in connected_services:


### PR DESCRIPTION
Toolbar: Disable search and send buttons if the adapter is not powered (unpaired devices should not be present anyway).

Device menu: Do not add the following if not powered:
* Connect items
* Send file
* Send note