### PR TITLE
Remove check_bluetooth_status from blueman-manager

### DIFF
--- a/blueman/gui/manager/ManagerStats.py
+++ b/blueman/gui/manager/ManagerStats.py
@@ -25,8 +25,11 @@ class ManagerStats:
 
         blueman.List.connect("adapter-changed", self.on_adapter_changed)
 
-        assert blueman.List.Adapter is not None
-        self.hci = adapter_path_to_name(blueman.List.Adapter.get_object_path())
+        self.hci = (
+            None
+            if blueman.List.Adapter is None
+            else adapter_path_to_name(blueman.List.Adapter.get_object_path())
+        )
 
         self.time = None
 

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -47,7 +47,6 @@ class PowerManager(AppletPlugin, StatusIconProvider):
 
         self.request_in_progress = False
 
-        self._add_dbus_signal("BluetoothStatusChanged", "b")
         self._add_dbus_method("SetBluetoothStatus", ("b",), "", self.request_power_state)
         self._add_dbus_method("GetBluetoothStatus", (), "b", self.get_bluetooth_status)
 
@@ -164,7 +163,6 @@ class PowerManager(AppletPlugin, StatusIconProvider):
             logging.info(f"Signalling {new_state}")
             self.current_state = new_state
 
-            self._emit_dbus_signal("BluetoothStatusChanged", new_state)
             for plugin in self.parent.Plugins.get_loaded_plugins(PowerStateListener):
                 plugin.on_power_state_changed(self, new_state)
 


### PR DESCRIPTION
The function is completely unreliable regarding its option to turn Bluetooth on and regularly leads to closing the application while doing so (#1119 #2161). Also, the whole system is incosistent as while it avoids starting blueman-manager with Bluetooth powered off, you can absolutely run blueman-manager with Bluetooth powered off e.g. simply by turning it off while it's open (#1707). There is even a menu item for turning Bluetooth off (and back on!) now.

Fun fact: Turning Bluetooth off while blueman-manager is running is actually meant to lead to the same dialog (and should have in 2.0), but #543 broke the signal handling: Since 2.1 `status` is set to a 1-tuple returned by `unpack` instead of a `bool` and the tuple is always `True`ish.

Note: blueman-adapters suffers from the same glitches (unreliable status check when turning Bluetooth on via the dialog, keeps running when Bluetooth gets turned off). That is not handled here.

@infirit: I'm not quite sure if you're in the same boat or rather want to to keep (and fix) the status check, so take this as an RFC.