### PR TITLE
Fix deprecations in tests

### DIFF
--- a/test/bluez/obex/test_imports.py
+++ b/test/bluez/obex/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/bluez/test_imports.py
+++ b/test/bluez/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/gui/applet/test_imports.py
+++ b/test/gui/applet/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/gui/manager/test_imports.py
+++ b/test/gui/manager/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/gui/test_imports.py
+++ b/test/gui/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/main/applet/test_imports.py
+++ b/test/main/applet/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/plugins/services/test_imports.py
+++ b/test/plugins/services/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/plugins/test_imports.py
+++ b/test/plugins/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/services/meta/test_imports.py
+++ b/test/services/meta/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/services/test_imports.py
+++ b/test/services/test_imports.py
@@ -6,7 +6,11 @@ from unittest import TestCase, TestSuite
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 

--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -12,7 +12,11 @@ Gdk.Screen.get_default = lambda: fake_x11_screen
 class TestImports(TestCase):
     def __init__(self, mod_name):
         name = f"test_{mod_name.replace('.', '_')}_import"
-        setattr(self, name, lambda: __import__(mod_name))
+
+        def f():
+            __import__(mod_name)
+
+        setattr(self, name, f)
         super().__init__(name)
 
 


### PR DESCRIPTION
Python 3.11 deprecated returning values from test functions which the lambda does.