### PR TITLE
Use small toolbar size and text beside icons

### DIFF
--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -91,8 +91,7 @@ class ManagerToolbar:
             self.b_remove.props.sensitive = True
             self.b_send.props.sensitive = powered and row["objpush"]
 
-            icon_name = "blueman-untrust-symbolic" if row["trusted"] else "blueman-trust-symbolic"
-            self.b_trust.props.icon_widget = Gtk.Image(icon_name=icon_name, pixel_size=24, visible=True)
+            self.b_trust.props.icon_name = "blueman-untrust-symbolic" if row["trusted"] else "blueman-trust-symbolic"
             self.b_trust.props.label = _("Untrust") if row["trusted"] else _("Trust")
 
     def on_device_propery_changed(self, dev_list: ManagerDeviceList, device: Device, tree_iter: Gtk.TreeIter,

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -63,7 +63,6 @@
             <child>
               <object class="GtkMenuItem" id="item_adapter">
                 <property name="visible">True</property>
-                <property name="sensitive">True</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_Adapter</property>
                 <property name="use-underline">True</property>
@@ -74,7 +73,6 @@
                     <child>
                       <object class="GtkImageMenuItem" id="search_item">
                         <property name="label" translatable="yes">_Search</property>
-                        <property name="visible">False</property>
                         <property name="can-focus">False</property>
                         <property name="use-underline">True</property>
                         <property name="image">im_search</property>
@@ -96,7 +94,6 @@
                     <child>
                       <object class="GtkImageMenuItem" id="prefs_item">
                         <property name="label" translatable="yes">_Preferences</property>
-                        <property name="visible">False</property>
                         <property name="can-focus">False</property>
                         <property name="use-underline">True</property>
                         <property name="image">im_prefs</property>
@@ -112,7 +109,6 @@
                     <child>
                       <object class="GtkImageMenuItem" id="power_item">
                         <property name="label" translatable="yes">Turn Bluetooth _On</property>
-                        <property name="visible">False</property>
                         <property name="can-focus">False</property>
                         <property name="use-underline">True</property>
                         <property name="image">im_power</property>
@@ -309,6 +305,8 @@
           <object class="GtkToolbar" id="toolbar">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="toolbar-style">both-horiz</property>
+            <property name="icon_size">2</property>
             <child>
               <object class="GtkToolButton" id="b_search">
                 <property name="visible">True</property>
@@ -340,6 +338,7 @@
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Create pairing with the device</property>
+                <property name="is-important">True</property>
                 <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Pair</property>
                 <property name="icon-name">blueman-pair-symbolic</property>
               </object>
@@ -354,6 +353,7 @@
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Mark/Unmark this device as trusted</property>
+                <property name="is-important">True</property>
                 <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Trust</property>
                 <property name="icon-name">blueman-trust-symbolic</property>
               </object>
@@ -368,6 +368,7 @@
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Remove this device from the known devices list</property>
+                <property name="is-important">True</property>
                 <property name="label" translatable="yes" comments="translators: toolbar item: keep it as short as possible">Remove</property>
                 <property name="icon-name">list-remove-symbolic</property>
               </object>


### PR DESCRIPTION
![Screenshot from 2023-12-29 09-49-01](https://github.com/blueman-project/blueman/assets/72220889/e9ec5892-47cc-4d00-a772-400cf3fb87c4)
Text can help new users identify actions easily and since there are few toolbar items i don't think space will be a problem with languages like Russian