### PR TITLE
Add bluetooth status icon in the statusbar

### DIFF
--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -582,6 +582,31 @@
                 <property name="position">2</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkSeparator">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage" id="bt_status_icon">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="icon-name">bluetooth-disabled</property>
+                <property name="icon_size">1</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">5</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="left-attach">0</property>


### PR DESCRIPTION
I would have liked to show the state of the adapter and the killswitch. While getting the adapter state is easy, the state of the killswitch is not. So for now get the global state from the applet.

I'll rebase when the PR for the dialog is merged.