### PR TITLE
ConnectionNotifier: Don't crash when there was no prior notification

### DIFF
--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -36,7 +36,7 @@ class ConnectionNotifier(AppletPlugin):
                 Notification(device.display_name, _('Disconnected'), icon_name=device["Icon"]).show()
 
     def _on_battery_update(self, path: str, value: int) -> None:
-        notification = self._notifications[path]
+        notification = self._notifications.get(path, None)
         if notification:
             try:
                 notification.set_message(f"{_('Connected')} {value}%")


### PR DESCRIPTION
I'm baffled why the user in #2304 isn't getting the property change when the device connected. We still need to not crash so let's fix this now.