### PR TITLE
Prepare 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.4.1
+
+### Changes
+
+* Translation updates
+* Handle incompabilities with kded6 running on desktops without StatusNotifierItem support
+
+### Bugs fixed
+
+* Fallback for missing icons
+* Correct Bluetooth state tracking in manager window
+* Sporadic error on battery data (Note that there was a regression in Linux 6.8.2, 6.7.11, 6.6.23 and 6.1.83 that causes it and lots of other trouble)
+* Active state on tray icon
+* Broken markup in tray menu
+
 ## 2.4
 
 ### New features
@@ -39,7 +54,7 @@
 * Make blueman-services a notebook
 * Use the TypedDict as constructor
 
-### Bugs fixes
+### Bugs fixed
 
 * Fix device-selected handlers
 * Fix deprecations in tests

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.61)
 
-AC_INIT([blueman], [2.4], [https://github.com/blueman-project/blueman/issues])
+AC_INIT([blueman], [2.4.1], [https://github.com/blueman-project/blueman/issues])
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([1.16.3 foreign dist-xz])

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'blueman', 'c',
-    version: '2.4',
+    version: '2.4.1',
     license: 'GPL3',
     meson_version: '>=0.56.0',
     default_options: 'b_lundef=false'


### PR DESCRIPTION
I plan to a add a note on icon themes to the release description on GitHub. Something like:

Note to maintainers: We found that the Adwaita Icon Theme dropped most non-symbolic icons in version 44, so that it can no longer be considered a generic fallback for GTK. blueman with just Adwaita Icon Theme will show a lot of missing icons. We are still puzzled by this change and try to figure out what to do. You can jump in at #2312. In the meantime, make sure that your packages depend on proper icons themes.