### PR TITLE
Handle incomplete StatusNotifierWatchers

### DIFF
--- a/blueman/main/indicators/StatusNotifierItem.py
+++ b/blueman/main/indicators/StatusNotifierItem.py
@@ -154,8 +154,8 @@ class StatusNotifierItem(IndicatorInterface):
                 "RegisterStatusNotifierItem", GLib.Variant("(s)", ("/org/blueman/sni",)),
                 None, Gio.DBusCallFlags.NONE, -1)
             watcher_expected = True
-        except GLib.Error:
-            watcher_expected = False
+        except GLib.Error as e:
+            watcher_expected = not e.message.startswith("org.freedesktop.DBusError.ServiceUnknown")
             raise IndicatorNotAvailable
 
     def set_icon(self, icon_name: str) -> None:


### PR DESCRIPTION
kded6 provides an `org.kde.StatusNotifierWatcher` service without its usual `/StatusNotifierWatcher` object if Plasma Workspace's StatusNotifierWatcher module is registered but not loaded (https://invent.kde.org/plasma/plasma-workspace/-/merge_requests/3301). We thus cannot just assume the whole service to be unavailable if the registration fails as we restart the tray application when the name appears.

This is a problem if the Plasma Workspace is around especially on i3 where no other application registers `org.kde.StatusNotifierWatcher`.

Closes #2311