### PR TITLE
Only show a singly battery notifcation

### DIFF
--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -36,7 +36,7 @@ class ConnectionNotifier(AppletPlugin):
                 Notification(device.display_name, _('Disconnected'), icon_name=device["Icon"]).show()
 
     def _on_battery_update(self, path: str, value: int) -> None:
-        notification = self._notifications.get(path, None)
+        notification = self._notifications.pop(path, None)
         if notification:
             try:
                 notification.set_message(f"{_('Connected')} {value}%")


### PR DESCRIPTION
From feedback in #2317 it became pretty clear that battery data is a mess with devices providing levels like full, medium, low and devices providing fine-grained percent values, flapping values etc. and we do not want to go into power management applet business, so we only show a single battery notification on connection (when the battery interface shows up or - if the interface is already present when the device connects - when the existing interface sends its first property update) and drop the reference to the connection notification to update so that further values do not lead to a notification. (In case people will ask for those notifications we might add them as a separate plugin that's disabled by default.)

Due to the great demand, I plan to backport this for 2.4.2, even though it's technically a regression.

Closes #2317