### PR TITLE
Fix audio profile menu item priorities

### DIFF
--- a/blueman/plugins/applet/Menu.py
+++ b/blueman/plugins/applet/Menu.py
@@ -133,6 +133,9 @@ class Menu(AppletPlugin):
         if isinstance(priority, int):
             priority = (priority, 0)
 
+        assert priority[0] < 256
+        assert priority[1] < 256
+
         item = MenuItem(self, owner, priority, text, markup, icon_name, tooltip, callback, submenu_function, visible,
                         sensitive)
         self.__menuitems[item.priority] = item

--- a/blueman/plugins/applet/PulseAudioProfile.py
+++ b/blueman/plugins/applet/PulseAudioProfile.py
@@ -79,7 +79,8 @@ class AudioProfiles(AppletPlugin):
             return items
 
         info = self._devices[device['Address']]
-        menu = self._menu.add(self, (42, info["index"]), _("Audio Profiles for %s") % device.display_name,
+        idx = max((item.priority[1] for item in self._device_menus.values()), default=-1) + 1
+        menu = self._menu.add(self, (42, idx), _("Audio Profiles for %s") % device.display_name,
                               icon_name="audio-card-symbolic",
                               submenu_function=lambda: _generate_profiles_menu(info))
         self._device_menus[device['Address']] = menu


### PR DESCRIPTION
We build a (32 bit) ID for the menu item from its priority values, using the sub priority as the lower 8 bits. Pulseaudio card indexes are theoretically 32 bit and PipeWire re-assignes them with large gaps on re-connect so that it provides high 3-digit numbers in practice that do not fit the 8 bits.

Closes #2331