### PR TITLE
Rename recent connections header

### DIFF
--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -185,7 +185,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
         menu: "Menu" = self.parent.Plugins.Menu
         self._mitems: List[MenuItem] = []
         menu.unregister(self)
-        menu.add(self, 52, text=_("Recent _Connections"), icon_name="document-open-recent-symbolic",
+        menu.add(self, 52, text=_("Reconnect to…"), icon_name="document-open-recent-symbolic",
                  sensitive=False, callback=lambda: None)
         for (idx, item) in enumerate(self.__menuitems):
             self._mitems.append(menu.add(self, (53, idx), **item))


### PR DESCRIPTION
I hope this makes things clearer and avoids confusion due to the change from 2.3 to 2.4.

Closes #2328