### PR TITLE
Only show a singly battery notifcation

### DIFF
--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -36,7 +36,7 @@ class ConnectionNotifier(AppletPlugin):
                 Notification(device.display_name, _('Disconnected'), icon_name=device["Icon"]).show()
 
     def _on_battery_update(self, path: str, value: int) -> None:
-        notification = self._notifications.get(path, None)
+        notification = self._notifications.pop(path, None)
         if notification:
             try:
                 notification.set_message(f"{_('Connected')} {value}%")


### PR DESCRIPTION
Backport of #2362 due to the great demand seen in #2317. This is technically a regression, but the current behavior seems unacceptable in many cases, so let's pretend that we never intentionally added those additional notifications.

Closes #2317