### PR TITLE
meson.build: use internal cython

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,8 @@
 project(
-    'blueman', 'c',
+    'blueman', 'c', 'cython',
     version: '2.4',
     license: 'GPL3',
-    meson_version: '>=0.56.0',
+    meson_version: '>=0.63.0',
     default_options: 'b_lundef=false'
 )
 

--- a/module/meson.build
+++ b/module/meson.build
@@ -1,10 +1,8 @@
 cython = find_program('cython', 'cython3' ,required: true)
 
-blueman_c = custom_target(
+blueman_c = pyinstall.extension_module(
     'blueman_c',
-    output: '_blueman.c',
-    input: '_blueman.pyx',
-    command: [cython, '--output-file', '@OUTPUT@', '@INPUT@'])
+    '_blueman.pyx')
 
 sources = [
     blueman_c,


### PR DESCRIPTION
This prevents the buildpath from being built into _blueman.so and thus fixes reproducibility