### PR TITLE
Initial meson devenv

### DIFF
--- a/blueman/Constants.py.in
+++ b/blueman/Constants.py.in
@@ -17,8 +17,7 @@ RFCOMM_WATCHER_PATH = "@LIBEXECDIR@/blueman-rfcomm-watcher"
 import os
 
 if 'BLUEMAN_SOURCE' in os.environ:
-    _dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    BIN_DIR = os.path.join(_dirname, 'apps')
-    ICON_PATH = os.path.join(_dirname, 'data', 'icons')
-    PIXMAP_PATH = os.path.join(_dirname, 'data', 'icons', 'pixmaps')
-    UI_PATH = os.path.join(_dirname, 'data', 'ui')
+    BIN_DIR = os.environ.get('BINDIR', "meson devenv failed")
+    ICON_PATH = os.environ.get('ICON_PATH', "meson devenv failed")
+    PIXMAP_PATH = os.environ.get('PIXMAP_PATH', "meson devenv failed")
+    UI_PATH = os.environ.get('UI_PATH', "meson devenv failed")

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'blueman', 'c',
     version: '2.4',
     license: 'GPL3',
-    meson_version: '>=0.56.0',
+    meson_version: '>=0.58.0',
     default_options: 'b_lundef=false'
 )
 
@@ -52,6 +52,15 @@ conf_data.set('dhconfig', get_option('dhcp-config-path'))
 conf_data.set('POLKIT', have_polkit)
 conf_data.set('GETTEXT_PACKAGE', package_name)
 conf_data.set('PYTHON', pyinstall.full_path())
+
+#Setup devenv
+PYTHON_PATHS=[join_paths(meson.current_source_dir(), 'blueman'), join_paths(meson.current_build_dir(), 'module')]
+meson.add_devenv({'BLUEMAN_SOURCE': '1'})
+meson.add_devenv({'PYTHONPATH': ':'.join(PYTHON_PATHS)})
+meson.add_devenv({'BINDIR': meson.current_build_dir()})
+meson.add_devenv({'ICON_PATH': join_paths(meson.current_source_dir(), 'data', 'icons')})
+meson.add_devenv({'PIXMAP_PATH': join_paths(meson.current_source_dir(), 'data', 'icons', 'pixmaps')})
+meson.add_devenv({'UI_PATH': join_paths(meson.current_source_dir(), 'data', 'ui')})
 
 # Check for build dependencies
 pythonlib = pyinstall.dependency()


### PR DESCRIPTION
If the build dir is `build` use `meson devenv -C build`. Seems to work ok from the command line. 

Not sure how this can be integrated into pycharm. The env can be dumped with `meson devenv -C build --dump` in several formats, maybe it can be used in pycharm somehow.

edit: When ubuntu latest moves to >=0.62 start making use of the method keyword.