### PR TITLE
Set Toolbar buttons half the opacity when not sensitive

### DIFF
--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -94,8 +94,7 @@ class ManagerToolbar:
             self.b_send.props.sensitive = powered and row["objpush"]
             self.b_bluetooth_status.props.sensitive = True
 
-            icon_name = "blueman-untrust-symbolic" if row["trusted"] else "blueman-trust-symbolic"
-            self.b_trust.props.icon_widget = Gtk.Image(icon_name=icon_name, pixel_size=24, visible=True)
+            self.b_trust.props.icon_name = "blueman-untrust-symbolic" if row["trusted"] else "blueman-trust-symbolic"
             self.b_trust.props.label = _("Untrust") if row["trusted"] else _("Trust")
 
     def on_device_propery_changed(self, dev_list: ManagerDeviceList, device: Device, tree_iter: Gtk.TreeIter,

--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -80,20 +80,24 @@ class ManagerToolbar:
         self.b_search.props.sensitive = powered and not (adapter and adapter["Discovering"])
 
         tree_iter = self.blueman.List.selected()
+        opacity = 0.5
         if tree_iter is None:
             self.b_bond.props.sensitive = False
+            self.b_bond.props.opacity = opacity
             self.b_trust.props.sensitive = False
             self.b_remove.props.sensitive = False
             self.b_send.props.sensitive = False
             self.b_bluetooth_status.props.sensitive = False
+            self.b_send.props.opacity = opacity
         else:
             row = self.blueman.List.get(tree_iter, "paired", "trusted", "objpush")
             self.b_bond.props.sensitive = powered and not row["paired"]
+            self.b_bond.props.opacity = 1.0 if powered and not row["paired"] else opacity
             self.b_trust.props.sensitive = True
             self.b_remove.props.sensitive = True
             self.b_send.props.sensitive = powered and row["objpush"]
             self.b_bluetooth_status.props.sensitive = True
-
+            self.b_send.props.opacity = 1.0 if powered and row["objpush"] else opacity
             self.b_trust.props.icon_name = "blueman-untrust-symbolic" if row["trusted"] else "blueman-trust-symbolic"
             self.b_trust.props.label = _("Untrust") if row["trusted"] else _("Trust")
 

--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -33,7 +33,6 @@ class ManagerToolbar:
 
         self.b_trust = blueman.builder.get_widget("b_trust", Gtk.ToolButton)
         self.b_trust.connect("clicked", self.on_action, self.blueman.toggle_trust)
-        self.b_trust.set_homogeneous(False)
 
         self.b_trust.props.label = _("Untrust")
         (size, nsize) = Gtk.Widget.get_preferred_size(self.b_trust)
@@ -48,7 +47,6 @@ class ManagerToolbar:
         self.b_send = blueman.builder.get_widget("b_send", Gtk.ToolButton)
         self.b_send.props.sensitive = False
         self.b_send.connect("clicked", self.on_action, self.blueman.send)
-        self.b_send.set_homogeneous(False)
 
         self.b_bluetooth_status = blueman.builder.get_widget("sw_bluetooth_status", Gtk.Switch)
 

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -298,7 +298,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="homogeneous">True</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -322,7 +322,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="homogeneous">True</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -336,7 +336,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="homogeneous">True</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -350,7 +350,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="homogeneous">True</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -360,7 +360,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="homogeneous">True</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -374,7 +374,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="homogeneous">True</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <child>
@@ -430,7 +430,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="homogeneous">True</property>
+                <property name="homogeneous">False</property>
               </packing>
             </child>
             <style>

--- a/stubs/gi/repository/Gtk.pyi
+++ b/stubs/gi/repository/Gtk.pyi
@@ -9572,6 +9572,7 @@ class ToolButton(ToolItem, Actionable):
     parent: ToolItem
 
     class _Props(ToolItem._Props):
+        icon_name: typing.Optional[str]
         icon_widget: typing.Optional[Widget]
         label: typing.Optional[str]
 
@@ -9579,6 +9580,7 @@ class ToolButton(ToolItem, Actionable):
 
     def __init__(self,
         *,
+        icon_name: typing.Optional[str],
         icon_widget: typing.Optional[Widget],
         label: typing.Optional[str] = None,
         # Container


### PR DESCRIPTION
This is especially noticeable when people try to use the Pair button with only keyboard as the button is skipped/not selectable when insensitive. PR is mainly to get feedback if this is what we want. One downside is that when text is slightly less readable as can be seen with the Send File button. I can also only do this for the Pair button.

This is how it looks like now:
![image](https://github.com/user-attachments/assets/83a2ce3f-0ff8-4c78-9fc6-babf761cc738)

Before:
![image](https://github.com/user-attachments/assets/55e5c56f-f2b8-4044-9fe7-659544749c3a)
