### PR TITLE
meson: Do not emit absolute path when S != B

### DIFF
--- a/module/meson.build
+++ b/module/meson.build
@@ -1,10 +1,12 @@
 cython = find_program('cython', 'cython3' ,required: true)
 
+cython_outfile = join_paths(meson.project_build_root(), '@OUTPUT@')
+cython_infile = join_paths(meson.project_build_root(), '@INPUT@')
 blueman_c = custom_target(
     'blueman_c',
     output: '_blueman.c',
     input: '_blueman.pyx',
-    command: [cython, '-w', meson.source_root(), '--output-file', join_paths(meson.build_root(), '@OUTPUT@'), join_paths(meson.build_root(), '@INPUT@')])
+    command: [cython, '-w', meson.project_source_root(), '--output-file', cython_outfile, cython_infile])
 
 sources = [
     blueman_c,

--- a/module/meson.build
+++ b/module/meson.build
@@ -4,7 +4,7 @@ blueman_c = custom_target(
     'blueman_c',
     output: '_blueman.c',
     input: '_blueman.pyx',
-    command: [cython, '--output-file', '@OUTPUT@', '@INPUT@'])
+    command: [cython, '-w', meson.source_root(), '--output-file', join_paths(meson.build_root(), '@OUTPUT@'), join_paths(meson.build_root(), '@INPUT@')])
 
 sources = [
     blueman_c,


### PR DESCRIPTION
build systems like OE build outside sourcetree in such cases it works ok but cython resolves the input file to absolute path and that gets emitted into genetate _blueman.c as module name, renders the build non-reproducible, wish cython had a better way to handle this but there is not, therefore tweak the meson build rule to account for specifying workdir to cython which will search the inputs correctly, and use meson's build_root to emit the output into build dir. This ensures that it becomes independent of source or build directories and cython does not generate the absolute paths into generate C code.

See cython discussion on [1]

[1] https://github.com/cython/cython/issues/5949