### PR TITLE
Fix Autoconnect and annotate object paths and bluetooth addresses

### DIFF
--- a/blueman/bluemantyping.py
+++ b/blueman/bluemantyping.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Union, TYPE_CHECKING
+from typing import Dict, Tuple, Union, TYPE_CHECKING, NewType
 from gi.repository import GObject
 
 if TYPE_CHECKING:
@@ -11,3 +11,6 @@ if TYPE_CHECKING:
 # https://github.com/GNOME/pygobject/blob/ac576400ecd554879c906791e6638d64bb8bcc2a/gi/pygi-type.c#L498
 # (We shield the possibility to provide a str to avoid errors)
 GSignals = Dict[str, Tuple[GObject.SignalFlags, None, Tuple[Union[None, type, GObject.GType, "_HasGType"], ...]]]
+
+ObjectPath = NewType("ObjectPath", str)
+BtAddress = NewType("BtAddress", str)

--- a/blueman/bluez/Adapter.py
+++ b/blueman/bluez/Adapter.py
@@ -1,4 +1,5 @@
 from typing import Optional, Callable
+from blueman.bluemantyping import ObjectPath
 
 from gi.repository import GLib
 
@@ -11,7 +12,7 @@ from blueman.bluez.errors import BluezDBusException
 class Adapter(Base):
     _interface_name = 'org.bluez.Adapter1'
 
-    def __init__(self, obj_path: str):
+    def __init__(self, obj_path: ObjectPath):
         super().__init__(obj_path=obj_path)
 
     def start_discovery(self, error_handler: Optional[Callable[[BluezDBusException], None]] = None) -> None:

--- a/blueman/bluez/AgentManager.py
+++ b/blueman/bluez/AgentManager.py
@@ -1,10 +1,12 @@
+from blueman.bluemantyping import ObjectPath
+
 from blueman.bluez.Base import Base
 from gi.repository import GLib
 
 
 class AgentManager(Base):
     _interface_name = 'org.bluez.AgentManager1'
-    _obj_path = '/org/bluez'
+    _obj_path = ObjectPath('/org/bluez')
 
     def __init__(self) -> None:
         super().__init__(obj_path=self._obj_path)

--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -1,11 +1,10 @@
 from typing import List, Callable, Optional, Any, Union, Dict
+from blueman.bluemantyping import GSignals, ObjectPath
 
 from gi.repository import Gio, GLib, GObject
 from gi.types import GObjectMeta
 from blueman.bluez.errors import parse_dbus_error, BluezDBusException
 import logging
-
-from blueman.bluemantyping import GSignals
 
 
 class BaseMeta(GObjectMeta):
@@ -41,7 +40,7 @@ class Base(GObject.Object, metaclass=BaseMeta):
     connect_signal = GObject.GObject.connect
     disconnect_signal = GObject.GObject.disconnect
 
-    def __init__(self, *, obj_path: str):
+    def __init__(self, *, obj_path: ObjectPath):
         super().__init__()
 
         self.__proxy = Gio.DBusProxy.new_for_bus_sync(
@@ -122,8 +121,8 @@ class Base(GObject.Object, metaclass=BaseMeta):
                           GLib.MAXINT,
                           None)
 
-    def get_object_path(self) -> str:
-        return self.__proxy.get_object_path()
+    def get_object_path(self) -> ObjectPath:
+        return ObjectPath(self.__proxy.get_object_path())
 
     def get_properties(self) -> Dict[str, Any]:
         param = GLib.Variant('(s)', (self._interface_name,))

--- a/blueman/bluez/Device.py
+++ b/blueman/bluez/Device.py
@@ -1,4 +1,5 @@
 from typing import Optional, Callable
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.Base import Base
 from blueman.bluez.AnyBase import AnyBase
@@ -8,7 +9,7 @@ from blueman.bluez.errors import BluezDBusException
 class Device(Base):
     _interface_name = 'org.bluez.Device1'
 
-    def __init__(self, obj_path: str):
+    def __init__(self, obj_path: ObjectPath):
         super().__init__(obj_path=obj_path)
 
     def pair(

--- a/blueman/bluez/Network.py
+++ b/blueman/bluez/Network.py
@@ -1,4 +1,5 @@
 from typing import Optional, Callable
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.Base import Base
 from blueman.bluez.AnyBase import AnyBase
@@ -10,7 +11,7 @@ from blueman.bluez.errors import BluezDBusException
 class Network(Base):
     _interface_name = 'org.bluez.Network1'
 
-    def __init__(self, obj_path: str):
+    def __init__(self, obj_path: ObjectPath):
         super().__init__(obj_path=obj_path)
 
     def connect(  # type: ignore

--- a/blueman/bluez/NetworkServer.py
+++ b/blueman/bluez/NetworkServer.py
@@ -1,3 +1,5 @@
+from blueman.bluemantyping import ObjectPath
+
 from blueman.bluez.Base import Base
 from gi.repository import GLib
 
@@ -5,7 +7,7 @@ from gi.repository import GLib
 class NetworkServer(Base):
     _interface_name = 'org.bluez.NetworkServer1'
 
-    def __init__(self, obj_path: str):
+    def __init__(self, obj_path: ObjectPath):
         super().__init__(obj_path=obj_path)
 
     def register(self, uuid: str, bridge: str) -> None:

--- a/blueman/bluez/obex/AgentManager.py
+++ b/blueman/bluez/obex/AgentManager.py
@@ -1,3 +1,4 @@
+from blueman.bluemantyping import ObjectPath
 import logging
 
 from blueman.bluez.errors import BluezDBusException
@@ -7,7 +8,7 @@ from gi.repository import GLib
 
 class AgentManager(Base):
     _interface_name = 'org.bluez.obex.AgentManager1'
-    _obj_path = '/org/bluez/obex'
+    _obj_path: ObjectPath = ObjectPath('/org/bluez/obex')
 
     def __init__(self) -> None:
         super().__init__(obj_path=self._obj_path)
@@ -22,7 +23,7 @@ class AgentManager(Base):
         param = GLib.Variant('(o)', (agent_path,))
         self._call('RegisterAgent', param, reply_handler=on_registered, error_handler=on_register_failed)
 
-    def unregister_agent(self, agent_path: str) -> None:
+    def unregister_agent(self, agent_path: ObjectPath) -> None:
         def on_unregistered() -> None:
             logging.info(agent_path)
 

--- a/blueman/bluez/obex/Client.py
+++ b/blueman/bluez/obex/Client.py
@@ -4,7 +4,7 @@ from blueman.bluez.errors import BluezDBusException
 from blueman.bluez.obex.Base import Base
 from gi.repository import GObject, GLib
 
-from blueman.bluemantyping import GSignals
+from blueman.bluemantyping import GSignals, ObjectPath, BtAddress
 
 
 class Client(Base):
@@ -13,13 +13,14 @@ class Client(Base):
     }
 
     _interface_name = 'org.bluez.obex.Client1'
-    _obj_path = '/org/bluez/obex'
+    _obj_path: ObjectPath = ObjectPath('/org/bluez/obex')
 
     def __init__(self) -> None:
         super().__init__(obj_path=self._obj_path)
 
-    def create_session(self, dest_addr: str, source_addr: str = "00:00:00:00:00:00", pattern: str = "opp") -> None:
-        def on_session_created(session_path: str) -> None:
+    def create_session(self, dest_addr: BtAddress, source_addr: BtAddress = BtAddress("00:00:00:00:00:00"),
+                       pattern: str = "opp") -> None:
+        def on_session_created(session_path: ObjectPath) -> None:
             logging.info(f"{dest_addr} {source_addr} {pattern} {session_path}")
 
         def on_session_failed(error: BluezDBusException) -> None:
@@ -31,7 +32,7 @@ class Client(Base):
         param = GLib.Variant('(sa{sv})', (dest_addr, {"Source": v_source_addr, "Target": v_pattern}))
         self._call('CreateSession', param, reply_handler=on_session_created, error_handler=on_session_failed)
 
-    def remove_session(self, session_path: str) -> None:
+    def remove_session(self, session_path: ObjectPath) -> None:
         def on_session_removed() -> None:
             logging.info(session_path)
 

--- a/blueman/bluez/obex/Manager.py
+++ b/blueman/bluez/obex/Manager.py
@@ -1,6 +1,7 @@
 import logging
 import weakref
 from typing import Dict, Callable, List, Tuple
+from blueman.bluemantyping import ObjectPath
 
 from gi.repository import GObject, Gio
 
@@ -48,7 +49,7 @@ class Manager(GObject.GObject, metaclass=SingletonGObjectMeta):
 
         if transfer_proxy:
             logging.info(object_path)
-            transfer = Transfer(obj_path=object_path)
+            transfer = Transfer(obj_path=ObjectPath(object_path))
             chandlerid = transfer.connect_signal('completed', self._on_transfer_completed, True)
             ehandlerid = transfer.connect_signal('error', self._on_transfer_completed, False)
             self.__transfers[object_path] = (transfer, (chandlerid, ehandlerid))

--- a/blueman/bluez/obex/ObjectPush.py
+++ b/blueman/bluez/obex/ObjectPush.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Dict
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.errors import BluezDBusException
 from blueman.bluez.obex.Base import Base
@@ -16,11 +17,11 @@ class ObjectPush(Base):
 
     _interface_name = 'org.bluez.obex.ObjectPush1'
 
-    def __init__(self, obj_path: str):
+    def __init__(self, obj_path: ObjectPath):
         super().__init__(obj_path=obj_path)
 
     def send_file(self, file_path: str) -> None:
-        def on_transfer_started(transfer_path: str, props: Dict[str, str]) -> None:
+        def on_transfer_started(transfer_path: ObjectPath, props: Dict[str, str]) -> None:
             logging.info(" ".join((self.get_object_path(), file_path, transfer_path)))
             self.emit('transfer-started', transfer_path, props['Filename'])
 
@@ -31,6 +32,6 @@ class ObjectPush(Base):
         param = GLib.Variant('(s)', (file_path,))
         self._call('SendFile', param, reply_handler=on_transfer_started, error_handler=on_transfer_error)
 
-    def get_session_path(self) -> str:
-        path: str = self.get_object_path()
+    def get_session_path(self) -> ObjectPath:
+        path: ObjectPath = self.get_object_path()
         return path

--- a/blueman/bluez/obex/Session.py
+++ b/blueman/bluez/obex/Session.py
@@ -1,15 +1,16 @@
+from blueman.bluemantyping import ObjectPath, BtAddress
 from blueman.bluez.obex.Base import Base
 
 
 class Session(Base):
     _interface_name = 'org.bluez.obex.Session1'
 
-    def __init__(self, obj_path: str):
+    def __init__(self, obj_path: ObjectPath):
         super().__init__(obj_path=obj_path)
 
     @property
-    def address(self) -> str:
-        dest: str = self.get('Destination')
+    def address(self) -> BtAddress:
+        dest: BtAddress = self.get('Destination')
         return dest
 
     @property

--- a/blueman/bluez/obex/Transfer.py
+++ b/blueman/bluez/obex/Transfer.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List, Optional
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.obex.Base import Base
 from gi.repository import GObject, Gio, GLib
@@ -16,7 +17,7 @@ class Transfer(Base):
 
     _interface_name = 'org.bluez.obex.Transfer1'
 
-    def __init__(self, obj_path: str):
+    def __init__(self, obj_path: ObjectPath):
         super().__init__(obj_path=obj_path)
 
     @property
@@ -30,8 +31,8 @@ class Transfer(Base):
         return name
 
     @property
-    def session(self) -> str:
-        session: str = self.get("Session")
+    def session(self) -> ObjectPath:
+        session: ObjectPath = self.get("Session")
         return session
 
     @property

--- a/blueman/config/AutoConnectConfig.py
+++ b/blueman/config/AutoConnectConfig.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+from blueman.bluemantyping import BtAddress
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
@@ -9,7 +10,7 @@ class AutoConnectConfig(Gio.Settings):
     def __init__(self) -> None:
         super().__init__(schema_id="org.blueman.plugins.autoconnect")
 
-    def bind_to_menuitem(self, item: Gtk.CheckMenuItem, data: Tuple[str, str]) -> None:
+    def bind_to_menuitem(self, item: Gtk.CheckMenuItem, data: Tuple[BtAddress, str]) -> None:
         def switch(active: bool) -> None:
             services = set(self["services"])
             if active:

--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -15,7 +15,7 @@ from gi.repository import GLib
 
 import gi
 
-from blueman.bluemantyping import GSignals
+from blueman.bluemantyping import GSignals, ObjectPath
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
@@ -64,7 +64,7 @@ class DeviceList(GenericList):
         self._anydevhandler = self.any_device.connect_signal("property-changed", self._on_device_property_changed)
 
         self.__discovery_time: float = 0
-        self.__adapter_path: Optional[str] = None
+        self.__adapter_path: Optional[ObjectPath] = None
         self.Adapter: Optional[Adapter] = None
         self.discovering = False
 
@@ -97,7 +97,7 @@ class DeviceList(GenericList):
             self.manager.disconnect(handler)
         super().destroy()
 
-    def __on_manager_signal(self, _manager: Manager, path: str, signal_name: str) -> None:
+    def __on_manager_signal(self, _manager: Manager, path: ObjectPath, signal_name: str) -> None:
         if signal_name == 'adapter-removed':
             self.emit("adapter-removed", path)
             if path == self.__adapter_path:
@@ -125,7 +125,7 @@ class DeviceList(GenericList):
             dev = row["device"]
             self.emit("device-selected", dev, tree_iter)
 
-    def _on_property_changed(self, _adapter: AnyAdapter, key: str, value: object, path: str) -> None:
+    def _on_property_changed(self, _adapter: AnyAdapter, key: str, value: object, path: ObjectPath) -> None:
         if not self.Adapter or self.Adapter.get_object_path() != path:
             return
 
@@ -134,7 +134,7 @@ class DeviceList(GenericList):
 
         self.emit("adapter-property-changed", self.Adapter, (key, value))
 
-    def _on_device_property_changed(self, _device: AnyDevice, key: str, value: object, path: str) -> None:
+    def _on_device_property_changed(self, _device: AnyDevice, key: str, value: object, path: ObjectPath) -> None:
         tree_iter = self.find_device_by_path(path)
 
         if tree_iter is not None:
@@ -158,10 +158,10 @@ class DeviceList(GenericList):
         pass
 
     # called when device needs to be added to the list
-    def device_add_event(self, object_path: str) -> None:
+    def device_add_event(self, object_path: ObjectPath) -> None:
         self.add_device(object_path)
 
-    def device_remove_event(self, object_path: str) -> None:
+    def device_remove_event(self, object_path: ObjectPath) -> None:
         logging.debug(object_path)
         tree_iter = self.find_device_by_path(object_path)
         if tree_iter is None:
@@ -220,7 +220,7 @@ class DeviceList(GenericList):
         self.emit("discovery-progress", progress)
         return True
 
-    def add_device(self, object_path: str) -> None:
+    def add_device(self, object_path: ObjectPath) -> None:
         device = Device(obj_path=object_path)
         # device belongs to another adapter
         if not self.Adapter or not device['Adapter'] == self.Adapter.get_object_path():
@@ -261,7 +261,7 @@ class DeviceList(GenericList):
         else:
             return True
 
-    def get_adapter_path(self) -> Optional[str]:
+    def get_adapter_path(self) -> Optional[ObjectPath]:
         return self.__adapter_path if self.is_valid_adapter() else None
 
     def stop_discovery(self) -> None:
@@ -288,7 +288,7 @@ class DeviceList(GenericList):
 
         self.path_to_row = {}
 
-    def find_device_by_path(self, object_path: str) -> Optional[Gtk.TreeIter]:
+    def find_device_by_path(self, object_path: ObjectPath) -> Optional[Gtk.TreeIter]:
         row = self.path_to_row.get(object_path, None)
         if row is None:
             return row

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -4,6 +4,7 @@ from gettext import gettext as _
 from operator import attrgetter
 from typing import Dict, List, Tuple, Optional, TYPE_CHECKING, Union, Iterable
 
+from blueman.bluemantyping import ObjectPath
 from blueman.Functions import create_menuitem, e_
 from blueman.bluez.Adapter import Adapter
 from blueman.bluez.Network import AnyNetwork
@@ -58,7 +59,7 @@ class MenuItemsProvider:
 
 
 class ManagerDeviceMenu(Gtk.Menu):
-    __ops__: Dict[str, str] = {}
+    __ops__: Dict[ObjectPath, str] = {}
     __instances__: List["ManagerDeviceMenu"] = []
 
     SelectedDevice: Device
@@ -334,7 +335,7 @@ class ManagerDeviceMenu(Gtk.Menu):
 
             if row["connected"] or generic_autoconnect:
                 item = Gtk.CheckMenuItem(label=generic_service.name)
-                config.bind_to_menuitem(item, (object_path, str(generic_service)))
+                config.bind_to_menuitem(item, (str(object_path), str(generic_service)))
                 item.show()
                 self.append(item)
 

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -3,6 +3,7 @@ from enum import Enum, auto
 from gettext import gettext as _
 from operator import attrgetter
 from typing import Dict, List, Tuple, Optional, TYPE_CHECKING, Union, Iterable
+from blueman.bluemantyping import BtAddress
 
 from blueman.bluemantyping import ObjectPath
 from blueman.Functions import create_menuitem, e_
@@ -328,6 +329,7 @@ class ManagerDeviceMenu(Gtk.Menu):
         config = AutoConnectConfig()
         generic_service = ServiceUUID("00000000-0000-0000-0000-000000000000")
         object_path = self.SelectedDevice.get_object_path()
+        btaddress: BtAddress = self.SelectedDevice["Address"]
         generic_autoconnect = (object_path, str(generic_service)) in set(config["services"])
 
         if row["connected"] or generic_autoconnect or autoconnect_items:
@@ -335,7 +337,7 @@ class ManagerDeviceMenu(Gtk.Menu):
 
             if row["connected"] or generic_autoconnect:
                 item = Gtk.CheckMenuItem(label=generic_service.name)
-                config.bind_to_menuitem(item, (str(object_path), str(generic_service)))
+                config.bind_to_menuitem(item, (btaddress, str(generic_service)))
                 item.show()
                 self.append(item)
 

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 import logging
 from typing import Dict, Tuple, TYPE_CHECKING, Any, Optional, Sequence
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.Adapter import Adapter
 from blueman.bluez.Device import Device
@@ -172,7 +173,7 @@ class ManagerMenu:
                 self.blueman.Config["last-adapter"] = adapter_path_to_name(adapter_path)
                 self.blueman.List.set_adapter(adapter_path)
 
-    def on_adapter_added(self, _manager: Optional[Manager], adapter_path: str) -> None:
+    def on_adapter_added(self, _manager: Optional[Manager], adapter_path: ObjectPath) -> None:
         adapter = Adapter(obj_path=adapter_path)
         menu = self.item_adapter.get_submenu()
         assert isinstance(menu, Gtk.Menu)

--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 import logging
 from typing import TYPE_CHECKING, Callable, Tuple, Optional
+from blueman.bluemantyping import ObjectPath
 
 import gi
 
@@ -62,7 +63,7 @@ class ManagerToolbar:
         if key == "Discovering" or key == "Powered":
             self._update_buttons(adapter)
 
-    def on_adapter_changed(self, _lst: ManagerDeviceList, adapter_path: Optional[str]) -> None:
+    def on_adapter_changed(self, _lst: ManagerDeviceList, adapter_path: Optional[ObjectPath]) -> None:
         logging.debug(f"toolbar adapter {adapter_path}")
         self._update_buttons(None if adapter_path is None else Adapter(obj_path=adapter_path))
 

--- a/blueman/main/Adapter.py
+++ b/blueman/main/Adapter.py
@@ -4,6 +4,7 @@ import logging
 import gettext
 import signal
 from typing import Dict, TypedDict, Optional, Any
+from blueman.bluemantyping import ObjectPath
 
 from blueman.Functions import *
 from blueman.bluez.Manager import Manager
@@ -105,7 +106,7 @@ class BluemanAdapters(Gtk.Application):
         Gtk.Application.do_startup(self)
         self.set_accels_for_action("app.quit", ["<Ctrl>w", "<Ctrl>q", "Escape"])
 
-    def on_property_changed(self, _adapter: Adapter, name: str, value: Any, path: str) -> None:
+    def on_property_changed(self, _adapter: Adapter, name: str, value: Any, path: ObjectPath) -> None:
         hci_dev = os.path.basename(path)
         if name == "Discoverable" and value == 0:
             self.tabs[hci_dev]["hidden_radio"].set_active(True)
@@ -113,7 +114,7 @@ class BluemanAdapters(Gtk.Application):
             self.tabs[hci_dev]["label"].set_text(f"{value} ({hci_dev})")
             self.tabs[hci_dev]["name_entry"].set_text(value)
 
-    def on_adapter_added(self, _manager: Manager, adapter_path: str) -> None:
+    def on_adapter_added(self, _manager: Manager, adapter_path: ObjectPath) -> None:
         hci_dev = os.path.basename(adapter_path)
         if hci_dev not in self._adapters:
             self._adapters[hci_dev] = Adapter(obj_path=adapter_path)

--- a/blueman/main/Applet.py
+++ b/blueman/main/Applet.py
@@ -5,6 +5,7 @@ from gi.repository import Gio, GLib, Gtk
 import logging
 import signal
 from typing import Any, cast
+from blueman.bluemantyping import ObjectPath
 
 from blueman.Functions import *
 from blueman.bluez.Manager import Manager
@@ -86,30 +87,30 @@ class BluemanApplet(Gtk.Application):
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
             plugin.on_manager_state_changed(self.manager_state)
 
-    def _on_adapter_property_changed(self, _adapter: AnyAdapter, key: str, value: Any, path: str) -> None:
+    def _on_adapter_property_changed(self, _adapter: AnyAdapter, key: str, value: Any, path: ObjectPath) -> None:
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
             plugin.on_adapter_property_changed(path, key, value)
 
-    def _on_device_property_changed(self, _device: AnyDevice, key: str, value: Any, path: str) -> None:
+    def _on_device_property_changed(self, _device: AnyDevice, key: str, value: Any, path: ObjectPath) -> None:
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
             plugin.on_device_property_changed(path, key, value)
 
-    def on_adapter_added(self, _manager: Manager, path: str) -> None:
+    def on_adapter_added(self, _manager: Manager, path: ObjectPath) -> None:
         logging.info(f"Adapter added {path}")
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
             plugin.on_adapter_added(path)
 
-    def on_adapter_removed(self, _manager: Manager, path: str) -> None:
+    def on_adapter_removed(self, _manager: Manager, path: ObjectPath) -> None:
         logging.info(f"Adapter removed {path}")
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
             plugin.on_adapter_removed(path)
 
-    def on_device_created(self, _manager: Manager, path: str) -> None:
+    def on_device_created(self, _manager: Manager, path: ObjectPath) -> None:
         logging.info(f"Device created {path}")
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
             plugin.on_device_created(path)
 
-    def on_device_removed(self, _manager: Manager, path: str) -> None:
+    def on_device_removed(self, _manager: Manager, path: ObjectPath) -> None:
         logging.info(f"Device removed {path}")
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
             plugin.on_device_removed(path)

--- a/blueman/main/BatteryWatcher.py
+++ b/blueman/main/BatteryWatcher.py
@@ -1,12 +1,13 @@
 import weakref
 from typing import Callable
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.Battery import Battery, AnyBattery
 from blueman.bluez.Manager import Manager
 
 
 class BatteryWatcher:
-    def __init__(self, callback: Callable[[str, int], None]) -> None:
+    def __init__(self, callback: Callable[[ObjectPath, int], None]) -> None:
         super().__init__()
         manager = Manager()
         weakref.finalize(

--- a/blueman/main/NetworkManager.py
+++ b/blueman/main/NetworkManager.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 from typing import Optional, Callable, Union
 
+from blueman.bluemantyping import BtAddress
 from blueman.Service import Service
 
 try:
@@ -27,7 +28,7 @@ class NMConnectionBase:
                 NMConnectionError(f"Invalid connection type {self.conntype}, should be panu or dun")
             )
         self.device = service.device
-        self.bdaddr = self.device['Address']
+        self.bdaddr: BtAddress = self.device['Address']
         self.error_handler = error_handler
         self.reply_handler = reply_handler
         self.connection = None

--- a/blueman/main/Sendto.py
+++ b/blueman/main/Sendto.py
@@ -7,7 +7,7 @@ from typing import List, Iterable, Optional
 from blueman.bluez.Device import Device
 from blueman.bluez.errors import BluezDBusException
 from blueman.main.Builder import Builder
-from blueman.bluemantyping import GSignals
+from blueman.bluemantyping import GSignals, ObjectPath
 from blueman.bluez.Adapter import Adapter
 from blueman.bluez.obex.ObjectPush import ObjectPush
 from blueman.bluez.obex.Manager import Manager
@@ -28,7 +28,7 @@ class Sender(Gtk.Dialog):
         'result': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_BOOLEAN,)),
     }
 
-    def __init__(self, device: Device, adapter_path: str, files: Iterable[str]) -> None:
+    def __init__(self, device: Device, adapter_path: ObjectPath, files: Iterable[str]) -> None:
         super().__init__(
             title=_("Bluetooth File Transfer"),
             name="BluemanSendTo",
@@ -154,7 +154,7 @@ class Sender(Gtk.Dialog):
         text = "%s %d/%d %.2f (%s/s) %s %s" % (_("Sending File"), num, self.num_files, speed, unit, _("ETA:"), eta)
         self.pb.set_text(text)
 
-    def on_transfer_started(self, _object_push: ObjectPush, transfer_path: str, filename: str) -> None:
+    def on_transfer_started(self, _object_push: ObjectPush, transfer_path: ObjectPath, filename: str) -> None:
         if self.total_transferred == 0:
             self._update_pb_text(0.0, "B")
 
@@ -262,13 +262,13 @@ class Sender(Gtk.Dialog):
             d.show()
             self.error_dialog = d
 
-    def on_session_added(self, _manager: Manager, session_path: str) -> None:
+    def on_session_added(self, _manager: Manager, session_path: ObjectPath) -> None:
         self.object_push = ObjectPush(obj_path=session_path)
         self.object_push_handlers.append(self.object_push.connect("transfer-started", self.on_transfer_started))
         self.object_push_handlers.append(self.object_push.connect("transfer-failed", self.on_transfer_failed))
         self.process_queue()
 
-    def on_session_removed(self, _manager: Manager, session_path: str) -> None:
+    def on_session_removed(self, _manager: Manager, session_path: ObjectPath) -> None:
         logging.debug(f"Session removed: {session_path}")
         if self.object_push:
             for handlerid in self.object_push_handlers:

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -3,6 +3,7 @@ from gettext import gettext as _
 from html import escape
 from xml.etree import ElementTree
 from typing import Dict, Optional, overload, Callable, Union, TYPE_CHECKING, Tuple, Any, List
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.Device import Device
 from blueman.bluez.AgentManager import AgentManager
@@ -94,22 +95,40 @@ class BluezAgent(DbusService):
 
         return dialog, pin_entry
 
-    def get_device_string(self, object_path: str) -> str:
+    def get_device_string(self, object_path: ObjectPath) -> str:
         device = Device(obj_path=object_path)
         return f"<b>{escape(device.display_name)}</b> ({device['Address']})"
 
     @overload
-    def ask_passkey(self, dialog_msg: str, is_numeric: "Literal[True]", object_path: str, ok: Callable[[int], None],
-                    err: Callable[[Union[BluezErrorCanceled, BluezErrorRejected]], None]) -> None:
+    def ask_passkey(
+            self,
+            dialog_msg: str,
+            is_numeric: "Literal[True]",
+            object_path: ObjectPath,
+            ok: Callable[[int], None],
+            err: Callable[[Union[BluezErrorCanceled, BluezErrorRejected]], None]
+    ) -> None:
         ...
 
     @overload
-    def ask_passkey(self, dialog_msg: str, is_numeric: "Literal[False]", object_path: str, ok: Callable[[str], None],
-                    err: Callable[[Union[BluezErrorCanceled, BluezErrorRejected]], None]) -> None:
+    def ask_passkey(
+            self,
+            dialog_msg: str,
+            is_numeric: "Literal[False]",
+            object_path: ObjectPath,
+            ok: Callable[[str], None],
+            err: Callable[[Union[BluezErrorCanceled, BluezErrorRejected]], None]
+    ) -> None:
         ...
 
-    def ask_passkey(self, dialog_msg: str, is_numeric: bool, object_path: str, ok: Callable[[Any], None],
-                    err: Callable[[Union[BluezErrorCanceled, BluezErrorRejected]], None]) -> None:
+    def ask_passkey(
+            self,
+            dialog_msg: str,
+            is_numeric: bool,
+            object_path: ObjectPath,
+            ok: Callable[[Any], None],
+            err: Callable[[Union[BluezErrorCanceled, BluezErrorRejected]], None]
+    ) -> None:
         def passkey_dialog_cb(dialog: Gtk.Dialog, response_id: int) -> None:
             if response_id == Gtk.ResponseType.ACCEPT:
                 ret = pin_entry.get_text()
@@ -159,7 +178,7 @@ class BluezAgent(DbusService):
             self._notification.close()
             self._notification = None
 
-    def _on_request_pin_code(self, object_path: str, ok: Callable[[str], None],
+    def _on_request_pin_code(self, object_path: ObjectPath, ok: Callable[[str], None],
                              err: Callable[[Union[BluezErrorCanceled, BluezErrorRejected]], None]) -> None:
         logging.info("Agent.RequestPinCode")
         dialog_msg = _("Enter PIN code for authentication:")
@@ -168,7 +187,7 @@ class BluezAgent(DbusService):
         if self.dialog:
             self.dialog.present()
 
-    def _on_request_passkey(self, object_path: str, ok: Callable[[int], None],
+    def _on_request_passkey(self, object_path: ObjectPath, ok: Callable[[int], None],
                             err: Callable[[Union[BluezErrorCanceled, BluezErrorRejected]], None]) -> None:
         logging.info("Agent.RequestPasskey")
         dialog_msg = _("Enter passkey for authentication:")
@@ -176,7 +195,7 @@ class BluezAgent(DbusService):
         if self.dialog:
             self.dialog.present()
 
-    def _on_display_passkey(self, object_path: str, passkey: int, entered: int) -> None:
+    def _on_display_passkey(self, object_path: ObjectPath, passkey: int, entered: int) -> None:
         logging.info(f"DisplayPasskey ({object_path}, {passkey:d} {entered:d})")
         dev = Device(obj_path=object_path)
         self._devhandlerids[object_path] = dev.connect_signal("property-changed", self._on_device_property_changed)
@@ -188,7 +207,7 @@ class BluezAgent(DbusService):
         self._notification = Notification("Bluetooth", notify_message, 0, icon_name="blueman")
         self._notification.show()
 
-    def _on_display_pin_code(self, object_path: str, pin_code: str) -> None:
+    def _on_display_pin_code(self, object_path: ObjectPath, pin_code: str) -> None:
         logging.info(f'DisplayPinCode ({object_path}, {pin_code})')
         dev = Device(obj_path=object_path)
         self._devhandlerids[object_path] = dev.connect_signal("property-changed", self._on_device_property_changed)
@@ -197,7 +216,7 @@ class BluezAgent(DbusService):
         self._notification = Notification("Bluetooth", notify_message, 0, icon_name="blueman")
         self._notification.show()
 
-    def _on_request_confirmation(self, object_path: str, passkey: Optional[int], ok: Callable[[], None],
+    def _on_request_confirmation(self, object_path: ObjectPath, passkey: Optional[int], ok: Callable[[], None],
                                  err: Callable[[BluezErrorCanceled], None]) -> None:
         def on_confirm_action(action: str) -> None:
             if action == "confirm":
@@ -216,11 +235,11 @@ class BluezAgent(DbusService):
                                           icon_name="blueman")
         self._notification.show()
 
-    def _on_request_authorization(self, object_path: str, ok: Callable[[], None],
+    def _on_request_authorization(self, object_path: ObjectPath, ok: Callable[[], None],
                                   err: Callable[[BluezErrorCanceled], None]) -> None:
         self._on_request_confirmation(object_path, None, ok, err)
 
-    def _on_authorize_service(self, object_path: str, uuid: str, ok: Callable[[], None],
+    def _on_authorize_service(self, object_path: ObjectPath, uuid: str, ok: Callable[[], None],
                               err: Callable[[BluezErrorRejected], None]) -> None:
         def on_auth_action(action: str) -> None:
             logging.info(action)

--- a/blueman/plugins/AppletPlugin.py
+++ b/blueman/plugins/AppletPlugin.py
@@ -1,4 +1,5 @@
 from typing import Tuple, Callable, Set, Any, TYPE_CHECKING
+from blueman.bluemantyping import ObjectPath
 
 from blueman.plugins.BasePlugin import BasePlugin
 
@@ -59,27 +60,27 @@ class AppletPlugin(BasePlugin):
         """Run when the dbus service appears and disappears. Should only be used to setup, register agents etc"""
         pass
 
-    def on_adapter_added(self, path: str) -> None:
+    def on_adapter_added(self, path: ObjectPath) -> None:
         """Run when a new adapter is added to the system"""
         pass
 
-    def on_adapter_removed(self, path: str) -> None:
+    def on_adapter_removed(self, path: ObjectPath) -> None:
         """Run when an adapter is removed from the system"""
         pass
 
-    def on_device_created(self, path: str) -> None:
+    def on_device_created(self, path: ObjectPath) -> None:
         """Run when a new device is found"""
         pass
 
-    def on_device_removed(self, path: str) -> None:
+    def on_device_removed(self, path: ObjectPath) -> None:
         """Run when a device is removed"""
         pass
 
-    def on_adapter_property_changed(self, path: str, key: str, value: Any) -> None:
+    def on_adapter_property_changed(self, path: ObjectPath, key: str, value: Any) -> None:
         """Run when a property changes of any adapters. Make sure to distinguish your actions by path"""
         pass
 
-    def on_device_property_changed(self, path: str, key: str, value: Any) -> None:
+    def on_device_property_changed(self, path: ObjectPath, key: str, value: Any) -> None:
         """Run when a property changes of any devices. Make sure to distinguish your actions by path"""
         pass
 

--- a/blueman/plugins/applet/AutoConnect.py
+++ b/blueman/plugins/applet/AutoConnect.py
@@ -1,5 +1,6 @@
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Union, Optional, Any
+from blueman.bluemantyping import ObjectPath
 
 from gi.repository import GLib
 
@@ -35,7 +36,7 @@ class AutoConnect(AppletPlugin):
         if state:
             self._run()
 
-    def on_adapter_property_changed(self, path: str, key: str, value: Any) -> None:
+    def on_adapter_property_changed(self, path: ObjectPath, key: str, value: Any) -> None:
         if key == "Powered" and value:
             self._run()
 

--- a/blueman/plugins/applet/AutoConnect.py
+++ b/blueman/plugins/applet/AutoConnect.py
@@ -41,8 +41,8 @@ class AutoConnect(AppletPlugin):
             self._run()
 
     def _run(self) -> bool:
-        for address, uuid in self.get_option('services'):
-            device = self.parent.Manager.find_device(address)
+        for btaddress, uuid in self.get_option('services'):
+            device = self.parent.Manager.find_device(btaddress)
             if device is None or device.get("Connected"):
                 continue
 

--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -1,6 +1,7 @@
 import logging
 from gettext import gettext as _
 from typing import Any, Dict, Union
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.Device import Device
 from blueman.gui.Notification import Notification, _NotificationBubble, _NotificationDialog
@@ -14,7 +15,7 @@ class ConnectionNotifier(AppletPlugin):
     __icon__ = "bluetooth-symbolic"
     __description__ = _("Shows desktop notifications when devices get connected or disconnected.")
 
-    _notifications: Dict[str, Union[_NotificationBubble, _NotificationDialog]] = {}
+    _notifications: Dict[ObjectPath, Union[_NotificationBubble, _NotificationDialog]] = {}
 
     def on_load(self) -> None:
         self._battery_watcher = BatteryWatcher(self._on_battery_update)
@@ -22,7 +23,7 @@ class ConnectionNotifier(AppletPlugin):
     def on_unload(self) -> None:
         del self._battery_watcher
 
-    def on_device_property_changed(self, path: str, key: str, value: Any) -> None:
+    def on_device_property_changed(self, path: ObjectPath, key: str, value: Any) -> None:
         if key == "Connected":
             device = Device(obj_path=path)
             if value:
@@ -35,7 +36,7 @@ class ConnectionNotifier(AppletPlugin):
             else:
                 Notification(device.display_name, _('Disconnected'), icon_name=device["Icon"]).show()
 
-    def _on_battery_update(self, path: str, value: int) -> None:
+    def _on_battery_update(self, path: ObjectPath, value: int) -> None:
         notification = self._notifications.pop(path, None)
         if notification:
             try:

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -1,5 +1,6 @@
 from gettext import gettext as _
 from typing import Callable, Union, TYPE_CHECKING
+from blueman.bluemantyping import ObjectPath
 
 from _blueman import RFCOMMError
 from gi.repository import GLib
@@ -61,7 +62,7 @@ class DBusService(AppletPlugin):
     def _plugins_changed(self) -> None:
         self._emit_dbus_signal("PluginsChanged")
 
-    def connect_service(self, object_path: str, uuid: str, ok: Callable[[], None],
+    def connect_service(self, object_path: ObjectPath, uuid: str, ok: Callable[[], None],
                         err: Callable[[Union[BluezDBusException, "NMConnectionError",
                                              RFCOMMError, GLib.Error, str]], None]) -> None:
         try:
@@ -97,7 +98,7 @@ class DBusService(AppletPlugin):
                 logging.info("No handler registered")
                 err("Service not supported\nPossibly the plugin that handles this service is not loaded")
 
-    def _disconnect_service(self, object_path: str, uuid: str, port: int, ok: Callable[[], None],
+    def _disconnect_service(self, object_path: ObjectPath, uuid: str, port: int, ok: Callable[[], None],
                             err: Callable[[Union[BluezDBusException, "NMConnectionError",
                                                  GLib.Error, str]], None]) -> None:
         if uuid == '00000000-0000-0000-0000-000000000000':

--- a/blueman/plugins/applet/DhcpClient.py
+++ b/blueman/plugins/applet/DhcpClient.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 import logging
 from typing import List, Any
+from blueman.bluemantyping import ObjectPath
 
 from gi.repository import GLib
 
@@ -28,12 +29,12 @@ class DhcpClient(AppletPlugin):
     def on_unload(self) -> None:
         del self._any_network
 
-    def _on_network_prop_changed(self, _network: AnyNetwork, key: str, value: Any, object_path: str) -> None:
+    def _on_network_prop_changed(self, _network: AnyNetwork, key: str, value: Any, object_path: ObjectPath) -> None:
         if key == "Interface":
             if value != "":
                 self.dhcp_acquire(object_path)
 
-    def dhcp_acquire(self, object_path: str) -> None:
+    def dhcp_acquire(self, object_path: ObjectPath) -> None:
         device = Network(obj_path=object_path)["Interface"]
 
         if device not in self.querying:

--- a/blueman/plugins/applet/GameControllerWakelock.py
+++ b/blueman/plugins/applet/GameControllerWakelock.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 import logging
 from typing import Any
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.Device import Device
 from blueman.Functions import launch
@@ -40,7 +41,7 @@ class GameControllerWakelock(AppletPlugin):
             self.wake_lock = 1
             self.xdg_screensaver("resume")
 
-    def on_device_property_changed(self, path: str, key: str, value: Any) -> None:
+    def on_device_property_changed(self, path: ObjectPath, key: str, value: Any) -> None:
         if key == "Connected":
             klass = Device(obj_path=path)["Class"] & 0x1fff
 

--- a/blueman/plugins/applet/NetUsage.py
+++ b/blueman/plugins/applet/NetUsage.py
@@ -17,7 +17,7 @@ from gi.repository import Gio
 import gi
 
 from blueman.plugins.applet.PPPSupport import PPPConnectedListener
-from blueman.bluemantyping import GSignals
+from blueman.bluemantyping import GSignals, ObjectPath
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
@@ -309,7 +309,7 @@ class NetUsage(AppletPlugin, GObject.GObject, PPPConnectedListener):
         self.parent.Plugins.Menu.add(self, 84, text=_("Network _Usage"), icon_name="network-wireless-symbolic",
                                      tooltip=_("Shows network traffic usage"), callback=self.activate_ui)
 
-    def _on_network_property_changed(self, _network: AnyNetwork, key: str, value: Any, path: str) -> None:
+    def _on_network_property_changed(self, _network: AnyNetwork, key: str, value: Any, path: ObjectPath) -> None:
         if key == "Interface" and value != "":
             d = Device(obj_path=path)
             self.monitor_interface(d, value)

--- a/blueman/plugins/applet/Networking.py
+++ b/blueman/plugins/applet/Networking.py
@@ -1,5 +1,6 @@
 from gettext import gettext as _
 from typing import Dict, Optional
+from blueman.bluemantyping import ObjectPath
 
 from gi.repository import GLib
 from gi.repository import Gio
@@ -21,7 +22,7 @@ class Networking(AppletPlugin):
     _dns_server_provider: Optional[DNSServerProvider] = None
 
     def on_load(self) -> None:
-        self._registered: Dict[str, bool] = {}
+        self._registered: Dict[ObjectPath, bool] = {}
 
         self.Config = Gio.Settings(schema_id="org.blueman.network")
         self.Config.connect("changed", self.on_config_changed)

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -2,6 +2,7 @@ from enum import Enum
 from gettext import gettext as _
 import logging
 from typing import Callable, Any, Optional
+from blueman.bluemantyping import ObjectPath
 
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.bluez.Adapter import Adapter
@@ -180,7 +181,7 @@ class PowerManager(AppletPlugin, StatusIconProvider):
     def get_bluetooth_status(self) -> bool:
         return self.current_state
 
-    def on_adapter_property_changed(self, _path: str, key: str, value: Any) -> None:
+    def on_adapter_property_changed(self, _path: ObjectPath, key: str, value: Any) -> None:
         if key == "Powered":
             if value and not self.current_state:
                 logging.warning("adapter powered on while in off state, turning bluetooth on")
@@ -195,6 +196,6 @@ class PowerManager(AppletPlugin, StatusIconProvider):
     def on_status_icon_query_icon(self) -> Optional[str]:
         return "blueman-disabled" if not self.get_bluetooth_status() else None
 
-    def on_adapter_added(self, path: str) -> None:
+    def on_adapter_added(self, path: ObjectPath) -> None:
         adapter = Adapter(obj_path=path)
         adapter.set("Powered", self.adapter_state)

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -4,6 +4,7 @@ import html
 import time
 import logging
 from typing import List, TYPE_CHECKING, Optional, Callable, cast, Union
+from blueman.bluemantyping import ObjectPath, BtAddress
 
 from blueman.bluez.Device import Device
 from blueman.bluez.errors import DBusNoSuchAdapterError
@@ -108,7 +109,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
     def on_adapter_removed(self, path: str) -> None:
         self._rebuild()
 
-    def notify(self, object_path: str, uuid: str) -> None:
+    def notify(self, object_path: ObjectPath, uuid: str) -> None:
         device = Device(obj_path=object_path)
         logging.info(f"{device} {uuid}")
         try:
@@ -119,7 +120,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
 
         item = {
             "adapter": adapter["Address"],
-            "address": device['Address'],
+            "address": BtAddress(device['Address']),
             "alias": device.display_name,
             "icon": device['Icon'],
             "name": ServiceUUID(uuid).name,
@@ -165,7 +166,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
             item["mitem"]["sensitive"] = True
             self.parent.Plugins.Menu.on_menu_changed()
 
-        self.parent.Plugins.DBusService.connect_service(item["device"], item["uuid"], reply, err)
+        self.parent.Plugins.DBusService.connect_service(ObjectPath(item["device"]), item["uuid"], reply, err)
 
     def _build_menu_item(self, item: "Item") -> "SubmenuItemDict":
         alias = html.escape(item["alias"])
@@ -193,7 +194,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
             self._mitems.append(menu.add(self, (53, idx), **item))
         menu.add(self, 59)
 
-    def _get_device_path(self, adapter_path: str, address: str) -> Optional[str]:
+    def _get_device_path(self, adapter_path: ObjectPath, address: BtAddress) -> Optional[str]:
         try:
             adapter = self.parent.Manager.get_adapter(adapter_path)
         except DBusNoSuchAdapterError:

--- a/blueman/plugins/applet/ShowConnected.py
+++ b/blueman/plugins/applet/ShowConnected.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 import logging
 from typing import Optional, Any, List, Set
+from blueman.bluemantyping import ObjectPath
 
 from gi.repository import GLib
 
@@ -22,7 +23,7 @@ class ShowConnected(AppletPlugin, StatusIconProvider):
                         "connections in the tooltip.")
 
     def on_load(self) -> None:
-        self._connections: Set[str] = set()
+        self._connections: Set[ObjectPath] = set()
         self.active = False
         self.initialized = False
         self._handlers: List[int] = []
@@ -62,7 +63,7 @@ class ShowConnected(AppletPlugin, StatusIconProvider):
 
     def update_statusicon(self) -> None:
         if self._connections:
-            def build_line(obj_path: str) -> str:
+            def build_line(obj_path: ObjectPath) -> str:
                 line: str = Device(obj_path=obj_path)["Alias"]
                 try:
                     return f"{line} 🔋{Battery(obj_path=obj_path)['Percentage']}%"
@@ -93,7 +94,7 @@ class ShowConnected(AppletPlugin, StatusIconProvider):
             self._connections = set()
             self.update_statusicon()
 
-    def on_device_property_changed(self, path: str, key: str, value: Any) -> None:
+    def on_device_property_changed(self, path: ObjectPath, key: str, value: Any) -> None:
         if key == "Connected":
             if value:
                 self._connections.add(path)

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -5,6 +5,7 @@ import shutil
 import logging
 from html import escape
 from typing import List, Dict, TYPE_CHECKING, Callable, Tuple, Optional, Union
+from blueman.bluemantyping import ObjectPath, BtAddress
 
 from blueman.bluez.obex.AgentManager import AgentManager
 from blueman.bluez.obex.Manager import Manager
@@ -28,7 +29,7 @@ if TYPE_CHECKING:
 
     class PendingTransferDict(TypedDict):
         transfer_path: str
-        address: str
+        address: BtAddress
         root: str
         filename: str
         size: Optional[int]
@@ -46,7 +47,7 @@ class ObexErrorCanceled(DbusError):
 
 
 class Agent(DbusService):
-    __agent_path = '/org/bluez/obex/agent/blueman'
+    __agent_path = ObjectPath('/org/bluez/obex/agent/blueman')
 
     def __init__(self, applet: BluemanApplet):
         super().__init__(None, "org.bluez.obex.Agent1", self.__agent_path, Gio.BusType.SESSION)
@@ -73,7 +74,7 @@ class Agent(DbusService):
     def _release(self) -> None:
         raise Exception(self.__agent_path + " was released unexpectedly")
 
-    def _authorize_push(self, transfer_path: str, ok: Callable[[str], None],
+    def _authorize_push(self, transfer_path: ObjectPath, ok: Callable[[str], None],
                         err: Callable[[ObexErrorRejected], None]) -> None:
         def on_action(action: str) -> None:
             logging.info(f"Action {action}")

--- a/blueman/plugins/manager/Services.py
+++ b/blueman/plugins/manager/Services.py
@@ -1,4 +1,5 @@
 from typing import List, Callable
+from blueman.bluemantyping import BtAddress
 
 import cairo
 
@@ -73,14 +74,14 @@ class Services(ManagerPlugin, MenuItemsProvider):
                 items.append(DeviceMenuItem(item, DeviceMenuItem.Group.DISCONNECT, service.priority + 100))
                 item.show()
 
-        object_path = device.get_object_path()
+        btaddress: BtAddress = device["Address"]
         if services:
             config = AutoConnectConfig()
             autoconnect_services = set(config["services"])
             for service in services:
-                if service.connected_instances or (object_path, service.uuid) in autoconnect_services:
+                if service.connected_instances or (btaddress, service.uuid) in autoconnect_services:
                     item = Gtk.CheckMenuItem(label=service.name)
-                    config.bind_to_menuitem(item, (object_path, service.uuid))
+                    config.bind_to_menuitem(item, (btaddress, service.uuid))
                     item.show()
                     items.append(DeviceMenuItem(item, DeviceMenuItem.Group.AUTOCONNECT, service.priority))
 

--- a/blueman/plugins/mechanism/Network.py
+++ b/blueman/plugins/mechanism/Network.py
@@ -1,4 +1,5 @@
 from typing import Callable, Union, Dict, Type, TYPE_CHECKING
+from blueman.bluemantyping import ObjectPath
 
 from blueman.bluez.Network import Network as BluezNetwork
 from blueman.plugins.MechanismPlugin import MechanismPlugin
@@ -20,7 +21,7 @@ class Network(MechanismPlugin):
         self.parent.add_method("EnableNetwork", ("s", "s", "s", "b"), "", self._enable_network, pass_sender=True)
         self.parent.add_method("DisableNetwork", (), "", self._disable_network, pass_sender=True)
 
-    def _run_dhcp_client(self, object_path: str, caller: str, ok: Callable[[str], None],
+    def _run_dhcp_client(self, object_path: ObjectPath, caller: str, ok: Callable[[str], None],
                          err: Callable[[Union[Exception, int]], None]) -> None:
         self.timer.stop()
 


### PR DESCRIPTION
Like the annotate commit mentions, I was hoping to catch the issue where we passed the wrong string to `Manager.find_device`. I can move this commit to a separate PR if you like.

We have been storing the object path to GSettings for the AutoConnect plugin since the latest release so let's not break it for those users by now storing the bluetooth address instead.