### PR TITLE
Rfcomm.py: convert port_id gdouble/float to int

### DIFF
--- a/blueman/plugins/mechanism/Rfcomm.py
+++ b/blueman/plugins/mechanism/Rfcomm.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import signal
+import typing
 from blueman.Constants import RFCOMM_WATCHER_PATH
 from blueman.plugins.MechanismPlugin import MechanismPlugin
 
@@ -10,10 +11,12 @@ class Rfcomm(MechanismPlugin):
         self.parent.add_method("OpenRFCOMM", ("d",), "", self._open_rfcomm)
         self.parent.add_method("CloseRFCOMM", ("d",), "", self._close_rfcomm)
 
-    def _open_rfcomm(self, port_id: int) -> None:
+    def _open_rfcomm(self, port_id: typing.Union[int, float]) -> None:
+        port_id = int(port_id)
         subprocess.Popen([RFCOMM_WATCHER_PATH, f"/dev/rfcomm{port_id:d}"])
 
-    def _close_rfcomm(self, port_id: int) -> None:
+    def _close_rfcomm(self, port_id: typing.Union[int, float]) -> None:
+        port_id = int(port_id)
         out, err = subprocess.Popen(['ps', '-e', 'o', 'pid,args'], stdout=subprocess.PIPE).communicate()
         for line in out.decode("UTF-8").splitlines():
             pid, cmdline = line.split(maxsplit=1)


### PR DESCRIPTION
When connecting to a serial port from blueman the following exception is raised because `port_id` in `OpenRFCOMM` is passed as `Glib.Variant` `gdouble` `d`:

```
  Connection Failed: File "/usr/lib/python3/dist-packages/blueman/main/DbusService.py", line 154, in _handle_method_call
      method(*(args + (ok, lambda exception: self._return_dbus_error(invocation, exception))))
    File "/usr/lib/python3/dist-packages/blueman/plugins/applet/DBusService.py", line 93, in connect_service
      service.connect(reply_handler=lambda port: ok(), error_handler=err)
    File "/usr/lib/python3/dist-packages/blueman/services/meta/SerialService.py", line 104, in connect
      Mechanism().OpenRFCOMM('(d)', port_id)
    File "/usr/lib/python3/dist-packages/gi/overrides/Gio.py", line 349, in __call__
      result = self.dbus_proxy.call_sync(self.method_name, arg_variant,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  gi.repository.GLib.GError: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.Failed: Traceback (most recent call last):
    File "/usr/lib/python3/dist-packages/blueman/main/DbusService.py", line 156, in _handle_method_call
      ok(method(*args))
         ^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/blueman/plugins/mechanism/Rfcomm.py", line 14, in _open_rfcomm
      subprocess.Popen([RFCOMM_WATCHER_PATH, f"/dev/rfcomm{port_id:d}"])
                                                          ^^^^^^^^^^^
  ValueError: Unknown format code 'd' for object of type 'float'
   (0)


```

Similar thing happens to `CloseRFCOMM`.

Change the typing annotation to allow for `Union` of `float+int` and explicitly convert to `int` by calling `int(port_id)`.