### PR TITLE
Applet: Handle UnknownObject DBus error.

### DIFF
--- a/blueman/bluez/errors.py
+++ b/blueman/bluez/errors.py
@@ -85,6 +85,10 @@ class DBusUnsupportedMajorClassError(BluezDBusException):
     pass
 
 
+class DBusUnknownObjectError(BluezDBusException):
+    pass
+
+
 class DBusServiceUnknownError(BluezDBusException):
     pass
 
@@ -121,6 +125,7 @@ __DICT_ERROR__ = {'org.bluez.Error.Failed': DBusFailedError,
                   'org.bluez.Error.AuthenticationCanceled': DBusAuthenticationCanceledError,
                   'org.bluez.serial.Error.NotSupported': DBusNotSupportedError,
                   'org.bluez.Error.UnsupportedMajorClass': DBusUnsupportedMajorClassError,
+                  'org.freedesktop.DBus.Error.UnknownObject': DBusUnknownObjectError,
                   'org.freedesktop.DBus.Error.ServiceUnknown': DBusServiceUnknownError}
 
 

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -7,7 +7,7 @@ from typing import List, TYPE_CHECKING, Optional, Callable, cast, Union
 from blueman.bluemantyping import ObjectPath, BtAddress
 
 from blueman.bluez.Device import Device
-from blueman.bluez.errors import DBusNoSuchAdapterError
+from blueman.bluez.errors import DBusNoSuchAdapterError, DBusUnknownObjectError
 from blueman.gui.Notification import Notification
 from blueman.Sdp import ServiceUUID
 from blueman.plugins.AppletPlugin import AppletPlugin
@@ -200,7 +200,11 @@ class RecentConns(AppletPlugin, PowerStateListener):
         except DBusNoSuchAdapterError:
             return None
 
-        device = self.parent.Manager.find_device(address, adapter.get_object_path())
+        try:
+            device = self.parent.Manager.find_device(address, adapter.get_object_path())
+        except DBusUnknownObjectError:
+            return None
+
         return device.get_object_path() if device is not None else None
 
     def _get_items(self) -> List["Item"]:


### PR DESCRIPTION
Every 10 s, I see this error, on Ubuntu 24.04.1, which uses Blueman 2.3.5:

```
 During handling of the above exception, another exception occurred:
 Traceback (most recent call last):
   File "/usr/lib/python3/dist-packages/blueman/main/Applet.py", line 97, in on_device_created
     plugin.on_device_created(path)
   File "/usr/lib/python3/dist-packages/blueman/plugins/applet/RecentConns.py", line 99, in on_device_created
     self._rebuild()
   File "/usr/lib/python3/dist-packages/blueman/plugins/applet/RecentConns.py", line 80, in _rebuild
     self._items = self._get_items()
                   ^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/blueman/plugins/applet/RecentConns.py", line 199, in _get_items
     return sorted(
            ^^^^^^^
   File "/usr/lib/python3/dist-packages/blueman/plugins/applet/RecentConns.py", line 213, in <genexpr>
     if i["adapter"] not in adapter_addresses or self._get_device_path(i["adapter"], i["address"])),
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/blueman/plugins/applet/RecentConns.py", line 193, in _get_device_path
     device = self.parent.Manager.find_device(address, adapter.get_object_path())
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/blueman/bluez/Manager.py", line 146, in find_device
     if device['Address'] == address:
        ~~~~~~^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/blueman/bluez/Base.py", line 135, in __getitem__
     return self.get(key)
            ^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/blueman/bluez/Base.py", line 106, in get
     raise parse_dbus_error(e)
 blueman.bluez.errors.BluezDBusException: org.freedesktop.DBus.Error.UnknownObject Method "Get" with signature "ss" on interface "org.freedesktop.DBus.Properties" doesn't exist
```

Since there is already exception handling for the adaptor going away (https://github.com/blueman-project/blueman/commit/c67ae920c5bfd3932ec6715cc0336139b436f88b), it seems reasonable to add this, in case of devices that "flicker". I can't say for sure why my device is listed by the adapter, but don't actually exist.

(I've also had the applet pinned at 100% CPU, but I think that's a separate issue.)