### PR TITLE
Dbus method added to set a flag for the paring button

### DIFF
--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -254,13 +254,13 @@ class Blueman(Gtk.Application):
             dialog.connect("close", lambda d: d.destroy())
             dialog.show()
 
-    @staticmethod
-    def bond(device: Device) -> None:
+    def bond(self, device: Device) -> None:
         def error_handler(e: Exception) -> None:
             logging.exception(e)
             message = f"Pairing failed for:\n{device.display_name} ({device['Address']})"
             Notification('Bluetooth', message, icon_name="blueman").show()
-
+        path = device.get_object_path()
+        self.Applet.SetParingState("(sb)", path, True)
         device.pair(error_handler=error_handler)
 
     @staticmethod


### PR DESCRIPTION
**Environment**
Ubuntu22.04

**Blueman version**
Commit hash: 52f0f03

**Problem**
Every time a headset is paired with the paring button, the notification of "Connected" and "Disconnected" pops up even though the headset is neither connected nor disconnected. 

**Cause**
This problem seems to be caused by that it receives "Connected" and "Disconnected" signal even when it is just paring.

**Modification**
Dbus method is added to set a flag to judge if a device is paring using the paring button. The method is accessed from bond(), which is a callback method set for the paring button. Also, since it seems bond() is never used as a static method, the decorator was removed.
