### PR TITLE
UI Fix: Make search button available after device list becomes empty

### DIFF
--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -73,7 +73,7 @@ class ManagerToolbar:
         device: Optional[Device],
         _tree_iter: Gtk.TreeIter,
     ) -> None:
-        self._update_buttons(None if device is None else Adapter(obj_path=device["Adapter"]))
+        self._update_buttons(dev_list.Adapter)
 
     def _update_buttons(self, adapter: Optional[Adapter]) -> None:
         powered = adapter is not None and adapter["Powered"]


### PR DESCRIPTION
**Problem**
The search button becomes unavailable after the device list is empty.

**Cause**
The _update_button() function receives None when the device list becomes empty, causing the sensitivity of the search button to be disabled if the argument (adapter) is None.

**Solution**
Pass the instance variable of ManagerDeviceList, Adapter, to the _update_button() function.