### PR TITLE
Hide blueman-applet in KDE and GNOME

### DIFF
--- a/data/blueman.desktop.in
+++ b/data/blueman.desktop.in
@@ -5,4 +5,6 @@ Icon=blueman
 Exec=blueman-applet
 Terminal=false
 Type=Application
+NoDisplay=true
+NotShowIn=KDE;GNOME;
 Categories=


### PR DESCRIPTION
New versions of GNOME and KDE have dedicated UI for this