### PR TITLE
apps: parse log level with logging.getLevelName()

### DIFF
--- a/apps/blueman-adapters.in
+++ b/apps/blueman-adapters.in
@@ -22,20 +22,7 @@ if __name__ == '__main__':
     parser.add_argument("--socket-id", dest="socket_id", action="store", type=int, metavar="ID")
     parser.add_argument("adapter", nargs="?", metavar="ADAPTER NAME")
     args = parser.parse_args()
-
-    if args.LEVEL.upper() == "DEBUG":
-        log_level = logging.DEBUG
-    elif args.LEVEL.upper() == "INFO":
-        log_level = logging.INFO
-    elif args.LEVEL.upper() == "WARNING":
-        log_level = logging.WARNING
-    elif args.LEVEL.upper() == "ERROR":
-        log_level = logging.ERROR
-    elif args.LEVEL.upper() == "CRITICAL":
-        log_level = logging.CRITICAL
-    else:
-        log_level = logging.WARNING
-
+    log_level = logging.getLevelName(args.LEVEL.upper())
     create_logger(log_level, "blueman-adapters", syslog=args.syslog)
 
     set_proc_title()

--- a/apps/blueman-applet.in
+++ b/apps/blueman-applet.in
@@ -19,20 +19,7 @@ from blueman.main.Applet import BluemanApplet
 if __name__ == '__main__':
     parser = create_parser()
     args = parser.parse_args()
-
-    if args.LEVEL.upper() == "DEBUG":
-        log_level = logging.DEBUG
-    elif args.LEVEL.upper() == "INFO":
-        log_level = logging.INFO
-    elif args.LEVEL.upper() == "WARNING":
-        log_level = logging.WARNING
-    elif args.LEVEL.upper() == "ERROR":
-        log_level = logging.ERROR
-    elif args.LEVEL.upper() == "CRITICAL":
-        log_level = logging.CRITICAL
-    else:
-        log_level = logging.WARNING
-
+    log_level = logging.getLevelName(args.LEVEL.upper())
     create_logger(log_level, "blueman-applet", syslog=args.syslog)
 
     set_proc_title()

--- a/apps/blueman-manager.in
+++ b/apps/blueman-manager.in
@@ -19,20 +19,7 @@ from blueman.Functions import set_proc_title, create_parser, create_logger
 if __name__ == '__main__':
     parser = create_parser()
     args = parser.parse_args()
-
-    if args.LEVEL.upper() == "DEBUG":
-        log_level = logging.DEBUG
-    elif args.LEVEL.upper() == "INFO":
-        log_level = logging.INFO
-    elif args.LEVEL.upper() == "WARNING":
-        log_level = logging.WARNING
-    elif args.LEVEL.upper() == "ERROR":
-        log_level = logging.ERROR
-    elif args.LEVEL.upper() == "CRITICAL":
-        log_level = logging.CRITICAL
-    else:
-        log_level = logging.WARNING
-
+    log_level = logging.getLevelName(args.LEVEL.upper())
     create_logger(log_level, "blueman-manager", syslog=args.syslog)
 
     app = Blueman()

--- a/apps/blueman-mechanism.in
+++ b/apps/blueman-mechanism.in
@@ -36,19 +36,7 @@ parser.add_argument("-d", "--debug", dest="debug", action="store_true")
 parser.add_argument("-s", "--stop-timer", dest="stoptimer", action="store_true")
 args = parser.parse_args()
 
-if args.LEVEL.upper() == "DEBUG":
-    log_level = logging.DEBUG
-elif args.LEVEL.upper() == "INFO":
-    log_level = logging.INFO
-elif args.LEVEL.upper() == "WARNING":
-    log_level = logging.WARNING
-elif args.LEVEL.upper() == "ERROR":
-    log_level = logging.ERROR
-elif args.LEVEL.upper() == "CRITICAL":
-    log_level = logging.CRITICAL
-else:
-    log_level = logging.WARNING
-
+log_level = logging.getLevelName(args.LEVEL.upper())
 logger = create_logger(log_level, "blueman-mechanism", syslog=True)
 
 if args.debug:

--- a/apps/blueman-sendto.in
+++ b/apps/blueman-sendto.in
@@ -144,20 +144,7 @@ if __name__ == '__main__':
                         help=_("Files to be send to the bluetooth device"))
 
     args = parser.parse_args()
-
-    if args.LEVEL.upper() == "DEBUG":
-        log_level = logging.DEBUG
-    elif args.LEVEL.upper() == "INFO":
-        log_level = logging.INFO
-    elif args.LEVEL.upper() == "WARNING":
-        log_level = logging.WARNING
-    elif args.LEVEL.upper() == "ERROR":
-        log_level = logging.ERROR
-    elif args.LEVEL.upper() == "CRITICAL":
-        log_level = logging.CRITICAL
-    else:
-        log_level = logging.WARNING
-
+    log_level = logging.getLevelName(args.LEVEL.upper())
     create_logger(log_level, "blueman-sendto", syslog=args.syslog)
 
     set_proc_title()

--- a/apps/blueman-services.in
+++ b/apps/blueman-services.in
@@ -22,20 +22,7 @@ from blueman.main.Services import BluemanServices
 if __name__ == '__main__':
     parser = create_parser()
     args = parser.parse_args()
-
-    if args.LEVEL.upper() == "DEBUG":
-        log_level = logging.DEBUG
-    elif args.LEVEL.upper() == "INFO":
-        log_level = logging.INFO
-    elif args.LEVEL.upper() == "WARNING":
-        log_level = logging.WARNING
-    elif args.LEVEL.upper() == "ERROR":
-        log_level = logging.ERROR
-    elif args.LEVEL.upper() == "CRITICAL":
-        log_level = logging.CRITICAL
-    else:
-        log_level = logging.WARNING
-
+    log_level = logging.getLevelName(args.LEVEL.upper())
     create_logger(log_level, "blueman-services", syslog=args.syslog)
 
     setup_icon_path()

--- a/apps/blueman-tray.in
+++ b/apps/blueman-tray.in
@@ -18,20 +18,7 @@ from blueman.main.Tray import BluemanTray
 if __name__ == '__main__':
     parser = create_parser()
     args = parser.parse_args()
-
-    if args.LEVEL.upper() == "DEBUG":
-        log_level = logging.DEBUG
-    elif args.LEVEL.upper() == "INFO":
-        log_level = logging.INFO
-    elif args.LEVEL.upper() == "WARNING":
-        log_level = logging.WARNING
-    elif args.LEVEL.upper() == "ERROR":
-        log_level = logging.ERROR
-    elif args.LEVEL.upper() == "CRITICAL":
-        log_level = logging.CRITICAL
-    else:
-        log_level = logging.WARNING
-
+    log_level = logging.getLevelName(args.LEVEL.upper())
     create_logger(log_level, "blueman-tray", syslog=args.syslog)
 
     set_proc_title()

--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -270,7 +270,7 @@ def create_parser(
         parser = argparse.ArgumentParser()
 
     if loglevel:
-        parser.add_argument("--loglevel", dest="LEVEL", default="warning")
+        parser.add_argument("--loglevel", dest="LEVEL", default="WARNING")
 
     if syslog:
         parser.add_argument("--syslog", dest="syslog", action="store_true")


### PR DESCRIPTION
The logging.getLevelName() function returns the numeric representation of logging level.

The args.LEVEL is "warning" by default.
Just to be in line with the Python let's make it in upper case "WARNING". But if previously an incorrect level name used e.g. CRIT then the WARNING fallback value used instead, but now it will fail. This shouldn't be a big problem.