### PR TITLE
More direct types

### DIFF
--- a/blueman/bluemantyping.py
+++ b/blueman/bluemantyping.py
@@ -1,16 +1,15 @@
-from typing import Union, TYPE_CHECKING, NewType
+from typing import NewType, Protocol, Union
 from gi.repository import GObject
 
-if TYPE_CHECKING:
-    from typing_extensions import Protocol
 
-    class _HasGType(Protocol):
-        __gtype__: GObject.GType
+class _HasGType(Protocol):
+    __gtype__: GObject.GType
+
 
 # Actually supported types are int, bool, str, float, and object but no subclasses, see
 # https://github.com/GNOME/pygobject/blob/ac576400ecd554879c906791e6638d64bb8bcc2a/gi/pygi-type.c#L498
 # (We shield the possibility to provide a str to avoid errors)
-GSignals = dict[str, tuple[GObject.SignalFlags, None, tuple[Union[None, type, GObject.GType, "_HasGType"], ...]]]
+GSignals = dict[str, tuple[GObject.SignalFlags, None, tuple[Union[None, type, GObject.GType, _HasGType], ...]]]
 
 ObjectPath = NewType("ObjectPath", str)
 BtAddress = NewType("BtAddress", str)

--- a/blueman/gui/CommonUi.py
+++ b/blueman/gui/CommonUi.py
@@ -1,15 +1,12 @@
 from datetime import datetime
 from gettext import gettext as _
-from typing import overload, TYPE_CHECKING
+from typing import overload, Literal
 
 from blueman.Constants import WEBSITE, VERSION
 
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-
-if TYPE_CHECKING:
-    from typing import Literal
 
 
 class ErrorDialog(Gtk.MessageDialog):
@@ -40,12 +37,12 @@ class ErrorDialog(Gtk.MessageDialog):
 
 
 @overload
-def show_about_dialog(app_name: str, run: "Literal[True]" = True, parent: Gtk.Window | None = None) -> None:
+def show_about_dialog(app_name: str, run: Literal[True] = True, parent: Gtk.Window | None = None) -> None:
     ...
 
 
 @overload
-def show_about_dialog(app_name: str, run: "Literal[False]", parent: Gtk.Window | None = None) -> Gtk.AboutDialog:
+def show_about_dialog(app_name: str, run: Literal[False], parent: Gtk.Window | None = None) -> Gtk.AboutDialog:
     ...
 
 

--- a/blueman/gui/GenericList.py
+++ b/blueman/gui/GenericList.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any, TypedDict
 from collections.abc import Iterable, Mapping, Callable, Collection
 
 import gi
@@ -6,21 +6,17 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 
-if TYPE_CHECKING:
-    from typing_extensions import TypedDict
+class _ListDataDictBase(TypedDict):
+    id: str
+    type: type
 
-    class _ListDataDictBase(TypedDict):
-        id: str
-        type: type
 
-    class ListDataDict(_ListDataDictBase, total=False):
-        renderer: Gtk.CellRenderer
-        render_attrs: Mapping[str, int]
-        view_props: Mapping[str, object]
-        celldata_func: tuple[Callable[[Gtk.TreeViewColumn, Gtk.CellRenderer, Gtk.TreeModelFilter, Gtk.TreeIter, Any],
-                                      None], Any]
-else:
-    ListDataDict = dict
+class ListDataDict(_ListDataDictBase, total=False):
+    renderer: Gtk.CellRenderer
+    render_attrs: Mapping[str, int]
+    view_props: Mapping[str, object]
+    celldata_func: tuple[Callable[[Gtk.TreeViewColumn, Gtk.CellRenderer, Gtk.TreeModelFilter, Gtk.TreeIter, Any],
+                                  None], Any]
 
 
 # noinspection PyAttributeOutsideInit

--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -5,14 +5,15 @@ from typing import TYPE_CHECKING, cast, TypeVar
 from blueman.main.Builder import Builder
 from blueman.main.PluginManager import PluginManager
 from blueman.plugins.AppletPlugin import AppletPlugin
+from blueman.plugins.BasePlugin import Option, BasePlugin
 
 import gi
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
 from gi.repository import Gtk, Gdk, Gio, GLib, GObject
 
+
 if TYPE_CHECKING:
-    from blueman.plugins.BasePlugin import Option, BasePlugin
     from blueman.main.Applet import BluemanApplet
 
 
@@ -69,13 +70,13 @@ class SettingsWidget(Gtk.Box):
                 label = Gtk.Label(label="<i >" + v["desc"] + "</i>", wrap=True, use_markup=True, xalign=0.0)
                 self.pack_start(label, False, False, 0)
 
-    def handle_change(self, widget: Gtk.Widget, opt: str, params: "Option", prop: str) -> None:
+    def handle_change(self, widget: Gtk.Widget, opt: str, params: Option, prop: str) -> None:
         val = params["type"](getattr(widget.props, prop))
         logging.debug(f"changed {opt} {val}")
 
         self.inst.set_option(opt, val)
 
-    def get_control_widget(self, opt: str, params: "Option") -> Gtk.Widget:
+    def get_control_widget(self, opt: str, params: Option) -> Gtk.Widget:
         if params["type"] == bool:
             c = Gtk.CheckButton(label=params["name"])
 
@@ -329,7 +330,7 @@ class PluginDialog(Gtk.ApplicationWindow):
             self.model.insert_sorted(plugin_item, self._model_sort_func)
         self.listbox.select_row(self.listbox.get_row_at_index(0))
 
-    _T = TypeVar("_T", bound="BasePlugin")
+    _T = TypeVar("_T", bound=BasePlugin)
 
     def plugin_state_changed(self, _plugins: PluginManager[_T], name: str, loaded: bool) -> None:
         logging.debug(f"{name} {loaded}")

--- a/blueman/main/DbusService.py
+++ b/blueman/main/DbusService.py
@@ -1,13 +1,10 @@
 import logging
 import sys
 import traceback
-from typing import Any, overload, TYPE_CHECKING
+from typing import Any, overload, Literal
 from collections.abc import Callable, Collection, Mapping
 
 from gi.repository import Gio, GLib
-
-if TYPE_CHECKING:
-    from typing import Literal
 
 
 class DbusError(Exception):
@@ -46,7 +43,7 @@ class DbusService:
     @overload
     def add_method(self, name: str, arguments: tuple[str, ...], return_values: tuple[str, ...],
                    method: Callable[..., Any], pass_sender: bool = False,
-                   is_async: "Literal[False]" = False) -> None:
+                   is_async: Literal[False] = False) -> None:
         ...
 
     def add_method(self, name: str, arguments: tuple[str, ...], return_values: str | tuple[str, ...],

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -2,7 +2,7 @@ import logging
 from gettext import gettext as _
 from html import escape
 from xml.etree import ElementTree
-from typing import overload, TYPE_CHECKING, Any
+from typing import overload, Any, Literal
 from collections.abc import Callable
 from blueman.bluemantyping import ObjectPath
 
@@ -19,9 +19,6 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-
-if TYPE_CHECKING:
-    from typing import Literal
 
 
 class BluezErrorCanceled(DbusError):
@@ -104,7 +101,7 @@ class BluezAgent(DbusService):
     def ask_passkey(
             self,
             dialog_msg: str,
-            is_numeric: "Literal[True]",
+            is_numeric: Literal[True],
             object_path: ObjectPath,
             ok: Callable[[int], None],
             err: Callable[[BluezErrorCanceled | BluezErrorRejected], None]
@@ -115,7 +112,7 @@ class BluezAgent(DbusService):
     def ask_passkey(
             self,
             dialog_msg: str,
-            is_numeric: "Literal[False]",
+            is_numeric: Literal[False],
             object_path: ObjectPath,
             ok: Callable[[str], None],
             err: Callable[[BluezErrorCanceled | BluezErrorRejected], None]

--- a/blueman/main/indicators/GtkStatusIcon.py
+++ b/blueman/main/indicators/GtkStatusIcon.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, overload, cast
+from typing import overload, cast, Protocol
 from collections.abc import Callable, Iterable
 
 import gi
@@ -9,28 +9,25 @@ from blueman.main.indicators.IndicatorInterface import IndicatorInterface
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from blueman.Functions import create_menuitem
+from blueman.plugins.applet.Menu import MenuItemDict, SubmenuItemDict
 
-if TYPE_CHECKING:
-    from typing_extensions import Protocol
 
-    from blueman.plugins.applet.Menu import MenuItemDict, SubmenuItemDict
-
-    class MenuItemActivator(Protocol):
-        def __call__(self, *idx: int) -> None:
-            ...
+class MenuItemActivator(Protocol):
+    def __call__(self, *idx: int) -> None:
+        ...
 
 
 @overload
-def build_menu(items: Iterable[tuple[int, "MenuItemDict"]], activate: "MenuItemActivator") -> Gtk.Menu:
+def build_menu(items: Iterable[tuple[int, MenuItemDict]], activate: MenuItemActivator) -> Gtk.Menu:
     ...
 
 
 @overload
-def build_menu(items: Iterable[tuple[int, "SubmenuItemDict"]], activate: Callable[[int], None]) -> Gtk.Menu:
+def build_menu(items: Iterable[tuple[int, SubmenuItemDict]], activate: Callable[[int], None]) -> Gtk.Menu:
     ...
 
 
-def build_menu(items: Iterable[tuple[int, "SubmenuItemDict"]], activate: Callable[..., None]) -> Gtk.Menu:
+def build_menu(items: Iterable[tuple[int, SubmenuItemDict]], activate: Callable[..., None]) -> Gtk.Menu:
     menu = Gtk.Menu()
     for index, item in items:
         if 'text' in item and 'icon_name' in item:
@@ -91,5 +88,5 @@ class GtkStatusIcon(IndicatorInterface):
     def set_visibility(self, visible: bool) -> None:
         self.indicator.props.visible = visible
 
-    def set_menu(self, menu: Iterable["MenuItemDict"]) -> None:
+    def set_menu(self, menu: Iterable[MenuItemDict]) -> None:
         self._menu = build_menu(((item["id"], item) for item in menu), self._on_activate)

--- a/blueman/main/indicators/IndicatorInterface.py
+++ b/blueman/main/indicators/IndicatorInterface.py
@@ -1,9 +1,7 @@
 from abc import abstractmethod, ABCMeta
-from typing import TYPE_CHECKING
 from collections.abc import Iterable
 
-if TYPE_CHECKING:
-    from blueman.plugins.applet.Menu import MenuItemDict
+from blueman.plugins.applet.Menu import MenuItemDict
 
 
 class IndicatorNotAvailable(RuntimeError):
@@ -28,5 +26,5 @@ class IndicatorInterface(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def set_menu(self, menu: Iterable["MenuItemDict"]) -> None:
+    def set_menu(self, menu: Iterable[MenuItemDict]) -> None:
         ...

--- a/blueman/plugins/BasePlugin.py
+++ b/blueman/plugins/BasePlugin.py
@@ -1,29 +1,26 @@
 import logging
 import weakref
 from gettext import gettext as _
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar, TypedDict
 
 from gi.repository import Gio
 
 
-if TYPE_CHECKING:
-    from typing_extensions import TypedDict
+# type is actually Type[T] and default is T but this is not supported by Python 3.10's typing.TypedDict
+class OptionBase(TypedDict):
+    type: type
+    default: Any
 
-    # type is actually Type[T] and default is T but this is not supported https://github.com/python/mypy/issues/3863
-    class OptionBase(TypedDict):
-        type: type
-        default: Any
 
-    class Option(OptionBase, total=False):
-        name: str
-        desc: str
-        range: tuple[int, int]
+class Option(OptionBase, total=False):
+    name: str
+    desc: str
+    range: tuple[int, int]
 
-    class GSettings(TypedDict):
-        schema: str
-        path: None
-else:
-    Option = dict
+
+class GSettings(TypedDict):
+    schema: str
+    path: None
 
 
 class BasePlugin:
@@ -39,9 +36,9 @@ class BasePlugin:
 
     __instance__ = None
 
-    __gsettings__: "GSettings"
+    __gsettings__: GSettings
 
-    __options__: dict[str, "Option"] = {}
+    __options__: dict[str, Option] = {}
 
     def __init__(self, *_args: object) -> None:
         if self.__options__:

--- a/blueman/plugins/ServicePlugin.py
+++ b/blueman/plugins/ServicePlugin.py
@@ -1,4 +1,4 @@
-from typing import Union, TYPE_CHECKING
+from typing import Literal, Union, TYPE_CHECKING
 
 
 import gi
@@ -6,8 +6,6 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 if TYPE_CHECKING:
-    from typing import Literal
-
     from blueman.main.Services import BluemanServices
 
 
@@ -48,7 +46,7 @@ class ServicePlugin:
         pass
 
     # return true if apply button should be sensitive or false if not. -1 to force disabled
-    def on_query_apply_state(self) -> Union[bool, "Literal[-1]"]:
+    def on_query_apply_state(self) -> Union[bool, Literal[-1]]:
         return False
 
     def on_apply(self) -> None:

--- a/blueman/plugins/applet/Menu.py
+++ b/blueman/plugins/applet/Menu.py
@@ -1,33 +1,33 @@
 from gettext import gettext as _
-from typing import TYPE_CHECKING
 from collections.abc import Iterable, Callable, Iterator, Mapping, Sequence
+from typing import TypedDict
 
 from gi.repository import GLib
 
 from blueman.plugins.AppletPlugin import AppletPlugin
 
-if TYPE_CHECKING:
-    from typing_extensions import TypedDict
 
-    class SubmenuItemDict(TypedDict):
-        text: str
-        markup: bool
-        icon_name: str
-        sensitive: bool
-        tooltip: str | None
-        callback: Callable[[], None]
+class SubmenuItemDict(TypedDict):
+    text: str
+    markup: bool
+    icon_name: str
+    sensitive: bool
+    tooltip: str | None
+    callback: Callable[[], None]
 
-    class MenuItemDictBase(SubmenuItemDict):
-        id: int
 
-    class MenuItemDict(MenuItemDictBase, total=False):
-        submenu: Iterable["SubmenuItemDict"]
+class MenuItemDictBase(SubmenuItemDict):
+    id: int
+
+
+class MenuItemDict(MenuItemDictBase, total=False):
+    submenu: Iterable[SubmenuItemDict]
 
 
 class MenuItem:
     def __init__(self, menu_plugin: "Menu", owner: AppletPlugin, priority: tuple[int, int], text: str | None,
                  markup: bool, icon_name: str | None, tooltip: str | None, callback: Callable[[], None] | None,
-                 submenu_function: Callable[[], Iterable["SubmenuItemDict"]] | None, visible: bool, sensitive: bool):
+                 submenu_function: Callable[[], Iterable[SubmenuItemDict]] | None, visible: bool, sensitive: bool):
         self._menu_plugin = menu_plugin
         self._owner = owner
         self._priority = priority
@@ -127,7 +127,7 @@ class Menu(AppletPlugin):
     def add(self, owner: AppletPlugin, priority: int | tuple[int, int], text: str | None = None,
             markup: bool = False, icon_name: str | None = None, tooltip: str | None = None,
             callback: Callable[[], None] | None = None,
-            submenu_function: Callable[[], Iterable["SubmenuItemDict"]] | None = None,
+            submenu_function: Callable[[], Iterable[SubmenuItemDict]] | None = None,
             visible: bool = True, sensitive: bool = True) -> MenuItem:
 
         if isinstance(priority, int):

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import logging
 from html import escape
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, TypedDict, Union
 from collections.abc import Callable
 from blueman.bluemantyping import ObjectPath, BtAddress
 
@@ -20,21 +20,21 @@ from blueman.plugins.AppletPlugin import AppletPlugin
 
 from gi.repository import GLib, Gio
 
-if TYPE_CHECKING:
-    from typing_extensions import TypedDict
 
-    class TransferDict(TypedDict):
-        path: str
-        size: int | None
-        name: str
+class TransferDict(TypedDict):
+    path: str
+    size: int | None
+    name: str
 
-    class PendingTransferDict(TypedDict):
-        transfer_path: str
-        address: BtAddress
-        root: str
-        filename: str
-        size: int | None
-        name: str
+
+class PendingTransferDict(TypedDict):
+    transfer_path: str
+    address: BtAddress
+    root: str
+    filename: str
+    size: int | None
+    name: str
+
 
 NotificationType = Union[_NotificationBubble, _NotificationDialog]
 
@@ -63,8 +63,8 @@ class Agent(DbusService):
 
         self._allowed_devices: list[str] = []
         self._notification: NotificationType | None = None
-        self._pending_transfer: Optional["PendingTransferDict"] = None
-        self.transfers: dict[str, "TransferDict"] = {}
+        self._pending_transfer: Optional[PendingTransferDict] = None
+        self.transfers: dict[str, TransferDict] = {}
 
     def register_at_manager(self) -> None:
         AgentManager().register_agent(self.__agent_path)

--- a/blueman/plugins/manager/PulseAudioProfile.py
+++ b/blueman/plugins/manager/PulseAudioProfile.py
@@ -1,6 +1,5 @@
 from gettext import gettext as _
 import logging
-from typing import TYPE_CHECKING
 from collections.abc import Mapping, Sequence
 
 from blueman.bluez.Device import Device
@@ -14,14 +13,12 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
-
-if TYPE_CHECKING:
-    from blueman.main.PulseAudioUtils import CardInfo  # noqa: F401
+from blueman.main.PulseAudioUtils import CardInfo
 
 
 class PulseAudioProfile(ManagerPlugin, MenuItemsProvider):
     def on_load(self) -> None:
-        self.devices: dict[str, "CardInfo"] = {}
+        self.devices: dict[str, CardInfo] = {}
 
         self.deferred: list[Device] = []
 
@@ -45,7 +42,7 @@ class PulseAudioProfile(ManagerPlugin, MenuItemsProvider):
     def on_pa_event(self, utils: PulseAudioUtils, event: int, idx: int) -> None:
         logging.debug(f"{event} {idx}")
 
-        def get_card_cb(card: "CardInfo") -> None:
+        def get_card_cb(card: CardInfo) -> None:
             drivers = ("module-bluetooth-device.c",
                        "module-bluez4-device.c",
                        "module-bluez5-device.c")
@@ -66,7 +63,7 @@ class PulseAudioProfile(ManagerPlugin, MenuItemsProvider):
                 utils.get_card(idx, get_card_cb)
 
     def query_pa(self, device: Device, item: Gtk.MenuItem) -> None:
-        def list_cb(cards: Mapping[str, "CardInfo"]) -> None:
+        def list_cb(cards: Mapping[str, CardInfo]) -> None:
             for c in cards.values():
                 if c["proplist"]["device.string"] == device['Address']:
                     self.devices[device['Address']] = c

--- a/blueman/plugins/services/Network.py
+++ b/blueman/plugins/services/Network.py
@@ -2,7 +2,7 @@ from gettext import gettext as _
 from random import randint
 import logging
 import ipaddress
-from typing import cast, Union, TYPE_CHECKING
+from typing import cast, Literal, Union
 
 from blueman.Functions import have, get_local_interfaces
 from blueman.main.Builder import Builder
@@ -14,9 +14,6 @@ from blueman.gui.CommonUi import ErrorDialog
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gio, Gtk, GObject
-
-if TYPE_CHECKING:
-    from typing import Literal
 
 
 class Network(ServicePlugin):
@@ -108,7 +105,7 @@ class Network(ServicePlugin):
 
         entry.props.secondary_icon_name = None
 
-    def on_query_apply_state(self) -> Union[bool, "Literal[-1]"]:
+    def on_query_apply_state(self) -> Union[bool, Literal[-1]]:
         opts = self.get_options()
         if not opts:
             return False

--- a/stubs/_blueman.pyi
+++ b/stubs/_blueman.pyi
@@ -1,5 +1,4 @@
-from typing import List, Dict, Optional
-from typing_extensions import TypedDict
+from typing import List, Dict, Optional, TypedDict
 
 ERR: Dict[int, str]
 RFCOMM_HANGUP_NOW: int


### PR DESCRIPTION
Replace all imports from typing_extensions with standard typing, move them out of TYPE_CHECKING checks and use defined types directly instead of as strings