### PR TITLE
Make connection notifications transient

### DIFF
--- a/blueman/gui/Notification.py
+++ b/blueman/gui/Notification.py
@@ -162,6 +162,12 @@ class _NotificationBubble(Gio.DBusProxy):
         self._timeout = timeout
         self._return_id = None
 
+        if self._timeout > 0:
+            try:
+                self.set_hint('transient', True)
+            except ValueError:
+                pass
+
         if icon_name:
             self._app_icon = icon_name
         elif image_data:

--- a/blueman/gui/Notification.py
+++ b/blueman/gui/Notification.py
@@ -24,7 +24,7 @@ class Fade(AnimBase):
 
 
 class _NotificationDialog(Gtk.MessageDialog):
-    def __init__(self, summary: str, message: str, _timeout: int = -1,
+    def __init__(self, summary: str, message: str, _timeout: int = -1, _transient: bool = False,
                  actions: Iterable[tuple[str, str]] | None = None,
                  actions_cb: Callable[[str], None] | None = None, icon_name: str | None = None,
                  image_data: GdkPixbuf.Pixbuf | None = None) -> None:
@@ -119,7 +119,7 @@ class _NotificationDialog(Gtk.MessageDialog):
 
 
 class _NotificationBubble(Gio.DBusProxy):
-    def __init__(self, summary: str, message: str, timeout: int = -1,
+    def __init__(self, summary: str, message: str, timeout: int = -1, transient: bool = False,
                  actions: Iterable[tuple[str, str]] | None = None,
                  actions_cb: Callable[[str], None] | None = None, icon_name: str | None = None,
                  image_data: GdkPixbuf.Pixbuf | None = None) -> None:
@@ -162,7 +162,7 @@ class _NotificationBubble(Gio.DBusProxy):
         self._timeout = timeout
         self._return_id = None
 
-        if self._timeout > 0:
+        if transient:
             try:
                 self.set_hint('transient', True)
             except ValueError:
@@ -273,9 +273,16 @@ class _NotificationBubble(Gio.DBusProxy):
         self._return_id = None
 
 
-def Notification(summary: str, message: str, timeout: int = -1, actions: Iterable[tuple[str, str]] | None = None,
-                 actions_cb: Callable[[str], None] | None = None, icon_name: str | None = None,
-                 image_data: GdkPixbuf.Pixbuf | None = None) -> _NotificationBubble | _NotificationDialog:
+def Notification(
+    summary: str,
+    message: str,
+    timeout: int = -1,
+    transient: bool = False,
+    actions: Iterable[tuple[str, str]] | None = None,
+    actions_cb: Callable[[str], None] | None = None,
+    icon_name: str | None = None,
+    image_data: GdkPixbuf.Pixbuf | None = None
+) -> _NotificationBubble | _NotificationDialog:
 
     forced_fallback = not Gio.Settings(schema_id='org.blueman.general')['notification-daemon']
     try:
@@ -295,4 +302,4 @@ def Notification(summary: str, message: str, timeout: int = -1, actions: Iterabl
     else:
         klass = _NotificationBubble
 
-    return klass(summary, message, timeout, actions, actions_cb, icon_name, image_data)
+    return klass(summary, message, timeout, transient, actions, actions_cb, icon_name, image_data)

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -229,8 +229,8 @@ class BluezAgent(DbusService):
             notify_message += "\n" + _("Confirm value for authentication:") + f" <b>{passkey:06}</b>"
         actions = [("confirm", _("Confirm")), ("deny", _("Deny"))]
 
-        self._notification = Notification("Bluetooth", notify_message, 0, actions, on_confirm_action,
-                                          icon_name="blueman")
+        self._notification = Notification("Bluetooth", notify_message, 0,
+                                          actions=actions, actions_cb=on_confirm_action, icon_name="blueman")
         self._notification.show()
 
     def _on_request_authorization(self, object_path: ObjectPath, ok: Callable[[], None],
@@ -260,6 +260,7 @@ class BluezAgent(DbusService):
                    ("accept", _("Accept")),
                    ("deny", _("Deny"))]
 
-        n = Notification(_("Bluetooth Authentication"), notify_message, 0, actions, on_auth_action, icon_name="blueman")
+        n = Notification(_("Bluetooth Authentication"), notify_message, 0,
+                         actions=actions, actions_cb=on_auth_action, icon_name="blueman")
         n.show()
         self._service_notifications.append(n)

--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -30,11 +30,17 @@ class ConnectionNotifier(AppletPlugin):
                 self._notifications[path] = notification = Notification(
                     device.display_name,
                     _('Connected'),
-                    icon_name=device["Icon"]
+                    icon_name=device["Icon"],
+                    timeout=5,
                 )
                 notification.show()
             else:
-                Notification(device.display_name, _('Disconnected'), icon_name=device["Icon"]).show()
+                Notification(
+                    device.display_name,
+                    _('Disconnected'),
+                    icon_name=device["Icon"],
+                    timeout=5,
+                ).show()
 
     def _on_battery_update(self, path: ObjectPath, value: int) -> None:
         notification = self._notifications.pop(path, None)

--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -31,7 +31,7 @@ class ConnectionNotifier(AppletPlugin):
                     device.display_name,
                     _('Connected'),
                     icon_name=device["Icon"],
-                    timeout=5,
+                    transient=True,
                 )
                 notification.show()
             else:
@@ -39,7 +39,7 @@ class ConnectionNotifier(AppletPlugin):
                     device.display_name,
                     _('Disconnected'),
                     icon_name=device["Icon"],
-                    timeout=5,
+                    transient=True,
                 ).show()
 
     def _on_battery_update(self, path: ObjectPath, value: int) -> None:

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -128,7 +128,7 @@ class Agent(DbusService):
                 _("Incoming file over Bluetooth"),
                 _("Incoming file %(0)s from %(1)s") % {"0": "<b>" + escape(filename) + "</b>",
                                                        "1": "<b>" + escape(name) + "</b>"},
-                30000, 
+                30000,
                 actions=[("accept", _("Accept")), ("reject", _("Reject"))], actions_cb=on_action, icon_name="blueman"
             )
             notification.show()

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -128,8 +128,8 @@ class Agent(DbusService):
                 _("Incoming file over Bluetooth"),
                 _("Incoming file %(0)s from %(1)s") % {"0": "<b>" + escape(filename) + "</b>",
                                                        "1": "<b>" + escape(name) + "</b>"},
-                30000, [("accept", _("Accept")), ("reject", _("Reject"))], on_action,
-                icon_name="blueman"
+                30000, 
+                actions=[("accept", _("Accept")), ("reject", _("Reject"))], actions_cb=on_action, icon_name="blueman"
             )
             notification.show()
         # Device is trusted or was already allowed, larger file -> display a notification, but auto-accept


### PR DESCRIPTION
This PR sets a timeout for connection notifications and sets the transient hint so that these notifications do not remain in the notification list.

This has been a bother for me, with my Bluetooth mouse connecting and disconnecting and piling up a list of irrelevant notifications.