### PR TITLE
StatusNotifierItem: announce version and status

### DIFF
--- a/blueman/main/indicators/StatusNotifierItem.py
+++ b/blueman/main/indicators/StatusNotifierItem.py
@@ -13,8 +13,11 @@ from blueman.plugins.applet.Menu import MenuItemDict, SubmenuItemDict
 
 class MenuService(DbusService):
     def __init__(self, on_activate_menu_item: MenuItemActivator) -> None:
-        super().__init__(None, "com.canonical.dbusmenu", "/org/blueman/sni/menu", Gio.BusType.SESSION)
+        super().__init__(None, "com.canonical.dbusmenu", "/org/blueman/sni/menu", Gio.BusType.SESSION,
+                         {"Version": "u", "Status": "s"})
         self._items: OrderedDict[int, MenuItemDict] = OrderedDict()
+        self.Version = 1
+        self.Status = "normal"
         self._revision = 0
         self._revision_advertised = -1
         self._on_activate = on_activate_menu_item


### PR DESCRIPTION
Fixes #2598 

According to https://bazaar.launchpad.net/~dbusmenu-team/libdbusmenu/trunk.16.10/view/head:/libdbusmenu-glib/dbus-menu.xml, there should be 4 properties, but I am implemented 2, which makes sense.

And here https://bazaar.launchpad.net/~dbusmenu-team/libdbusmenu/trunk.16.10/view/head:/libdbusmenu-glib/server.c
you can see, than libdbusmenu announces version 3.