### PR TITLE
Manager: Hide bt status switch when PowerManager is not available

### DIFF
--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -80,6 +80,10 @@ class ManagerToolbar:
         powered = adapter is not None and adapter["Powered"]
         self.b_search.props.sensitive = powered and not (adapter and adapter["Discovering"])
 
+        pm_enabled = "PowerManager" in self.blueman.Applet.QueryPlugins()
+        bt_status_box = self.blueman.builder.get_widget("bt_status_box", Gtk.Box)
+        bt_status_box.set_visible(pm_enabled)
+
         tree_iter = self.blueman.List.selected()
         opacity = 0.5
         if tree_iter is None:


### PR DESCRIPTION
This will hide the switch if the PowerManager plugin isn't loaded.