### PR TITLE
Use GActions where possible

### DIFF
--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -35,15 +35,6 @@ class ManagerMenu:
         self.item_view = self.blueman.builder.get_widget("item_view", Gtk.MenuItem)
         self.item_help = self.blueman.builder.get_widget("item_help", Gtk.MenuItem)
 
-        item_toolbar = blueman.builder.get_widget("show_tb_item", Gtk.CheckMenuItem)
-        self.blueman.Config.bind("show-toolbar", item_toolbar, "active", Gio.SettingsBindFlags.DEFAULT)
-
-        item_statusbar = blueman.builder.get_widget("show_sb_item", Gtk.CheckMenuItem)
-        self.blueman.Config.bind("show-statusbar", item_statusbar, "active", Gio.SettingsBindFlags.DEFAULT)
-
-        item_unnamed = blueman.builder.get_widget("hide_unnamed_item", Gtk.CheckMenuItem)
-        self.blueman.Config.bind("hide-unnamed", item_unnamed, "active", Gio.SettingsBindFlags.DEFAULT)
-
         self.device_menu: ManagerDeviceMenu | None = None
 
         self._sort_alias_item = blueman.builder.get_widget("sort_name_item", Gtk.CheckMenuItem)
@@ -54,9 +45,6 @@ class ManagerMenu:
             self._sort_alias_item.props.active = True
         else:
             self._sort_timestamp_item.props.active = True
-
-        sort_descending_item = blueman.builder.get_widget("sort_descending_item", Gtk.CheckMenuItem)
-        self.blueman.Config.bind("sort-descending", sort_descending_item, "active", Gio.SettingsBindFlags.DEFAULT)
 
         self.Search = blueman.builder.get_widget("search_item", Gtk.ImageMenuItem)
 
@@ -93,6 +81,12 @@ class ManagerMenu:
         elif key == "hide-unnamed":
             logging.debug("refilter")
             self.blueman.List.filter.refilter()
+        elif key == "show-toolbar":
+            toolbar = self.blueman.builder.get_widget("toolbar", Gtk.Toolbar)
+            toolbar.set_visible(value)
+        elif key == "show-statusbar":
+            statusbar = self.blueman.builder.get_widget("statusbar", Gtk.Box)
+            statusbar.set_visible(value)
 
     def on_device_selected(self, _lst: ManagerDeviceList, device: Device | None, tree_iter: Gtk.TreeIter) -> None:
         if tree_iter and device:

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -32,9 +32,6 @@ class ManagerMenu:
         self.item_adapter = self.blueman.builder.get_widget("item_adapter", Gtk.MenuItem)
         self.item_device = self.blueman.builder.get_widget("item_device", Gtk.MenuItem)
 
-        self.item_view = self.blueman.builder.get_widget("item_view", Gtk.MenuItem)
-        self.item_help = self.blueman.builder.get_widget("item_help", Gtk.MenuItem)
-
         self.device_menu: ManagerDeviceMenu | None = None
 
         self._sort_alias_item = blueman.builder.get_widget("sort_name_item", Gtk.CheckMenuItem)

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -63,11 +63,10 @@ class ManagerMenu:
         self._sort_alias_item.connect("activate", self._on_sorting_changed, "alias")
         self._sort_timestamp_item.connect("activate", self._on_sorting_changed, "timestamp")
 
-    def _on_sorting_changed(self, btn: Gtk.CheckMenuItem, sort_opt: str) -> None:
-        if sort_opt == 'alias' and btn.props.active:
-            self.Config['sort-by'] = "alias"
-        elif sort_opt == "timestamp" and btn.props.active:
-            self.Config['sort-by'] = "timestamp"
+    def _on_sorting_changed(self, _btn: Gtk.CheckMenuItem, sort_opt: str) -> None:
+        action = self.blueman.lookup_action("sort-by")
+        assert action is not None
+        action.change_state(GLib.Variant.new_string(sort_opt))
 
     def _on_settings_changed(self, settings: Gio.Settings, key: str) -> None:
         value = settings[key]

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -1,4 +1,3 @@
-from gettext import gettext as _
 import logging
 from typing import TYPE_CHECKING, Any
 from collections.abc import Sequence
@@ -9,9 +8,7 @@ from blueman.bluez.Device import Device
 from blueman.bluez.Manager import Manager
 from blueman.gui.manager.ManagerDeviceList import ManagerDeviceList
 from blueman.gui.manager.ManagerDeviceMenu import ManagerDeviceMenu
-from blueman.gui.CommonUi import show_about_dialog
-from blueman.Constants import WEBSITE
-from blueman.Functions import launch, adapter_path_to_name
+from blueman.Functions import adapter_path_to_name
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -38,16 +35,6 @@ class ManagerMenu:
         self.item_view = self.blueman.builder.get_widget("item_view", Gtk.MenuItem)
         self.item_help = self.blueman.builder.get_widget("item_help", Gtk.MenuItem)
 
-        report_item = blueman.builder.get_widget("report", Gtk.ImageMenuItem)
-        report_item.connect("activate", lambda x: launch(f"xdg-open {WEBSITE}/issues"))
-
-        help_item = blueman.builder.get_widget("help", Gtk.ImageMenuItem)
-        assert self.blueman.window is not None
-        widget = self.blueman.window.get_toplevel()
-        assert isinstance(widget, Gtk.Window)
-        window = widget
-        help_item.connect("activate", lambda x: show_about_dialog('Blueman ' + _('Device Manager'), parent=window))
-
         item_toolbar = blueman.builder.get_widget("show_tb_item", Gtk.CheckMenuItem)
         self.blueman.Config.bind("show-toolbar", item_toolbar, "active", Gio.SettingsBindFlags.DEFAULT)
 
@@ -71,20 +58,9 @@ class ManagerMenu:
         sort_descending_item = blueman.builder.get_widget("sort_descending_item", Gtk.CheckMenuItem)
         self.blueman.Config.bind("sort-descending", sort_descending_item, "active", Gio.SettingsBindFlags.DEFAULT)
 
-        item_plugins = blueman.builder.get_widget("plugins_item", Gtk.ImageMenuItem)
-        item_plugins.connect('activate', self._on_plugin_dialog_activate)
-
-        item_services = blueman.builder.get_widget("services_item", Gtk.ImageMenuItem)
-        item_services.connect('activate', lambda *args: launch("blueman-services", name=_("Service Preferences")))
-
-        self.Search = search_item = blueman.builder.get_widget("search_item", Gtk.ImageMenuItem)
-        search_item.connect("activate", lambda x: self.blueman.inquiry())
+        self.Search = blueman.builder.get_widget("search_item", Gtk.ImageMenuItem)
 
         self._adapter_settings = blueman.builder.get_widget("prefs_item", Gtk.ImageMenuItem)
-        self._adapter_settings.connect("activate", lambda x: self.blueman.adapter_properties())
-
-        exit_item = blueman.builder.get_widget("exit_item", Gtk.ImageMenuItem)
-        exit_item.connect("activate", lambda x: self.blueman.quit())
 
         self._manager = Manager()
         self._manager.connect_signal("adapter-added", self.on_adapter_added)
@@ -202,8 +178,3 @@ class ManagerMenu:
         else:
             self.Search.props.visible = False
             self._adapter_settings.props.visible = False
-
-    def _on_plugin_dialog_activate(self, _item: Gtk.MenuItem) -> None:
-        def cb(_proxy: Gio.DBusProxy, _res: Any, _userdata: Any) -> None:
-            pass
-        self.blueman.Applet.OpenPluginDialog(result_handler=cb)

--- a/blueman/gui/manager/ManagerToolbar.py
+++ b/blueman/gui/manager/ManagerToolbar.py
@@ -1,7 +1,6 @@
 from gettext import gettext as _
 import logging
 from typing import TYPE_CHECKING
-from collections.abc import Callable
 from blueman.bluemantyping import ObjectPath
 
 import gi
@@ -27,36 +26,23 @@ class ManagerToolbar:
         self.blueman.List.connect("adapter-property-changed", self.on_adapter_property_changed)
 
         self.b_search = blueman.builder.get_widget("b_search", Gtk.ToolButton)
-        self.b_search.connect("clicked", lambda button: blueman.inquiry())
-
         self.b_bond = blueman.builder.get_widget("b_bond", Gtk.ToolButton)
-        self.b_bond.connect("clicked", self.on_action, self.blueman.bond)
-
         self.b_trust = blueman.builder.get_widget("b_trust", Gtk.ToolButton)
-        self.b_trust.connect("clicked", self.on_action, self.blueman.toggle_trust)
 
         self.b_trust.props.label = _("Untrust")
         (size, nsize) = Gtk.Widget.get_preferred_size(self.b_trust)
         self.b_trust.props.label = _("Trust")
         (size2, nsize2) = Gtk.Widget.get_preferred_size(self.b_trust)
-
         self.b_trust.props.width_request = max(size.width, size2.width)
 
         self.b_remove = blueman.builder.get_widget("b_remove", Gtk.ToolButton)
-        self.b_remove.connect("clicked", self.on_action, self.blueman.remove)
 
         self.b_send = blueman.builder.get_widget("b_send", Gtk.ToolButton)
         self.b_send.props.sensitive = False
-        self.b_send.connect("clicked", self.on_action, self.blueman.send)
 
         self.b_bluetooth_status = blueman.builder.get_widget("sw_bluetooth_status", Gtk.Switch)
 
         self.on_adapter_changed(blueman.List, blueman.List.get_adapter_path())
-
-    def on_action(self, _button: Gtk.ToolButton, func: Callable[[Device], None]) -> None:
-        device = self.blueman.List.get_selected_device()
-        if device is not None:
-            func(device)
 
     def on_adapter_property_changed(self, _lst: ManagerDeviceList, adapter: Adapter,
                                     key_value: tuple[str, object]) -> None:

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from blueman.bluez.Adapter import Adapter
 from blueman.bluez.Device import Device
 from blueman.bluez.Manager import Manager
+from blueman.Constants import WEBSITE
 from blueman.Functions import *
 from blueman.gui.manager.ManagerDeviceList import ManagerDeviceList
 from blueman.gui.manager.ManagerToolbar import ManagerToolbar
@@ -15,7 +16,7 @@ from blueman.gui.manager.ManagerStats import ManagerStats
 from blueman.gui.manager.ManagerProgressbar import ManagerProgressbar
 from blueman.main.Builder import Builder
 from blueman.main.DBusProxies import AppletService, DBusProxyFailed, DBus, AppletServiceApplication
-from blueman.gui.CommonUi import ErrorDialog
+from blueman.gui.CommonUi import ErrorDialog, show_about_dialog
 from blueman.gui.Notification import Notification
 from blueman.main.PluginManager import PluginManager
 import blueman.plugins.manager
@@ -79,6 +80,11 @@ class Blueman(Gtk.Application):
         self.register_action("trust-toggle", self.simple_action)
         self.register_action("remove", self.simple_action)
         self.register_action("send", self.simple_action)
+        self.register_action("report", self.simple_action)
+        self.register_action("help", self.simple_action)
+        self.register_action("plugins", self.simple_action)
+        self.register_action("services", self.simple_action)
+        self.register_action("preferences", self.simple_action)
 
         self.register_action("Quit", self.simple_action)
         self.set_accels_for_action("app.Quit", ["<Ctrl>q", "<Ctrl>w"])
@@ -227,6 +233,18 @@ class Blueman(Gtk.Application):
                 device = self.List.get_selected_device()
                 if device is not None:
                     self.send(device)
+            case "report":
+                launch(f"xdg-open {WEBSITE}/issues", system=True)
+            case "help":
+                widget = self.window.get_toplevel() if self.window else None
+                assert isinstance(widget, Gtk.Window)
+                show_about_dialog('Blueman ' + _('Device Manager'), parent=widget)
+            case "plugins":
+                self.Applet.OpenPluginDialog()
+            case "services":
+                launch("blueman-services", name=_("Service Preferences"))
+            case "preferences":
+                self.adapter_properties()
             case _ as name:
                 logging.error(f"Unknown action: {name}")
 

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -87,6 +87,7 @@ class Blueman(Gtk.Application):
         self.register_settings_action("show-toolbar")
         self.register_settings_action("show-statusbar")
         self.register_settings_action("hide-unnamed")
+        self.register_settings_action("sort-by")
 
         bt_status_action = Gio.SimpleAction.new_stateful("bluetooth_status", None, GLib.Variant.new_boolean(False))
         bt_status_action.connect("change-state", self._on_bt_state_changed)

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -65,12 +65,6 @@ class Blueman(Gtk.Application):
 
         self.builder = Builder("manager-main.ui")
 
-        toolbar = self.builder.get_widget("toolbar", Gtk.Toolbar)
-        statusbar = self.builder.get_widget("statusbar", Gtk.Box)
-
-        self.Config.bind("show-toolbar", toolbar, "visible", Gio.SettingsBindFlags.DEFAULT)
-        self.Config.bind("show-statusbar", statusbar, "visible", Gio.SettingsBindFlags.DEFAULT)
-
         self._infobar = self.builder.get_widget("message_area", Gtk.InfoBar)
         self._infobar.connect("response", self._infobar_response)
         self._infobar_bt: str = ""
@@ -88,6 +82,11 @@ class Blueman(Gtk.Application):
 
         self.register_action("Quit", self.simple_action)
         self.set_accels_for_action("app.Quit", ["<Ctrl>q", "<Ctrl>w"])
+
+        self.register_settings_action("sort-descending")
+        self.register_settings_action("show-toolbar")
+        self.register_settings_action("show-statusbar")
+        self.register_settings_action("hide-unnamed")
 
         bt_status_action = Gio.SimpleAction.new_stateful("bluetooth_status", None, GLib.Variant.new_boolean(False))
         bt_status_action.connect("change-state", self._on_bt_state_changed)

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -92,11 +92,6 @@ class Blueman(Gtk.Application):
             self.Plugins = PluginManager(ManagerPlugin, blueman.plugins.manager, self)
             self.Plugins.load_plugin()
 
-            # Add margin for resize grip or it will overlap
-            if self.window.get_has_resize_grip():
-                margin_right = statusbar.get_margin_right()
-                statusbar.set_margin_right(margin_right + 10)
-
             def on_applet_signal(_proxy: AppletService, _sender: str, signal_name: str, params: GLib.Variant) -> None:
                 action = self.lookup_action("bluetooth_status")
 

--- a/blueman/main/Manager.py
+++ b/blueman/main/Manager.py
@@ -74,6 +74,12 @@ class Blueman(Gtk.Application):
         self._infobar.connect("response", self._infobar_response)
         self._infobar_bt: str = ""
 
+        self.register_action("inquiry", self.simple_action)
+        self.register_action("bond", self.simple_action)
+        self.register_action("trust-toggle", self.simple_action)
+        self.register_action("remove", self.simple_action)
+        self.register_action("send", self.simple_action)
+
         self.register_action("Quit", self.simple_action)
         self.set_accels_for_action("app.Quit", ["<Ctrl>q", "<Ctrl>w"])
 
@@ -203,6 +209,24 @@ class Blueman(Gtk.Application):
         match action.get_name():
             case "Quit":
                 self.quit()
+            case "inquiry":
+                self.inquiry()
+            case "bond":
+                device = self.List.get_selected_device()
+                if device is not None:
+                    self.bond(device)
+            case "trust-toggle":
+                device = self.List.get_selected_device()
+                if device is not None:
+                    self.toggle_trust(device)
+            case "remove":
+                device = self.List.get_selected_device()
+                if device is not None:
+                    self.remove(device)
+            case "send":
+                device = self.List.get_selected_device()
+                if device is not None:
+                    self.send(device)
             case _ as name:
                 logging.error(f"Unknown action: {name}")
 

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -141,6 +141,7 @@
                     <property name="can-focus">False</property>
                     <child>
                       <object class="GtkCheckMenuItem" id="show_tb_item">
+                        <property name="action-name">app.show-toolbar</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Show _Toolbar</property>
@@ -149,6 +150,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckMenuItem" id="show_sb_item">
+                        <property name="action-name">app.show-statusbar</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Show _Statusbar</property>
@@ -157,6 +159,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckMenuItem" id="hide_unnamed_item">
+                        <property name="action-name">app.hide-unnamed</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Hide _unnamed devices</property>
@@ -206,6 +209,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckMenuItem" id="sort_descending_item">
+                                <property name="action-name">app.sort-descending</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">_Descending</property>

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -69,6 +69,7 @@
                     <property name="can-focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="search_item">
+                        <property name="action-name">app.inquiry</property>
                         <property name="label" translatable="yes">_Search</property>
                         <property name="can-focus">False</property>
                         <property name="use-underline">True</property>
@@ -90,6 +91,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="prefs_item">
+                        <property name="action-name">app.preferences</property>
                         <property name="label" translatable="yes">_Preferences</property>
                         <property name="can-focus">False</property>
                         <property name="use-underline">True</property>
@@ -105,6 +107,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="exit_item">
+                        <property name="action-name">app.Quit</property>
                         <property name="label" translatable="yes">_Exit</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -215,6 +218,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="plugins_item">
+                        <property name="action-name">app.plugins</property>
                         <property name="label" translatable="yes">_Plugins</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -225,6 +229,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="services_item">
+                        <property name="action-name">app.services</property>
                         <property name="label" translatable="yes">_Local Services</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -249,6 +254,7 @@
                     <property name="can-focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="report">
+                        <property name="action-name">app.report</property>
                         <property name="label" translatable="yes">_Report a Problem</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -265,6 +271,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="help">
+                        <property name="action-name">app.help</property>
                         <property name="label" translatable="yes">_Help</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.40.0 -->
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Created with Cambalache 0.94.1 -->
 <interface>
+  <!-- interface-name manager-main.ui -->
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkImage" id="ib_more_icon">
     <property name="visible">True</property>
@@ -288,6 +289,7 @@
             <property name="can-focus">False</property>
             <child>
               <object class="GtkToolButton" id="b_search">
+                <property name="action-name">app.inquiry</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
@@ -313,6 +315,7 @@
             </child>
             <child>
               <object class="GtkToolButton" id="b_bond">
+                <property name="action-name">app.bond</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
@@ -327,6 +330,7 @@
             </child>
             <child>
               <object class="GtkToolButton" id="b_trust">
+                <property name="action-name">app.trust-toggle</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
@@ -341,6 +345,7 @@
             </child>
             <child>
               <object class="GtkToolButton" id="b_remove">
+                <property name="action-name">app.remove</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
@@ -365,6 +370,7 @@
             </child>
             <child>
               <object class="GtkToolButton" id="b_send">
+                <property name="action-name">app.send</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Send file(s) to the device</property>


### PR DESCRIPTION
This supersedes #1927. As mentioned in there, RadioMenuItems don't work with GAction in Gtk3.

The next step is to move the `Blueman`/`ManagerDeviceList` object out of `ToolBar` and `ManagerMenu` as both connect to the same `ManagerDeviceList` signals to do mostly the same thing, update the UI.