### PR TITLE
os-release file may have comments

### DIFF
--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -344,8 +344,11 @@ def log_system_info() -> None:
         try:
             with path.open() as f:
                 for line in f:
+                    line = line.strip()
+                    if line.startswith("#"):
+                        continue
                     try:
-                        key, val = line.strip().split("=")
+                        key, val = line.split("=")
                         release_dict[key] = val.strip("\"")
                     except ValueError:
                         logging.error(f"Unable to parse line: {line}")

--- a/blueman/bluez/errors.py
+++ b/blueman/bluez/errors.py
@@ -130,8 +130,6 @@ __DICT_ERROR__ = {'org.bluez.Error.Failed': DBusFailedError,
 
 
 def parse_dbus_error(exception: GLib.Error) -> BluezDBusException:
-    global __DICT_ERROR__
-
     gerror, dbus_error, message = exception.message.split(':', 2)
     try:
         return __DICT_ERROR__[dbus_error](message)


### PR DESCRIPTION
I moved to openSUSE tumbleweed and it has several lines of comments, which fail to parse.

flake8 complains about the global in bluez.errors and removing it seems to work fine for me. Let me know if you want to ignore it instead.