### PR TITLE
Appletplugin: Plugins provide dbus interfaces

### DIFF
--- a/blueman/Functions.py
+++ b/blueman/Functions.py
@@ -39,7 +39,7 @@ import time
 import subprocess
 import cairo
 
-from blueman.main.DBusProxies import AppletService, DBusProxyFailed
+from blueman.main.DBusProxies import AppletService, AppletPowerManagerService, DBusProxyFailed
 from blueman.Constants import BIN_DIR, ICON_PATH, BLUETOOTHD_PATH
 
 import gi
@@ -58,6 +58,7 @@ __all__ = ["check_bluetooth_status", "launch", "setup_icon_path", "adapter_path_
 def check_bluetooth_status(message: str, exitfunc: Callable[[], Any]) -> None:
     try:
         applet = AppletService()
+        powermanager = AppletPowerManagerService()
     except DBusProxyFailed as e:
         logging.exception(e)
         print("Blueman applet needs to be running")
@@ -67,7 +68,7 @@ def check_bluetooth_status(message: str, exitfunc: Callable[[], Any]) -> None:
     if "PowerManager" not in applet.QueryPlugins():
         return
 
-    if not applet.GetBluetoothStatus():
+    if not powermanager.get_bluetooth_status():
         d = Gtk.MessageDialog(
             type=Gtk.MessageType.ERROR, icon_name="blueman",
             text=_("Bluetooth Turned Off"), secondary_text=message)
@@ -81,8 +82,8 @@ def check_bluetooth_status(message: str, exitfunc: Callable[[], Any]) -> None:
             exitfunc()
             return
 
-    applet.SetBluetoothStatus('(b)', True)
-    if not applet.GetBluetoothStatus():
+    powermanager.set_bluetooth_status(True)
+    if not powermanager.get_bluetooth_status():
         print('Failed to enable bluetooth')
         exitfunc()
 

--- a/blueman/main/Applet.py
+++ b/blueman/main/Applet.py
@@ -13,7 +13,6 @@ from blueman.bluez.Adapter import AnyAdapter
 from blueman.bluez.Device import AnyDevice
 import blueman.plugins.applet
 from blueman.main.PluginManager import PersistentPluginManager
-from blueman.main.DbusService import DbusService
 from blueman.plugins.AppletPlugin import AppletPlugin
 from blueman.plugins.applet.DBusService import DBusService
 from blueman.plugins.applet.Menu import Menu
@@ -47,10 +46,6 @@ class BluemanApplet(Gtk.Application):
         self.Manager.connect_signal('adapter-removed', self.on_adapter_removed)
         self.Manager.connect_signal('device-created', self.on_device_created)
         self.Manager.connect_signal('device-removed', self.on_device_removed)
-
-        self.DbusSvc = DbusService("org.blueman.Applet", "org.blueman.Applet", "/org/blueman/Applet",
-                                   Gio.BusType.SESSION)
-        self.DbusSvc.register()
 
         self.Plugins = Plugins(self)
         self.Plugins.load_plugin()

--- a/blueman/main/DbusService.py
+++ b/blueman/main/DbusService.py
@@ -57,18 +57,15 @@ class DbusService:
         if is_async:
             options.add("async")
         self._methods[name] = (arguments, self._handle_return_type(return_values), method, options)
-        self._reregister()
 
     def remove_method(self, name: str) -> None:
         del self._methods[name]
-        self._reregister()
 
     def add_signal(self, name: str, types: str | tuple[str, ...]) -> None:
         if name in self._signals:
             raise Exception(f"{name} already defined")
 
         self._signals[name] = self._handle_return_type(types)
-        self._reregister()
 
     def _handle_return_type(self, types: str | tuple[str, ...]) -> tuple[str, ...]:
         if isinstance(types, str):
@@ -83,7 +80,6 @@ class DbusService:
 
     def remove_signal(self, name: str) -> None:
         del self._signals[name]
-        self._reregister()
 
     def emit_signal(self, name: str, *args: Any) -> None:
         self._bus.emit_signal(None, self._path, self._interface_name, name,
@@ -125,11 +121,6 @@ class DbusService:
         if self._regid is not None:
             self._bus.unregister_object(self._regid)
             self._regid = None
-
-    def _reregister(self) -> None:
-        if self._regid:
-            self.unregister()
-            self.register()
 
     def _handle_method_call(self, _connection: Gio.DBusConnection, sender: str, _path: str, interface_name: str,
                             method_name: str, parameters: GLib.Variant, invocation: Gio.DBusMethodInvocation) -> None:

--- a/blueman/main/Tray.py
+++ b/blueman/main/Tray.py
@@ -4,7 +4,7 @@ import os
 import signal
 import sys
 from blueman.Functions import log_system_info
-from blueman.main.DBusProxies import AppletService
+from blueman.main.DBusProxies import AppletMenuService
 from gi.repository import Gio, GLib
 
 from blueman.main.indicators.IndicatorInterface import IndicatorNotAvailable
@@ -38,22 +38,22 @@ class BluemanTray(Gio.Application):
     def _on_name_appeared(self, _connection: Gio.DBusConnection, name: str, _owner: str) -> None:
         logging.debug(f"Applet started on name {name}, showing indicator")
 
-        applet = AppletService()
-        for indicator_name in applet.GetStatusIconImplementations():
+        menu_service = AppletMenuService()
+        for indicator_name in menu_service.get_statusicon_implementations():
             indicator_class = getattr(import_module('blueman.main.indicators.' + indicator_name), indicator_name)
             try:
-                self.indicator = indicator_class(self, applet.GetIconName())
+                self.indicator = indicator_class(self, menu_service.get_icon_name())
                 break
             except IndicatorNotAvailable:
                 logging.info(f'Indicator "{indicator_name}" is not available')
         logging.info(f'Using indicator "{self.indicator.__class__.__name__}"')
 
-        applet.connect('g-signal', self.on_signal)
+        menu_service.connect('g-signal', self.on_signal)
 
-        self.indicator.set_tooltip_title(applet.GetToolTipTitle())
-        self.indicator.set_tooltip_text(applet.GetToolTipText())
-        self.indicator.set_visibility(applet.GetVisibility())
-        self.indicator.set_menu(applet.GetMenu())
+        self.indicator.set_tooltip_title(menu_service.get_tooltip_title())
+        self.indicator.set_tooltip_text(menu_service.get_tooltip_text())
+        self.indicator.set_visibility(menu_service.get_visibility())
+        self.indicator.set_menu(menu_service.get_menu())
 
         self._active = True
 
@@ -62,12 +62,12 @@ class BluemanTray(Gio.Application):
         self.quit()
 
     def activate_menu_item(self, *indexes: int) -> None:
-        AppletService().ActivateMenuItem('(ai)', indexes)
+        AppletMenuService().ActivateMenuItem('(ai)', indexes)
 
     def activate_status_icon(self) -> None:
-        AppletService().Activate()
+        AppletMenuService().Activate()
 
-    def on_signal(self, _applet: AppletService, _sender_name: str, signal_name: str, args: GLib.Variant) -> None:
+    def on_signal(self, _applet: AppletMenuService, _sender_name: str, signal_name: str, args: GLib.Variant) -> None:
         if signal_name == 'IconNameChanged':
             self.indicator.set_icon(*args)
         elif signal_name == 'ToolTipTitleChanged':

--- a/blueman/plugins/applet/DBusService.py
+++ b/blueman/plugins/applet/DBusService.py
@@ -47,6 +47,7 @@ class DBusService(AppletPlugin):
     __unloadable__ = False
     __description__ = _("Provides DBus API for other Blueman components")
     __author__ = "Walmis"
+    __dbus_iface_name__ = "org.blueman.Applet"
 
     def on_load(self) -> None:
         self._add_dbus_method("QueryPlugins", (), "as", self.parent.Plugins.get_loaded)

--- a/blueman/plugins/applet/DhcpClient.py
+++ b/blueman/plugins/applet/DhcpClient.py
@@ -15,6 +15,7 @@ class DhcpClient(AppletPlugin):
     __description__ = _("Provides a basic dhcp client for Bluetooth PAN connections.")
     __icon__ = "network-workgroup-symbolic"
     __author__ = "Walmis"
+    __dbus_iface_name__ = "org.blueman.Applet.DhcpClient"
 
     _any_network = None
 
@@ -24,7 +25,7 @@ class DhcpClient(AppletPlugin):
 
         self.querying: list[str] = []
 
-        self._add_dbus_method("DhcpClient", ("s",), "", self.dhcp_acquire)
+        self._add_dbus_method("DhcpClient", ("o",), "", self.dhcp_acquire)
 
     def on_unload(self) -> None:
         del self._any_network

--- a/blueman/plugins/applet/Menu.py
+++ b/blueman/plugins/applet/Menu.py
@@ -116,6 +116,7 @@ class Menu(AppletPlugin):
     __icon__ = "open-menu-symbolic"
     __author__ = "Walmis"
     __unloadable__ = False
+    __dbus_iface_name__ = "org.blueman.Applet.Menu"
 
     def on_load(self) -> None:
         self.__menuitems: dict[tuple[int, int], MenuItem] = {}

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -33,6 +33,7 @@ class PowerManager(AppletPlugin, StatusIconProvider):
     __description__ = _("Controls Bluetooth adapter power states")
     __author__ = "Walmis"
     __icon__ = "gnome-power-manager-symbolic"
+    __dbus_iface_name__ = "org.blueman.Applet.PowerManager"
 
     class State(Enum):
         ON = 2

--- a/blueman/plugins/applet/StatusIcon.py
+++ b/blueman/plugins/applet/StatusIcon.py
@@ -25,6 +25,7 @@ class StatusIconProvider:
 class StatusIcon(AppletPlugin, GObject.GObject):
     __icon__ = "bluetooth-symbolic"
     __depends__ = ["StandardItems", "Menu"]
+    __dbus_iface_name__ = "org.blueman.Applet.StatusIcon"
 
     __gsettings__ = {
         "schema": "org.blueman.general",

--- a/blueman/services/meta/NetworkService.py
+++ b/blueman/services/meta/NetworkService.py
@@ -45,7 +45,7 @@ class NetworkService(Service):
     @property
     def common_actions(self) -> set[Action]:
         def renew() -> None:
-            AppletService().DhcpClient('(s)', self.device.get_object_path())
+            AppletService().dchp_client(self.device.get_object_path())
 
         return {Action(
             _("Renew IP Address"),


### PR DESCRIPTION
This moves the handling of plugin dbus services to the individual plugins. `DBusService` provides the basic services to mange the applet and it's plugins under `org.blueman.Applet`. This service should never be unloaded to avoid #2722.

Instead of tearing down `org.blueman.Applet` when a plugin is (un)loaded each plugin now provides it's own interface. Added convenience functions to the proxies to make this more manageable.