### PR TITLE
Use file monitor to handle changes in KillSwitch

### DIFF
--- a/blueman/bluez/errors.py
+++ b/blueman/bluez/errors.py
@@ -130,8 +130,6 @@ __DICT_ERROR__ = {'org.bluez.Error.Failed': DBusFailedError,
 
 
 def parse_dbus_error(exception: GLib.Error) -> BluezDBusException:
-    global __DICT_ERROR__
-
     gerror, dbus_error, message = exception.message.split(':', 2)
     try:
         return __DICT_ERROR__[dbus_error](message)

--- a/blueman/plugins/applet/KillSwitch.py
+++ b/blueman/plugins/applet/KillSwitch.py
@@ -90,7 +90,7 @@ class KillSwitch(AppletPlugin, PowerStateHandler, StatusIconVisibilityHandler):
             self._enabled = False
             self._hardblocked = False
 
-    def _on_connman_appeared(self, connection: Gio.DBusConnection, name: str, owner: str) -> None:
+    def _on_connman_appeared(self, _connection: Gio.DBusConnection, name: str, _owner: str) -> None:
         logging.info(f"{name} appeared")
         self._connman_proxy = Gio.DBusProxy.new_for_bus_sync(
             Gio.BusType.SYSTEM,
@@ -101,7 +101,7 @@ class KillSwitch(AppletPlugin, PowerStateHandler, StatusIconVisibilityHandler):
             'net.connman.Technology',
             None)
 
-    def _on_connman_vanished(self, connection: Gio.DBusConnection, name: str) -> None:
+    def _on_connman_vanished(self, _connection: Gio.DBusConnection, name: str) -> None:
         logging.info(f"{name} vanished")
         self._connman_proxy = None
 

--- a/blueman/plugins/mechanism/RfKill.py
+++ b/blueman/plugins/mechanism/RfKill.py
@@ -1,7 +1,7 @@
 import os
 import struct
 from blueman.plugins.MechanismPlugin import MechanismPlugin
-from blueman.plugins.applet.KillSwitch import RFKILL_TYPE_BLUETOOTH, RFKILL_OP_CHANGE_ALL
+from blueman.plugins.applet.KillSwitch import RFKILL_TYPE_BLUETOOTH, RFKillOp
 
 if not os.path.exists('/dev/rfkill'):
     raise ImportError("Hardware kill switch not found")
@@ -14,4 +14,4 @@ class RfKill(MechanismPlugin):
     def _set_rfkill_state(self, state: bool, caller: str) -> None:
         self.confirm_authorization(caller, "org.blueman.rfkill.setstate")
         with open('/dev/rfkill', 'r+b', buffering=0) as f:
-            f.write(struct.pack("IBBBB", 0, RFKILL_TYPE_BLUETOOTH, RFKILL_OP_CHANGE_ALL, (0 if state else 1), 0))
+            f.write(struct.pack("IBBBB", 0, RFKILL_TYPE_BLUETOOTH, RFKillOp.CHANGE_ALL, (0 if state else 1), 0))


### PR DESCRIPTION
Technically mechanism plugin RfKill could also not be allowed to open the device but I'm uncertain how likely this is.

Also used an enum to represent the operation and some housekeeping.