### PR TITLE
Fix handling for new StatusNotifierWatcher

### DIFF
--- a/blueman/main/indicators/StatusNotifierItem.py
+++ b/blueman/main/indicators/StatusNotifierItem.py
@@ -155,7 +155,7 @@ class StatusNotifierItem(IndicatorInterface):
                 None, Gio.DBusCallFlags.NONE, -1)
             watcher_expected = True
         except GLib.Error as e:
-            watcher_expected = not e.message.startswith("org.freedesktop.DBusError.ServiceUnknown")
+            watcher_expected = not e.message.startswith("GDBus.Error:org.freedesktop.DBusError.ServiceUnknown")
             raise IndicatorNotAvailable
 
     def set_icon(self, icon_name: str) -> None:


### PR DESCRIPTION
blueman-tray restarts when a new StatusNotifierWatcher appears. This is especially relevant when blueman and a watcher like waybar get started in the session in no particular order. Unfortunately we have to use the `GLib.Error.message` and it looks like #2334 lacked the prefix; at least I cannot find any hint that this could have worked.

Fixes #2765