### PR TITLE
Info: Convert dialog to window (fixes #2796)

### DIFF
--- a/blueman/plugins/manager/Info.py
+++ b/blueman/plugins/manager/Info.py
@@ -53,9 +53,10 @@ def show_info(device: Device, parent: Gtk.Window) -> None:
         return False
 
     clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
-    dialog = Gtk.Dialog(icon_name="blueman", title="blueman")
-    dialog.set_transient_for(parent)
-    dialog_content_area = dialog.get_content_area()
+    dialog = Gtk.Window(icon_name="blueman", title="blueman", transient_for=parent)
+
+    dialog_content_area = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+    dialog.add(dialog_content_area)
 
     label = Gtk.Label()
     label.set_markup(_("<big>Select row(s) and use <i>Control + C</i> to copy</big>"))
@@ -112,8 +113,7 @@ def show_info(device: Device, parent: Gtk.Window) -> None:
             logging.info(f"Could not add property {name}")
             pass
 
-    dialog.run()
-    dialog.destroy()
+    dialog.show_all()
 
 
 class Info(ManagerPlugin, MenuItemsProvider):


### PR DESCRIPTION
This adds a Close button to the info dialog to make it easier to close the dialog, especially on tablets without a dedicated keyboard.

<img width="846" height="763" alt="blueman" src="https://github.com/user-attachments/assets/8e6775e5-83fd-4458-b4f6-c591d9f887c3" />
