### PR TITLE
TransferService: Handle when the transfer fails

### DIFF
--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -296,7 +296,7 @@ class TransferService(AppletPlugin):
         dest = dest_dir.joinpath(filename)
         try:
             shutil.move(src, dest)
-        except (OSError, PermissionError):
+        except (OSError, PermissionError, FileNotFoundError):
             logging.error("Failed to move files", exc_info=True)
             success = False
 


### PR DESCRIPTION
Fixes this error
```python
lueman-applet 19.56.35 ERROR    TransferService:300 _on_transfer_completed: Failed to move files
Traceback (most recent call last):
  File "/usr/lib/python3.13/shutil.py", line 856, in move
    os.rename(src, real_dst)
    ~~~~~~~~~^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/.cache/obexd/2025-09-15-09-42-50-039.jpg' -> '/home/user/Downloads/2025-09-15-09-42-50-039.jpg'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/blueman/plugins/applet/TransferService.py", line 298, in _on_transfer_completed
    shutil.move(src, dest)
    ~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 876, in move
    copy_function(src, real_dst)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 468, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 260, in copyfile
    with open(src, 'rb') as fsrc:
         ~~~~^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/.cache/obexd/2025-09-15-09-42-50-039.jpg'
```