### PR TITLE
TransferService: Use Session Source to get correct adapter

### DIFF
--- a/blueman/bluez/obex/Session.py
+++ b/blueman/bluez/obex/Session.py
@@ -17,3 +17,8 @@ class Session(Base):
     def root(self) -> str:
         root: str = self.get('Root')
         return root
+
+    @property
+    def source(self) -> BtAddress:
+        source: BtAddress = self.get('Source')
+        return source

--- a/blueman/plugins/applet/TransferService.py
+++ b/blueman/plugins/applet/TransferService.py
@@ -109,7 +109,7 @@ class Agent(DbusService):
         size = transfer.size
 
         try:
-            adapter = self._applet.Manager.get_adapter()
+            adapter = self._applet.Manager.get_adapter(session.source)
             device = self._applet.Manager.find_device(address, adapter.get_object_path())
             assert device is not None
             name = device.display_name


### PR DESCRIPTION
Ran into blueman using the first, but wrong in my case, adapter while investigating the TypeError issue I introduced.

Should I add the other properties [1] from the session while I'm at it?

[1] https://github.com/bluez/bluez/blob/master/doc/org.bluez.obex.Session.rst