### PR TITLE
ShowConnected: Use discard to drop path from connections

### DIFF
--- a/blueman/plugins/applet/ShowConnected.py
+++ b/blueman/plugins/applet/ShowConnected.py
@@ -99,7 +99,7 @@ class ShowConnected(AppletPlugin, StatusIconProvider):
             if value:
                 self._connections.add(path)
             else:
-                self._connections.remove(path)
+                self._connections.discard(path)
 
             if (self._connections and not self.active) or (not self._connections and self.active):
                 self.parent.Plugins.StatusIcon.icon_should_change()


### PR DESCRIPTION
Here is a the dbus traffic that led to the KeyError. Up to this point we never see the `Connected` property change eventhough a connection was established for the pair. Not sure what we're supposed to do here but at least handle this gracefully.

Do we want to log an error for this?

```
/org/bluez/hci0/dev_14_05_89_AC_12_9A: org.freedesktop.DBus.Properties.PropertiesChanged ('org.bluez.Device1', {'UUIDs': <['00001105-0000-1000-8000-00805f9b34fb']>}, @as [])
/org/bluez/hci0/dev_14_05_89_AC_12_9A: org.freedesktop.DBus.Properties.PropertiesChanged ('org.bluez.Device1', {'Modalias': <'bluetooth:v00E0p0000d0000'>, 'UUIDs': <['00001105-0000-1000-8000-00805f9b34fb', '0000110a-0000-1000-8000-00805f9b34fb', '0000110c-0000-1000-8000-00805f9b34fb', '0000110e-0000-1000-8000-00805f9b34fb', '00001112-0000-1000-8000-00805f9b34fb', '00001115-0000-1000-8000-00805f9b34fb', '00001116-0000-1000-8000-00805f9b34fb', '0000111f-0000-1000-8000-00805f9b34fb', '0000112d-0000-1000-8000-00805f9b34fb', '0000112f-0000-1000-8000-00805f9b34fb', '00001132-0000-1000-8000-00805f9b34fb', '00001200-0000-1000-8000-00805f9b34fb', '00001800-0000-1000-8000-00805f9b34fb', '00001801-0000-1000-8000-00805f9b34fb', '00001855-0000-1000-8000-00805f9b34fb', 'a82efa21-ae5c-3dde-9bbc-f16da7b16c5a']>, 'ServicesResolved': <true>, 'Paired': <true>}, @as [])
/org/bluez/hci0/dev_14_05_89_AC_12_9A: org.freedesktop.DBus.Properties.PropertiesChanged ('org.bluez.Device1', {'ServicesResolved': <false>, 'Paired': <false>}, @as [])
/org/bluez/hci0/dev_14_05_89_AC_12_9A: org.bluez.Device1.Disconnected ('org.bluez.Reason.Local', 'Connection terminated by local host')
/org/bluez/hci0/dev_14_05_89_AC_12_9A: org.freedesktop.DBus.Properties.PropertiesChanged ('org.bluez.Device1', {'Connected': <false>}, @as [])
```