### PR TITLE
dbus: prefer closures2

### DIFF
--- a/blueman/main/DbusService.py
+++ b/blueman/main/DbusService.py
@@ -105,7 +105,10 @@ class DbusService:
 
         node_info = Gio.DBusNodeInfo.new_for_xml(node_xml)
 
-        regid = self._bus.register_object(
+        # register_object_with_closures2 requires GLib 2.84.0 (released 2025-03-06).
+        # Keep a fallback for older runtimes that only provide register_object().
+        register_object = getattr(self._bus, "register_object_with_closures2", self._bus.register_object)
+        regid = register_object(
             self._path,
             node_info.interfaces[0],
             self._handle_method_call,


### PR DESCRIPTION
`register_object_with_closures` is deprecated in favor of `register_object_with_closures2`, since the original leaks memory or otherwise requires some extra work to avoid leaking memory, I don't fully understand:

> [Deprecated in favour of g_dbus_connection_register_object_with_closures2(), which has more binding-friendly reference counting semantics.](https://docs.gtk.org/gio/method.DBusConnection.register_object_with_closures.html)

Keep getattr fallback so older GLib runtimes still work.

Fixes #3101

Testing:

I've been running this patch locally for 8 days with no issues. I've also got [this minimal reproducer](https://github.com/flaviut/blueman/commit/d3fbcbc0c9b01a68672ed69f60044cdbbb9dc00c), which quickly shows the fix works:

<img width="1783" height="740" alt="closure_leak_comparison" src="https://github.com/user-attachments/assets/6f71bfb3-a202-445b-8fd7-4cfa7851ab88" />