### PR TITLE
Improve connection reliability: logging, timeouts, and error handling

### DIFF
--- a/blueman/bluez/errors.py
+++ b/blueman/bluez/errors.py
@@ -130,7 +130,10 @@ __DICT_ERROR__ = {'org.bluez.Error.Failed': DBusFailedError,
 
 
 def parse_dbus_error(exception: GLib.Error) -> BluezDBusException:
-    gerror, dbus_error, message = exception.message.split(':', 2)
+    try:
+        gerror, dbus_error, message = exception.message.split(':', 2)
+    except ValueError:
+        return BluezDBusException(exception.message)
     try:
         return __DICT_ERROR__[dbus_error](message)
     except KeyError:

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -242,6 +242,8 @@ class ManagerDeviceList(DeviceList):
 
         if event.type == Gdk.EventType._2BUTTON_PRESS and cast(Gdk.EventButton, event).button == 1:
             if self.menu.show_generic_connect_calc(row["device"]['UUIDs']):
+                if self.menu.get_op(row["device"]):
+                    return False
                 if row["connected"]:
                     self.menu.disconnect_service(row["device"])
                 elif Adapter(obj_path=row["device"]["Adapter"])["Powered"]:

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -109,10 +109,17 @@ class ManagerDeviceMenu(Gtk.Menu):
 
     def set_op(self, device: Device, message: str) -> None:
         ManagerDeviceMenu.__ops__[device.get_object_path()] = message
+        GLib.timeout_add(60000, self._op_timeout, device)
         for inst in ManagerDeviceMenu.__instances__:
             logging.info(f"op: regenerating instance {inst}")
             if inst.SelectedDevice == self.SelectedDevice and not (inst.is_popup and not inst.props.visible):
                 inst.generate()
+
+    def _op_timeout(self, device: Device) -> bool:
+        if device.get_object_path() in ManagerDeviceMenu.__ops__:
+            logging.warning(f"Operation timed out for {device.get_object_path()}")
+            self.unset_op(device)
+        return GLib.SOURCE_REMOVE
 
     def get_op(self, device: Device) -> str | None:
         try:
@@ -163,7 +170,7 @@ class ManagerDeviceMenu(Gtk.Menu):
 
         self._appl.ConnectService('(os)', device.get_object_path(), uuid,
                                   result_handler=success, error_handler=fail,
-                                  timeout=GLib.MAXINT)
+                                  timeout=45000)
 
         prog.start()
 
@@ -183,7 +190,7 @@ class ManagerDeviceMenu(Gtk.Menu):
             return
 
         self._appl.DisconnectService('(osd)', device.get_object_path(), uuid, port,
-                                     result_handler=ok, error_handler=err, timeout=GLib.MAXINT)
+                                     result_handler=ok, error_handler=err, timeout=45000)
 
     def on_device_property_changed(self, lst: "ManagerDeviceList", _device: Device, tree_iter: Gtk.TreeIter,
                                    key_value: tuple[str, object]) -> None:

--- a/blueman/plugins/applet/AutoConnect.py
+++ b/blueman/plugins/applet/AutoConnect.py
@@ -1,3 +1,4 @@
+import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 from blueman.bluemantyping import ObjectPath, BtAddress
@@ -69,8 +70,9 @@ class AutoConnect(AppletPlugin):
                              {"service": service_name, "device": dev.display_name},
                              icon_name=dev["Icon"]).show()
 
-            def err(_reason: Exception | str) -> None:
-                pass
+            def err(_reason: Exception | str, dev: Device | None = device) -> None:
+                assert isinstance(dev, Device)
+                logging.warning(f"AutoConnect failed for {dev.display_name}: {_reason}")
 
             self.parent.Plugins.DBusService.connect_service(device.get_object_path(), uuid, reply, err)
 


### PR DESCRIPTION
## Summary
- **AutoConnect logging:** `AutoConnect.err()` silently discarded failures with `pass`. Now logs warnings so users/devs can see why auto-connect failed.
- **D-Bus timeout:** Replaced `timeout=GLib.MAXINT` with 45s on `ConnectService`/`DisconnectService` calls. Prevents indefinite UI freeze when BlueZ hangs (related: #2927).
- **Double-click guard:** Double-clicking a device while a connect/disconnect operation is already in progress no longer starts a duplicate operation.
- **Operation auto-clear:** Stuck operations in `ManagerDeviceMenu.__ops__` are now auto-cleared after 60 seconds, preventing the permanent "Connecting..." state.
- **Robust `parse_dbus_error`:** Added `ValueError` handling for malformed D-Bus error messages that don't contain the expected colon-separated format.

## Note on related PRs
This PR intentionally does **not** touch the error message mapping in `_handle_error_message` / `_BLUEZ_ERROR_MAP`, as that area is being improved by #3120 and #2556.

## Test plan
- [ ] Verify `AutoConnect` failures appear in log output
- [ ] Verify connect/disconnect operations time out after ~45s instead of hanging forever
- [ ] Verify double-clicking a device during an active operation does not start a second one
- [ ] Verify stuck "Connecting..." state auto-clears after 60s
- [ ] Verify malformed D-Bus errors don't crash the error handler
- [ ] `python -m py_compile` passes on all 4 modified files
- [ ] Existing test suite passes (8/9 unrelated to changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)