### PR TITLE
ManagerDeviceList: Guard double-click against duplicate operations

### DIFF
--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -242,6 +242,8 @@ class ManagerDeviceList(DeviceList):
 
         if event.type == Gdk.EventType._2BUTTON_PRESS and cast(Gdk.EventButton, event).button == 1:
             if self.menu.show_generic_connect_calc(row["device"]['UUIDs']):
+                if self.menu.get_op(row["device"]):
+                    return False
                 if row["connected"]:
                     self.menu.disconnect_service(row["device"])
                 elif Adapter(obj_path=row["device"]["Adapter"])["Powered"]:

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -225,9 +225,8 @@ class ManagerDeviceList(DeviceList):
         posdata = self.get_path_at_pos(int(cast(Gdk.EventButton, event).x), int(cast(Gdk.EventButton, event).y))
         if posdata is None:
             return False
-        else:
-            path = posdata[0]
-            assert path is not None
+        path = posdata[0]
+        assert path is not None
 
         tree_iter = self.filter.get_iter(path)
         assert tree_iter is not None

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -240,10 +240,11 @@ class ManagerDeviceList(DeviceList):
         if self.menu is None:
             self.menu = ManagerDeviceMenu(self.Blueman)
 
+        if self.menu.get_op(row["device"]):
+            return False
+
         if event.type == Gdk.EventType._2BUTTON_PRESS and cast(Gdk.EventButton, event).button == 1:
             if self.menu.show_generic_connect_calc(row["device"]['UUIDs']):
-                if self.menu.get_op(row["device"]):
-                    return False
                 if row["connected"]:
                     self.menu.disconnect_service(row["device"])
                 elif Adapter(obj_path=row["device"]["Adapter"])["Powered"]:


### PR DESCRIPTION
A quick second double-click on a device row while a connect/disconnect is still in flight currently fires a second `connect_service`/`disconnect_service` call. This can lead to duplicate BlueZ requests and confusing UI state.

Check `menu.get_op(device)` before initiating, and skip if an operation is already tracked for that device.