### PR TITLE
errors: Handle malformed messages in parse_dbus_error

### DIFF
--- a/blueman/bluez/errors.py
+++ b/blueman/bluez/errors.py
@@ -130,7 +130,10 @@ __DICT_ERROR__ = {'org.bluez.Error.Failed': DBusFailedError,
 
 
 def parse_dbus_error(exception: GLib.Error) -> BluezDBusException:
-    gerror, dbus_error, message = exception.message.split(':', 2)
+    try:
+        gerror, dbus_error, message = exception.message.split(':', 2)
+    except ValueError:
+        return BluezDBusException(exception.message)
     try:
         return __DICT_ERROR__[dbus_error](message)
     except KeyError:


### PR DESCRIPTION
`parse_dbus_error` assumes the exception message always has the form `gerror:dbus_error:message` and does an unchecked `split(':', 2)` unpack. If BlueZ (or a proxy/glib path) ever produces a message with fewer colons, this raises `ValueError` from inside the error handler itself, masking the original failure.

Wrap the split in try/except and fall back to returning a plain `BluezDBusException` with the raw message.