### PR TITLE
blueman-applet: serialize RegisterAgent and RequestDefaultAgent

### DIFF
--- a/blueman/bluez/AgentManager.py
+++ b/blueman/bluez/AgentManager.py
@@ -13,7 +13,7 @@ class AgentManager(Base):
 
     def register_agent(self, agent_path: str, capability: str = "", default: bool = False) -> None:
         param = GLib.Variant('(os)', (agent_path, capability))
-        self._call('RegisterAgent', param)
+        self._call_sync('RegisterAgent', param)
         if default:
             default_param = GLib.Variant('(o)', (agent_path,))
             self._call('RequestDefaultAgent', default_param)

--- a/blueman/bluez/Base.py
+++ b/blueman/bluez/Base.py
@@ -94,6 +94,9 @@ class Base(GObject.Object, metaclass=BaseMeta):
 
         self.__proxy.call(method, param, Gio.DBusCallFlags.NONE, GLib.MAXINT, None,
                           callback, reply_handler, error_handler)
+        
+    def _call_sync(self, method: str, param: GLib.Variant | None = None) -> GLib.Variant | None:
+        return self.__proxy.call_sync(method, param, Gio.DBusCallFlags.NONE, -1, None)
 
     def get(self, name: str) -> Any:
         try:


### PR DESCRIPTION
Fix race condition where RequestDefaultAgent is sent before RegisterAgent completes in async D-Bus environments (proxies/VMs), causing org.bluez.Error.DoesNotExist.

blueman-applet issues RegisterAgent and RequestDefaultAgent as two independent asynchronous D-Bus calls. In environments where D-Bus message processing or object export is not immediate (e.g. proxies, bridges, containers), this can lead to a race condition where RequestDefaultAgent is executed before the agent is fully registered, causing org.bluez.Error.DoesNotExist.

Fix this by ensuring RequestDefaultAgent is only called after completion of RegisterAgent, restoring correct ordering semantics required by BlueZ AgentManager1 API.