### PR TITLE
Set default agent after registration

### DIFF
--- a/blueman/bluez/AgentManager.py
+++ b/blueman/bluez/AgentManager.py
@@ -11,12 +11,16 @@ class AgentManager(Base):
     def __init__(self) -> None:
         super().__init__(obj_path=self._obj_path)
 
-    def register_agent(self, agent_path: str, capability: str = "", default: bool = False) -> None:
+    def register_agent(self, agent_path: ObjectPath, capability: str = "") -> None:
+        def on_reply() -> None:
+            self.request_default_agent(agent_path)
+
         param = GLib.Variant('(os)', (agent_path, capability))
-        self._call('RegisterAgent', param)
-        if default:
-            default_param = GLib.Variant('(o)', (agent_path,))
-            self._call('RequestDefaultAgent', default_param)
+        self._call('RegisterAgent', param=param, reply_handler=on_reply)
+
+    def request_default_agent(self, agent_path: ObjectPath) -> None:
+        default_param = GLib.Variant('(o)', (agent_path,))
+        self._call('RequestDefaultAgent', default_param)
 
     def unregister_agent(self, agent_path: str) -> None:
         param = GLib.Variant('(o)', (agent_path,))

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -30,7 +30,7 @@ class BluezErrorRejected(DbusError):
 
 
 class BluezAgent(DbusService):
-    __agent_path = '/org/bluez/agent/blueman'
+    __agent_path = ObjectPath('/org/bluez/agent/blueman')
 
     def __init__(self) -> None:
         super().__init__(None, "org.bluez.Agent1", self.__agent_path, Gio.BusType.SYSTEM)
@@ -54,7 +54,7 @@ class BluezAgent(DbusService):
     def register_agent(self) -> None:
         logging.info("Register Agent")
         self.register()
-        AgentManager().register_agent(self.__agent_path, "KeyboardDisplay", default=True)
+        AgentManager().register_agent(self.__agent_path, "KeyboardDisplay")
 
     def unregister_agent(self) -> None:
         logging.info("Unregister Agent")

--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -52,12 +52,12 @@ class BluezAgent(DbusService):
         self._service_notifications: list[_NotificationBubble | _NotificationDialog] = []
 
     def register_agent(self) -> None:
-        logging.info("Register Agent")
+        logging.debug(self.__agent_path)
         self.register()
         AgentManager().register_agent(self.__agent_path, "KeyboardDisplay")
 
     def unregister_agent(self) -> None:
-        logging.info("Unregister Agent")
+        logging.debug(self.__agent_path)
         self.unregister()
         AgentManager().unregister_agent(self.__agent_path)
 


### PR DESCRIPTION
#3209 rightfully points out we could potentially ask to be default agent before we finished registration. But instead of making it synchronous keep the registration asynchronous and request default agent when dbus replies.