### PR TITLE
Fix typo in D-Bus activation error message

### DIFF
--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -408,15 +408,16 @@ msgstr "Failed to reach blueman-manager"
 
 #: blueman/main/DBusProxies.py:91
 msgid ""
-"It seems like blueman-manager could no get activated via D-Bus. A typical "
+
+"It seems like blueman-manager could not be activated via D-Bus. A typical "
 "cause for this is a broken graphical setup in the D-Bus activation "
-"environment that can get resolved with a call to dbus-update-activation-"
+"environment, this can be resolved with a call to dbus-update-activation-"
 "environment, typically issued from xinitrc (respectively the Sway config or "
 "similar)."
 msgstr ""
-"It seems like blueman-manager could no get activated via D-Bus. A typical "
+"It seems like blueman-manager could not be activated via D-Bus. A typical "
 "cause for this is a broken graphical setup in the D-Bus activation "
-"environment that can get resolved with a call to dbus-update-activation-"
+"environment, this can be resolved with a call to dbus-update-activation-"
 "environment, typically issued from xinitrc (respectively the Sway config or "
 "similar)."
 


### PR DESCRIPTION
source string is read-only on weblate, so editing here.

Edit, there is some other master "English" file somewhere which needs to be changed instead of this one.