### PR TITLE
Implement restoring last power state of bluetooth adapter(s)

### DIFF
--- a/blueman/gui/applet/PluginDialog.py
+++ b/blueman/gui/applet/PluginDialog.py
@@ -57,17 +57,17 @@ class SettingsWidget(Gtk.Box):
         self.show_all()
 
     def construct_settings(self) -> None:
-        for k, v in self.inst.__class__.__options__.items():
-            if len(v) > 2:
-
-                label = Gtk.Label(label=v["name"])
+        for name, option in self.inst.__class__.__options__.items():
+            # Skip options without name and description in the plugin dialog.
+            if "desc" in option and "name" in option:
+                label = Gtk.Label(label=option["name"])
                 label.props.xalign = 0.0
 
-                w = self.get_control_widget(k, v)
+                w = self.get_control_widget(name, option)
 
                 self.pack_start(w, False, False, 0)
 
-                label = Gtk.Label(label="<i >" + v["desc"] + "</i>", wrap=True, use_markup=True, xalign=0.0)
+                label = Gtk.Label(label="<i >" + option["desc"] + "</i>", wrap=True, use_markup=True, xalign=0.0)
                 self.pack_start(label, False, False, 0)
 
     def handle_change(self, widget: Gtk.Widget, opt: str, params: Option, prop: str) -> None:

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -75,10 +75,6 @@ class PowerManager(AppletPlugin, StatusIconProvider):
     def on_unload(self) -> None:
         self.parent.Plugins.Menu.unregister(self)
 
-    @property
-    def CurrentState(self) -> bool:
-        return self.current_state
-
     def on_manager_state_changed(self, state: bool) -> None:
         if state:
             def timeout() -> bool:

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -109,7 +109,7 @@ class PowerManager(AppletPlugin, StatusIconProvider):
 
             self.adapter_state = state
         except Exception:
-            logging.error("Exception occurred", exc_info=True)
+            logging.error(f"Failed to set new power state: {state}", exc_info=True)
 
     class Callback:
         def __init__(self, parent: "PowerManager", state: bool):

--- a/blueman/plugins/applet/PowerManager.py
+++ b/blueman/plugins/applet/PowerManager.py
@@ -35,6 +35,24 @@ class PowerManager(AppletPlugin, StatusIconProvider):
     __icon__ = "gnome-power-manager-symbolic"
     __dbus_iface_name__ = "org.blueman.Applet.PowerManager"
 
+    __gsettings__ = {
+        "schema": "org.blueman.plugins.powermanager",
+        "path": None
+    }
+
+    __options__ = {
+        "last-power-state": {
+            "type": bool,
+            "default": False
+        },
+        "restore-power-state": {
+            "type": bool,
+            "default": False,
+            "name": "Restore power state",
+            "desc": "Restore the last known power state of bluetooth."
+        }
+    }
+
     class State(Enum):
         ON = 2
         OFF = 1
@@ -64,7 +82,13 @@ class PowerManager(AppletPlugin, StatusIconProvider):
     def on_manager_state_changed(self, state: bool) -> None:
         if state:
             def timeout() -> bool:
-                self.request_power_state(self.get_adapter_state())
+                if self.get_option("restore-power-state"):
+                    new_power_state = self.get_option("last-power-state")
+                    logging.info(f"Restoring last known bluetooth power state {new_power_state}")
+                else:
+                    new_power_state = self.get_adapter_state()
+
+                self.request_power_state(new_power_state)
                 return False
 
             GLib.timeout_add(1000, timeout)
@@ -166,6 +190,7 @@ class PowerManager(AppletPlugin, StatusIconProvider):
         if self.current_state != new_state:
             logging.info(f"Signalling {new_state}")
             self.current_state = new_state
+            self.set_option("last-power-state", self.current_state)
 
             self._emit_dbus_signal("BluetoothStatusChanged", new_state)
             for plugin in self.parent.Plugins.get_loaded_plugins(PowerStateListener):

--- a/data/org.blueman.gschema.xml
+++ b/data/org.blueman.gschema.xml
@@ -200,4 +200,12 @@
       <description>If this is set to true clicking the system tray icon will toggle the manager instead of focusing on it.</description>
     </key>
   </schema>
+  <schema id="org.blueman.plugins.powermanager" path="/org/blueman/plugins/powermanager/">
+    <key type="b" name="last-power-state">
+      <default>false</default>
+    </key>
+    <key type="mb" name="restore-power-state">
+      <default>nothing</default>
+    </key>
+</schema>
 </schemalist>


### PR DESCRIPTION
Off by default but I think this is reasonable. Bluedevil has a similar feature.