### PR TITLE
Update passkey message instead of closing and recreating notification

### DIFF
--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -49,6 +49,7 @@ class BluezAgent(DbusService):
         self._db: ElementTree.ElementTree | None = None
         self._devhandlerids: dict[str, int] = {}
         self._notification: _NotificationBubble | _NotificationDialog | None = None
+        self._passkey_notification: _NotificationBubble | _NotificationDialog | None = None
         self._service_notifications: list[_NotificationBubble | _NotificationDialog] = []
 
     def register_agent(self) -> None:
@@ -175,6 +176,9 @@ class BluezAgent(DbusService):
         if self._notification is not None:
             self._notification.close()
             self._notification = None
+        if self._passkey_notification is not None:
+            self._passkey_notification.close()
+            self._passkey_notification = None
 
     def _on_request_pin_code(self, object_path: ObjectPath, ok: Callable[[str], None],
                              err: Callable[[BluezErrorCanceled | BluezErrorRejected], None]) -> None:
@@ -201,9 +205,11 @@ class BluezAgent(DbusService):
         key = f"{passkey:06}"
         notify_message = _("Pairing passkey for") + f" {self.get_device_string(object_path)}: " \
                                                     f"{key[:entered]}<b>{key[entered]}</b>{key[entered + 1:]}"
-        self._close()
-        self._notification = Notification("Bluetooth", notify_message, 0, icon_name="blueman")
-        self._notification.show()
+        if self._passkey_notification is None:
+            self._passkey_notification = Notification("Bluetooth", notify_message, 0, icon_name="blueman")
+            self._passkey_notification.show()
+        else:
+            self._passkey_notification.set_message(notify_message)
 
     def _on_display_pin_code(self, object_path: ObjectPath, pin_code: str) -> None:
         logging.info(f'DisplayPinCode ({object_path}, {pin_code})')


### PR DESCRIPTION
Closing and recreating the notification was particularly problematic in the context of [the Qubes OS notification proxy not supporting CloseNotification](https://github.com/QubesOS/qubes-issues/issues/10862), but even with just xfce4-notifyd or the fallback dialog, it causes flickering. By now the notification code now supports `set_message` for a better approach. But only update a previous passkey notification and not potentially a notification that has `actions`.