### PR TITLE
Update passkey message instead of closing and recreating notification (2.4)

### DIFF
--- a/blueman/main/applet/BluezAgent.py
+++ b/blueman/main/applet/BluezAgent.py
@@ -50,6 +50,7 @@ class BluezAgent(DbusService):
         self._db: Optional[ElementTree.ElementTree] = None
         self._devhandlerids: Dict[str, int] = {}
         self._notification: Optional[Union[_NotificationBubble, _NotificationDialog]] = None
+        self._passkey_notification: Optional[Union[_NotificationBubble, _NotificationDialog]] = None
         self._service_notifications: List[Union[_NotificationBubble, _NotificationDialog]] = []
 
     def register_agent(self) -> None:
@@ -158,6 +159,9 @@ class BluezAgent(DbusService):
         if self._notification is not None:
             self._notification.close()
             self._notification = None
+        if self._passkey_notification is not None:
+            self._passkey_notification.close()
+            self._passkey_notification = None
 
     def _on_request_pin_code(self, object_path: str, ok: Callable[[str], None],
                              err: Callable[[Union[BluezErrorCanceled, BluezErrorRejected]], None]) -> None:
@@ -184,9 +188,11 @@ class BluezAgent(DbusService):
         key = f"{passkey:06}"
         notify_message = _("Pairing passkey for") + f" {self.get_device_string(object_path)}: " \
                                                     f"{key[:entered]}<b>{key[entered]}</b>{key[entered + 1:]}"
-        self._close()
-        self._notification = Notification("Bluetooth", notify_message, 0, icon_name="blueman")
-        self._notification.show()
+        if self._passkey_notification is None:
+            self._passkey_notification = Notification("Bluetooth", notify_message, 0, icon_name="blueman")
+            self._passkey_notification.show()
+        else:
+            self._passkey_notification.set_message(notify_message)
 
     def _on_display_pin_code(self, object_path: str, pin_code: str) -> None:
         logging.info(f'DisplayPinCode ({object_path}, {pin_code})')


### PR DESCRIPTION
This is the variant of #3252 I've tried out by patching the file in place. Not sure whether it's worth merging in order to release the change sooner.

Related: https://github.com/QubesOS/qubes-issues/issues/10862