### PR TITLE
Reconnect ObjectManager

### DIFF
--- a/blueman/bluez/Manager.py
+++ b/blueman/bluez/Manager.py
@@ -27,14 +27,7 @@ class Manager(GObject.GObject, metaclass=SingletonGObjectMeta):
 
     def __init__(self) -> None:
         super().__init__()
-        self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
-            Gio.BusType.SYSTEM, Gio.DBusObjectManagerClientFlags.DO_NOT_AUTO_START,
-            self.__bus_name, '/', None, None, None)
-
-        self._object_manager.connect("object-added", self._on_object_added)
-        self._object_manager.connect("object-removed", self._on_object_removed)
-        self._object_manager.connect("interface-added", self._on_interface_added)
-        self._object_manager.connect("interface-removed", self._on_interface_removed)
+        self.reconnect()
 
     def _on_object_added(self, _object_manager: Gio.DBusObjectManager, dbus_object: Gio.DBusObject) -> None:
         device_proxy = dbus_object.get_interface('org.bluez.Device1')
@@ -162,6 +155,15 @@ class Manager(GObject.GObject, metaclass=SingletonGObjectMeta):
             if device['Address'] == address:
                 return device
         return None
+
+    def reconnect(self) -> None:
+        self._object_manager = Gio.DBusObjectManagerClient.new_for_bus_sync(
+            Gio.BusType.SYSTEM, Gio.DBusObjectManagerClientFlags.DO_NOT_AUTO_START,
+            self.__bus_name, '/', None, None, None)
+        self._object_manager.connect("object-added", self._on_object_added)
+        self._object_manager.connect("object-removed", self._on_object_removed)
+        self._object_manager.connect("interface-added", self._on_interface_added)
+        self._object_manager.connect("interface-removed", self._on_interface_removed)
 
     def destroy(self) -> None:
         if self._object_manager:

--- a/blueman/main/Applet.py
+++ b/blueman/main/Applet.py
@@ -79,6 +79,7 @@ class BluemanApplet(Gtk.Application):
         logging.info(f"{name} {owner}")
         self.manager_state = True
         self.plugin_run_state_changed = True
+        self.Manager.reconnect()
         for plugin in self.Plugins.get_loaded_plugins(AppletPlugin):
             plugin.on_manager_state_changed(self.manager_state)
 


### PR DESCRIPTION
Due to the DO_NOT_AUTO_START flag, the client does not reconnect to the service after restart and provides a stale proxy.

Closes #3207