### PR TITLE
Revert "Suppress notifications for blocked devices (#3281)"

### DIFF
--- a/blueman/plugins/applet/ConnectionNotifier.py
+++ b/blueman/plugins/applet/ConnectionNotifier.py
@@ -26,8 +26,6 @@ class ConnectionNotifier(AppletPlugin):
     def on_device_property_changed(self, path: ObjectPath, key: str, value: Any) -> None:
         if key == "Connected":
             device = Device(obj_path=path)
-            if device["Blocked"]:
-                return
             if value:
                 self._notifications[path] = notification = Notification(
                     device.display_name,


### PR DESCRIPTION
I think that was completely misled. It targeted notifications for incoming connection attempts from blocked devices, which are mostly blocked by the kernel early on, so that no connection ever shows up (apart from very rare edge cases). What it actually suppresses, though, are notifications for any outgoing connection to blocked devices.