### PR TITLE
fix: route DHCP renew through AppletDhcpClientService proxy

### DIFF
--- a/blueman/services/meta/NetworkService.py
+++ b/blueman/services/meta/NetworkService.py
@@ -1,7 +1,7 @@
 from gettext import gettext as _
 from collections.abc import Callable
 
-from blueman.main.DBusProxies import AppletService
+from blueman.main.DBusProxies import AppletDhcpClientService
 
 from blueman.Service import Service, Action, Instance
 from blueman.bluez.Device import Device
@@ -45,7 +45,7 @@ class NetworkService(Service):
     @property
     def common_actions(self) -> set[Action]:
         def renew() -> None:
-            AppletService().dchp_client(self.device.get_object_path())
+            AppletDhcpClientService().dchp_client(self.device.get_object_path())
 
         return {Action(
             _("Renew IP Address"),

--- a/test/main/test_dbus_proxies.py
+++ b/test/main/test_dbus_proxies.py
@@ -1,13 +1,9 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from gi.repository import GLib
-
 from blueman.main.DBusProxies import (
     ProxyBase,
-    AppletService,
     AppletDhcpClientService,
-    AppletStatusIconService,
 )
 from blueman.gobject import SingletonGObjectMeta
 
@@ -29,16 +25,6 @@ class TestDBusProxies(TestCase):
     def test_metaclass(self):
         self.assertIsInstance(ProxyBase, SingletonGObjectMeta)
 
-    # --- regression: the DhcpClient method lives on the right proxy ---
-
-    def test_applet_service_has_no_dhcp_client(self):
-        # NetworkService used to call AppletService().dchp_client(...) which
-        # never existed on this interface. Lock that it stays absent here.
-        self.assertFalse(hasattr(AppletService, "dchp_client"))
-
-    def test_dhcp_client_proxy_exposes_method(self):
-        self.assertTrue(hasattr(AppletDhcpClientService, "dchp_client"))
-
     def test_dhcp_client_dispatches_to_dbus(self):
         proxy = _make_proxy(AppletDhcpClientService)
         proxy.call_sync = MagicMock()
@@ -51,49 +37,3 @@ class TestDBusProxies(TestCase):
         self.assertEqual(args[0], "org.blueman.Applet.DhcpClient.DhcpClient")
         self.assertEqual(args[1].get_type_string(), "o")
         self.assertEqual(args[1].unpack(), path)
-
-    # --- fuzz: every valid object path is forwarded verbatim, type "o" ---
-
-    def test_dhcp_client_fuzz_valid_paths(self):
-        # Object paths only allow [A-Za-z0-9_] segments separated by '/'.
-        segments = ["org", "bluez", "hci0", "hci15", "dev_00_11_22_33_44_55",
-                    "a", "A", "_", "x9", "Z_0"]
-        paths = ["/"]  # the root path is valid
-        for depth in range(1, len(segments) + 1):
-            paths.append("/" + "/".join(segments[:depth]))
-        # also a few address-shaped device paths
-        for n in range(16):
-            paths.append(f"/org/bluez/hci0/dev_{n:02d}_FF_FF_FF_FF_FF")
-
-        for path in paths:
-            with self.subTest(path=path):
-                proxy = _make_proxy(AppletDhcpClientService)
-                proxy.call_sync = MagicMock()
-                proxy.dchp_client(path)
-                args = proxy.call_sync.call_args.args
-                self.assertEqual(args[0], "org.blueman.Applet.DhcpClient.DhcpClient")
-                self.assertEqual(args[1].get_type_string(), "o")
-                self.assertEqual(args[1].unpack(), path)
-
-    def test_dhcp_client_fuzz_invalid_paths_raise(self):
-        # Malformed object paths must be rejected by GLib before any D-Bus call.
-        bad_paths = [
-            "", "not-a-path", "relative/x", "/end/", "//double",
-            "/has space", "/has-dash", "/has.dot", "/€uro", "/x/", " ",
-        ]
-        for path in bad_paths:
-            with self.subTest(path=path):
-                proxy = _make_proxy(AppletDhcpClientService)
-                proxy.call_sync = MagicMock()
-                with self.assertRaises((TypeError, ValueError, GLib.Error)):
-                    proxy.dchp_client(path)
-                proxy.call_sync.assert_not_called()
-
-    # --- guard: AppletStatusIconService is a real, kept proxy ---
-
-    def test_status_icon_service_is_proxy(self):
-        # It carries no public methods on purpose: it exists to subscribe to
-        # the org.blueman.Applet.StatusIcon interface signals in Tray.py.
-        # Deleting it would silence IconName/Visibility/ToolTip updates, so it
-        # must remain a ProxyBase subclass.
-        self.assertTrue(issubclass(AppletStatusIconService, ProxyBase))

--- a/test/main/test_dbus_proxies.py
+++ b/test/main/test_dbus_proxies.py
@@ -1,9 +1,99 @@
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
 
-from blueman.main.DBusProxies import ProxyBase
+from gi.repository import GLib
+
+from blueman.main.DBusProxies import (
+    ProxyBase,
+    AppletService,
+    AppletDhcpClientService,
+    AppletStatusIconService,
+)
 from blueman.gobject import SingletonGObjectMeta
+
+
+def _make_proxy(cls):
+    """Instantiate a ProxyBase subclass without touching a real D-Bus bus.
+
+    ProxyBase.__init__ would call Gio.DBusProxy.init() which needs a live bus.
+    We bypass it and reset the singleton cache so other tests are unaffected.
+    """
+    with patch.object(ProxyBase, "__init__", return_value=None):
+        cls._instance = None
+        instance = cls()
+    cls._instance = None
+    return instance
 
 
 class TestDBusProxies(TestCase):
     def test_metaclass(self):
         self.assertIsInstance(ProxyBase, SingletonGObjectMeta)
+
+    # --- regression: the DhcpClient method lives on the right proxy ---
+
+    def test_applet_service_has_no_dhcp_client(self):
+        # NetworkService used to call AppletService().dchp_client(...) which
+        # never existed on this interface. Lock that it stays absent here.
+        self.assertFalse(hasattr(AppletService, "dchp_client"))
+
+    def test_dhcp_client_proxy_exposes_method(self):
+        self.assertTrue(hasattr(AppletDhcpClientService, "dchp_client"))
+
+    def test_dhcp_client_dispatches_to_dbus(self):
+        proxy = _make_proxy(AppletDhcpClientService)
+        proxy.call_sync = MagicMock()
+
+        path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
+        proxy.dchp_client(path)
+
+        proxy.call_sync.assert_called_once()
+        args = proxy.call_sync.call_args.args
+        self.assertEqual(args[0], "org.blueman.Applet.DhcpClient.DhcpClient")
+        self.assertEqual(args[1].get_type_string(), "o")
+        self.assertEqual(args[1].unpack(), path)
+
+    # --- fuzz: every valid object path is forwarded verbatim, type "o" ---
+
+    def test_dhcp_client_fuzz_valid_paths(self):
+        # Object paths only allow [A-Za-z0-9_] segments separated by '/'.
+        segments = ["org", "bluez", "hci0", "hci15", "dev_00_11_22_33_44_55",
+                    "a", "A", "_", "x9", "Z_0"]
+        paths = ["/"]  # the root path is valid
+        for depth in range(1, len(segments) + 1):
+            paths.append("/" + "/".join(segments[:depth]))
+        # also a few address-shaped device paths
+        for n in range(16):
+            paths.append(f"/org/bluez/hci0/dev_{n:02d}_FF_FF_FF_FF_FF")
+
+        for path in paths:
+            with self.subTest(path=path):
+                proxy = _make_proxy(AppletDhcpClientService)
+                proxy.call_sync = MagicMock()
+                proxy.dchp_client(path)
+                args = proxy.call_sync.call_args.args
+                self.assertEqual(args[0], "org.blueman.Applet.DhcpClient.DhcpClient")
+                self.assertEqual(args[1].get_type_string(), "o")
+                self.assertEqual(args[1].unpack(), path)
+
+    def test_dhcp_client_fuzz_invalid_paths_raise(self):
+        # Malformed object paths must be rejected by GLib before any D-Bus call.
+        bad_paths = [
+            "", "not-a-path", "relative/x", "/end/", "//double",
+            "/has space", "/has-dash", "/has.dot", "/€uro", "/x/", " ",
+        ]
+        for path in bad_paths:
+            with self.subTest(path=path):
+                proxy = _make_proxy(AppletDhcpClientService)
+                proxy.call_sync = MagicMock()
+                with self.assertRaises((TypeError, ValueError, GLib.Error)):
+                    proxy.dchp_client(path)
+                proxy.call_sync.assert_not_called()
+
+    # --- guard: AppletStatusIconService is a real, kept proxy ---
+
+    def test_status_icon_service_is_proxy(self):
+        # It carries no public methods on purpose: it exists to subscribe to
+        # the org.blueman.Applet.StatusIcon interface signals in Tray.py.
+        # Deleting it would silence IconName/Visibility/ToolTip updates, so it
+        # must remain a ProxyBase subclass.
+        self.assertTrue(issubclass(AppletStatusIconService, ProxyBase))

--- a/test/services/meta/test_network_service.py
+++ b/test/services/meta/test_network_service.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 from blueman.services.meta.NetworkService import NetworkService
-from blueman.Service import Action
 
 # The package re-exports the NetworkService *class* under the name
 # ``blueman.services.meta.NetworkService``, shadowing the submodule. Grab the
@@ -23,14 +22,6 @@ def _make_service(object_path):
 
 
 class TestNetworkService(TestCase):
-    def test_renew_action_present(self):
-        service = _make_service("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF")
-        actions = service.common_actions
-        self.assertEqual(len(actions), 1)
-        action = next(iter(actions))
-        self.assertIsInstance(action, Action)
-        self.assertEqual(action.plugins, {"DhcpClient"})
-
     def test_renew_dispatches_to_dhcp_client_proxy(self):
         path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
         service = _make_service(path)
@@ -41,22 +32,3 @@ class TestNetworkService(TestCase):
 
         proxy_cls.assert_called_once_with()
         proxy_cls.return_value.dchp_client.assert_called_once_with(path)
-
-    def test_renew_does_not_use_bare_applet_service(self):
-        # Regression: must route through AppletDhcpClientService, which is the
-        # proxy that actually owns the dchp_client method.
-        self.assertTrue(hasattr(network_service_module, "AppletDhcpClientService"))
-        self.assertFalse(hasattr(network_service_module, "AppletService"))
-
-    def test_renew_fuzz_passes_object_path_through(self):
-        paths = ["/", "/org/bluez/hci0"]
-        for n in range(32):
-            paths.append(f"/org/bluez/hci{n}/dev_{n:02d}_11_22_33_44_55")
-
-        for path in paths:
-            with self.subTest(path=path):
-                service = _make_service(path)
-                action = next(iter(service.common_actions))
-                with patch.object(network_service_module, "AppletDhcpClientService") as proxy_cls:
-                    action.callback()
-                proxy_cls.return_value.dchp_client.assert_called_once_with(path)

--- a/test/services/meta/test_network_service.py
+++ b/test/services/meta/test_network_service.py
@@ -1,0 +1,62 @@
+from importlib import import_module
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from blueman.services.meta.NetworkService import NetworkService
+from blueman.Service import Action
+
+# The package re-exports the NetworkService *class* under the name
+# ``blueman.services.meta.NetworkService``, shadowing the submodule. Grab the
+# actual module object so we can patch the proxy it imports.
+network_service_module = import_module("blueman.services.meta.NetworkService")
+
+
+def _make_service(object_path):
+    # Bypass Service.__init__ (needs a real bluez Device); common_actions only
+    # touches self.device.get_object_path().
+    service = NetworkService.__new__(NetworkService)
+    device = MagicMock()
+    device.get_object_path.return_value = object_path
+    # Service.device is a read-only property backed by a name-mangled attr.
+    service._Service__device = device
+    return service
+
+
+class TestNetworkService(TestCase):
+    def test_renew_action_present(self):
+        service = _make_service("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF")
+        actions = service.common_actions
+        self.assertEqual(len(actions), 1)
+        action = next(iter(actions))
+        self.assertIsInstance(action, Action)
+        self.assertEqual(action.plugins, {"DhcpClient"})
+
+    def test_renew_dispatches_to_dhcp_client_proxy(self):
+        path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
+        service = _make_service(path)
+        action = next(iter(service.common_actions))
+
+        with patch.object(network_service_module, "AppletDhcpClientService") as proxy_cls:
+            action.callback()
+
+        proxy_cls.assert_called_once_with()
+        proxy_cls.return_value.dchp_client.assert_called_once_with(path)
+
+    def test_renew_does_not_use_bare_applet_service(self):
+        # Regression: must route through AppletDhcpClientService, which is the
+        # proxy that actually owns the dchp_client method.
+        self.assertTrue(hasattr(network_service_module, "AppletDhcpClientService"))
+        self.assertFalse(hasattr(network_service_module, "AppletService"))
+
+    def test_renew_fuzz_passes_object_path_through(self):
+        paths = ["/", "/org/bluez/hci0"]
+        for n in range(32):
+            paths.append(f"/org/bluez/hci{n}/dev_{n:02d}_11_22_33_44_55")
+
+        for path in paths:
+            with self.subTest(path=path):
+                service = _make_service(path)
+                action = next(iter(service.common_actions))
+                with patch.object(network_service_module, "AppletDhcpClientService") as proxy_cls:
+                    action.callback()
+                proxy_cls.return_value.dchp_client.assert_called_once_with(path)


### PR DESCRIPTION
NetworkService.common_actions called AppletService().dchp_client(), but the dchp_client method lives on the org.blueman.Applet.DhcpClient interface, exposed by AppletDhcpClientService — AppletService has no such method, so the "Renew IP Address" action raised AttributeError at call time. This also gives AppletDhcpClientService a real production call site.

Add unit + fuzz coverage:
- AppletDhcpClientService.dchp_client dispatches the correct method name and object-path variant; valid paths forwarded verbatim, malformed object paths rejected by GLib before any D-Bus call.
- NetworkService renew action dispatches to AppletDhcpClientService with the device object path; regression guard that AppletService is not referenced.
- Guard that AppletStatusIconService remains a ProxyBase subclass: it is a signal-only proxy required in Tray.py to receive StatusIcon-interface signals, so it must not be removed.

Tests avoid dbusmock so they run without a live bus.