### PR TITLE
security: validate network inputs before building shell/AT commands

### DIFF
--- a/blueman/main/NetConf.py
+++ b/blueman/main/NetConf.py
@@ -250,7 +250,7 @@ class UdhcpdHandler(DHCPHandler):
 
 class NetConf:
     _dhcp_handler: DHCPHandler | None = None
-    _ipt_rules: list[tuple[str, str, str]] = []
+    _ipt_rules: list[tuple[str, str, tuple[str, ...]]] = []
 
     _IPV4_SYS_PATH = pathlib.Path("/proc/sys/net/ipv4")
     _RUN_PATH = pathlib.Path("/var/run")
@@ -263,23 +263,42 @@ class NetConf:
             p.write_text("1")
 
     @classmethod
-    def _add_ipt_rule(cls, table: str, chain: str, rule: str) -> None:
-        cls._ipt_rules.append((table, chain, rule))
-        args = ["/sbin/iptables", "-t", table, "-A", chain] + rule.split(" ")
+    def _add_ipt_rule(cls, table: str, chain: str, *rule_args: str) -> None:
+        # Pass the rule as already-split arguments instead of splitting a single
+        # string on spaces. A value that contains a space (e.g. an address that
+        # was not validated) can no longer smuggle in extra iptables arguments.
+        cls._ipt_rules.append((table, chain, rule_args))
+        args = ["/sbin/iptables", "-t", table, "-A", chain, *rule_args]
         logging.debug(" ".join(args))
         ret = call(args)
         logging.info(f"Return code {ret}")
 
     @classmethod
     def _del_ipt_rules(cls) -> None:
-        for table, chain, rule in cls._ipt_rules:
-            call(["/sbin/iptables", "-t", table, "-D", chain] + rule.split(" "))
+        for table, chain, rule_args in cls._ipt_rules:
+            call(["/sbin/iptables", "-t", table, "-D", chain, *rule_args])
         cls._ipt_rules = []
         cls.unlock("iptables")
+
+    @staticmethod
+    def _validate_ipv4(ip4_address: str, ip4_mask: str) -> None:
+        # Reject anything that is not a plain IPv4 address before it reaches
+        # iptables/ip/ifconfig. This rules out embedded whitespace or other
+        # argument-injection payloads coming from the D-Bus caller.
+        try:
+            ipaddress.IPv4Address(ip4_address)
+        except ValueError:
+            raise NetworkSetupError(f"Invalid IPv4 address: {ip4_address!r}")
+        try:
+            ipaddress.IPv4Address(ip4_mask)
+        except ValueError:
+            raise NetworkSetupError(f"Invalid IPv4 netmask: {ip4_mask!r}")
 
     @classmethod
     def apply_settings(cls, ip4_address: str, ip4_mask: str, handler: type["DHCPHandler"],
                        address_changed: bool) -> None:
+        cls._validate_ipv4(ip4_address, ip4_mask)
+
         if not isinstance(cls._dhcp_handler, handler):
             if cls._dhcp_handler is not None:
                 cls._dhcp_handler.clean_up()
@@ -318,10 +337,10 @@ class NetConf:
         if address_changed or not cls.locked("iptables"):
             cls._del_ipt_rules()
 
-            cls._add_ipt_rule("nat", "POSTROUTING", f"-s {ip4_address}/{ip4_mask} -j MASQUERADE")
-            cls._add_ipt_rule("filter", "FORWARD", "-i pan1 -j ACCEPT")
-            cls._add_ipt_rule("filter", "FORWARD", "-o pan1 -j ACCEPT")
-            cls._add_ipt_rule("filter", "FORWARD", "-i pan1 -j ACCEPT")
+            cls._add_ipt_rule("nat", "POSTROUTING", "-s", f"{ip4_address}/{ip4_mask}", "-j", "MASQUERADE")
+            cls._add_ipt_rule("filter", "FORWARD", "-i", "pan1", "-j", "ACCEPT")
+            cls._add_ipt_rule("filter", "FORWARD", "-o", "pan1", "-j", "ACCEPT")
+            cls._add_ipt_rule("filter", "FORWARD", "-i", "pan1", "-j", "ACCEPT")
             cls.lock("iptables")
 
         if address_changed or not NetConf.locked("dhcp"):

--- a/blueman/main/PPPConnection.py
+++ b/blueman/main/PPPConnection.py
@@ -50,8 +50,15 @@ class PPPConnection(GObject.GObject):
         'error-occurred': (GObject.SignalFlags.NO_HOOKS, None, (str,))
     }
 
+    # 3GPP APN labels are alphanumerics separated by dots/dashes (TS 23.003).
+    # Anything else could break out of the quoted AT+CGDCONT argument below.
+    _APN_RE = re.compile(r"^[A-Za-z0-9.-]*$")
+
     def __init__(self, port: str, number: str = "*99#", apn: str = "", user: str = "", pwd: str = "") -> None:
         super().__init__()
+
+        if not self._APN_RE.match(apn):
+            raise PPPException(f"Invalid APN: {apn!r}")
 
         self.apn = apn
         self.number = number

--- a/blueman/main/PPPConnection.py
+++ b/blueman/main/PPPConnection.py
@@ -52,7 +52,7 @@ class PPPConnection(GObject.GObject):
 
     # 3GPP APN labels are alphanumerics separated by dots/dashes (TS 23.003).
     # Anything else could break out of the quoted AT+CGDCONT argument below.
-    _APN_RE = re.compile(r"^[A-Za-z0-9.-]*$")
+    _APN_RE = re.compile(r"[A-Za-z0-9.-]*\Z")
 
     def __init__(self, port: str, number: str = "*99#", apn: str = "", user: str = "", pwd: str = "") -> None:
         super().__init__()

--- a/blueman/plugins/mechanism/Rfcomm.py
+++ b/blueman/plugins/mechanism/Rfcomm.py
@@ -16,6 +16,13 @@ class Rfcomm(MechanismPlugin):
     def _close_rfcomm(self, port_id: int) -> None:
         out, err = subprocess.Popen(['ps', '-e', 'o', 'pid,args'], stdout=subprocess.PIPE).communicate()
         for line in out.decode("UTF-8").splitlines():
-            pid, cmdline = line.split(maxsplit=1)
+            fields = line.split(maxsplit=1)
+            # Skip header/blank/short rows that lack both a pid and a command.
+            if len(fields) != 2:
+                continue
+            pid, cmdline = fields
+            # The first column must be a numeric pid; ignore anything else.
+            if not pid.isdigit():
+                continue
             if f"blueman-rfcomm-watcher /dev/rfcomm{port_id:d}" in cmdline:
                 os.kill(int(pid), signal.SIGTERM)

--- a/test/main/test_netconf.py
+++ b/test/main/test_netconf.py
@@ -251,3 +251,87 @@ class TestNetConf(TestCase):
 
         self.assertFalse(NetConf.locked("netconfig"))
         self.assertFalse(NetConf.locked("iptables"))
+
+
+class TestValidateIpv4(TestCase):
+    def test_valid_addresses_pass(self) -> None:
+        for addr, mask in [
+            ("203.0.113.1", "255.255.255.0"),
+            ("10.0.0.1", "255.0.0.0"),
+            ("192.168.1.254", "255.255.255.252"),
+            ("0.0.0.0", "0.0.0.0"),
+            ("255.255.255.255", "255.255.255.255"),
+        ]:
+            with self.subTest(addr=addr, mask=mask):
+                # Must not raise.
+                NetConf._validate_ipv4(addr, mask)
+
+    def test_invalid_address_raises(self) -> None:
+        for bad in [
+            "203.0.113.1 -j ACCEPT",      # argument injection via space
+            "203.0.113.1/24",             # CIDR, not a bare address
+            "203.0.113.256",              # octet out of range
+            "203.0.113",                  # too few octets
+            "::1",                        # IPv6
+            "hostname",
+            "",
+            " ",
+            "203.0.113.1\n-j ACCEPT",     # newline injection
+            "0x7f.0.0.1",
+        ]:
+            with self.subTest(bad=bad):
+                with self.assertRaises(NetworkSetupError):
+                    NetConf._validate_ipv4(bad, "255.255.255.0")
+
+    def test_invalid_mask_raises(self) -> None:
+        for bad in ["255.255.255.0 extra", "notamask", "", "255.255.255"]:
+            with self.subTest(bad=bad):
+                with self.assertRaises(NetworkSetupError):
+                    NetConf._validate_ipv4("203.0.113.1", bad)
+
+    def test_fuzz_never_other_exception(self) -> None:
+        # Whatever the input, validation either passes or raises
+        # NetworkSetupError -- never a raw ValueError/TypeError.
+        samples = [
+            "1.2.3.4", "1.2.3.4 ", " 1.2.3.4", "1.2.3.4;rm -rf", "a.b.c.d",
+            "999.999.999.999", "1.2.3.4/255.255.255.0", "\t", "1.2.3.4\x00",
+            "12345", "-1.-1.-1.-1", "1.2.3.4 5.6.7.8",
+        ]
+        for s in samples:
+            with self.subTest(s=s):
+                try:
+                    NetConf._validate_ipv4(s, "255.255.255.0")
+                except NetworkSetupError:
+                    pass
+
+
+class TestIptablesRuleArgs(TestCase):
+    def setUp(self) -> None:
+        NetConf._ipt_rules = []
+        self.addCleanup(lambda: setattr(NetConf, "_ipt_rules", []))
+
+    @patch("blueman.main.NetConf.call", return_value=0)
+    def test_args_passed_without_splitting(self, call_mock: Mock) -> None:
+        NetConf._add_ipt_rule("nat", "POSTROUTING", "-s", "203.0.113.1/255.255.255.0", "-j", "MASQUERADE")
+        call_mock.assert_called_once_with(
+            ["/sbin/iptables", "-t", "nat", "-A", "POSTROUTING",
+             "-s", "203.0.113.1/255.255.255.0", "-j", "MASQUERADE"])
+
+    @patch("blueman.main.NetConf.call", return_value=0)
+    def test_value_with_space_stays_single_arg(self, call_mock: Mock) -> None:
+        # A value containing a space must remain one argument, not get split
+        # into extra iptables arguments.
+        NetConf._add_ipt_rule("filter", "FORWARD", "-s", "1.2.3.4 -j ACCEPT")
+        args = call_mock.call_args.args[0]
+        self.assertIn("1.2.3.4 -j ACCEPT", args)
+        self.assertEqual(args.count("-j"), 0)
+
+    @patch("blueman.main.NetConf.call", return_value=0)
+    def test_delete_uses_same_args(self, call_mock: Mock) -> None:
+        NetConf._add_ipt_rule("filter", "FORWARD", "-i", "pan1", "-j", "ACCEPT")
+        call_mock.reset_mock()
+        NetConf.unlock("iptables")
+        NetConf._del_ipt_rules()
+        call_mock.assert_called_once_with(
+            ["/sbin/iptables", "-t", "filter", "-D", "FORWARD", "-i", "pan1", "-j", "ACCEPT"])
+        self.assertEqual(NetConf._ipt_rules, [])

--- a/test/main/test_pppconnection.py
+++ b/test/main/test_pppconnection.py
@@ -17,7 +17,7 @@ class TestPPPConnectionApn(TestCase):
         self.assertIn('AT+CGDCONT=1,"IP","internet"', conn.commands)
 
     def test_valid_apns_accepted(self):
-        for apn in ["internet", "web.provider.com", "a-b.c", "APN123", "3g.example", ""]:
+        for apn in ["internet", "web.provider.com", "a-b.c", "APN123", "3g.example", "123456", "UPPERCASE.APN", "apn.v1-2.test", ""]:
             with self.subTest(apn=apn):
                 PPPConnection("/dev/rfcomm0", apn=apn)
 
@@ -32,6 +32,14 @@ class TestPPPConnectionApn(TestCase):
             "café",
             "foo\tbar",
             "foo,bar",
+            "apn'quote",
+            "apn$variable",
+            "apn&background",
+            "apn(parens)",
+            "apn#hash",
+            "apn!bang",
+            "apn@at",
+            "apn\rtrailer"
         ]:
             with self.subTest(apn=apn):
                 with self.assertRaises(PPPException):

--- a/test/main/test_pppconnection.py
+++ b/test/main/test_pppconnection.py
@@ -17,7 +17,10 @@ class TestPPPConnectionApn(TestCase):
         self.assertIn('AT+CGDCONT=1,"IP","internet"', conn.commands)
 
     def test_valid_apns_accepted(self):
-        for apn in ["internet", "web.provider.com", "a-b.c", "APN123", "3g.example", "123456", "UPPERCASE.APN", "apn.v1-2.test", ""]:
+        for apn in [
+            "internet", "web.provider.com", "a-b.c", "APN123", "3g.example",
+            "123456", "UPPERCASE.APN", "apn.v1-2.test", "",
+        ]:
             with self.subTest(apn=apn):
                 PPPConnection("/dev/rfcomm0", apn=apn)
 

--- a/test/main/test_pppconnection.py
+++ b/test/main/test_pppconnection.py
@@ -1,0 +1,64 @@
+from unittest import TestCase
+
+from blueman.main.PPPConnection import PPPConnection, PPPException
+
+
+def _cgdcont_commands(conn: PPPConnection):
+    return [c for c in conn.commands if isinstance(c, str) and c.startswith("AT+CGDCONT")]
+
+
+class TestPPPConnectionApn(TestCase):
+    def test_empty_apn_adds_no_cgdcont(self):
+        conn = PPPConnection("/dev/rfcomm0", apn="")
+        self.assertEqual(_cgdcont_commands(conn), [])
+
+    def test_valid_apn_builds_quoted_command(self):
+        conn = PPPConnection("/dev/rfcomm0", apn="internet")
+        self.assertIn('AT+CGDCONT=1,"IP","internet"', conn.commands)
+
+    def test_valid_apns_accepted(self):
+        for apn in ["internet", "web.provider.com", "a-b.c", "APN123", "3g.example", ""]:
+            with self.subTest(apn=apn):
+                PPPConnection("/dev/rfcomm0", apn=apn)
+
+    def test_invalid_apn_rejected(self):
+        for apn in [
+            'foo","extra',          # quote break-out
+            "foo bar",              # space
+            "foo;reboot",
+            "foo\nAT+X",            # newline injection
+            'a"b',
+            "foo/bar",
+            "café",
+            "foo\tbar",
+            "foo,bar",
+        ]:
+            with self.subTest(apn=apn):
+                with self.assertRaises(PPPException):
+                    PPPConnection("/dev/rfcomm0", apn=apn)
+
+    def test_rejected_apn_never_reaches_command(self):
+        # Defence in depth: an injection payload must never end up in a command.
+        with self.assertRaises(PPPException):
+            PPPConnection("/dev/rfcomm0", apn='x","IP","evil')
+
+    def test_fuzz_apn_no_unexpected_exception(self):
+        samples = [
+            "", "a", "A.B-C", "1234567890", "x" * 200,
+            "with space", "tab\tchar", "new\nline", 'quote"', "semi;colon",
+            "slash/", "comma,", "unicode-café", "null\x00byte", "%s%n",
+            "../../etc", "$(id)", "`id`", "&&ls",
+        ]
+        for apn in samples:
+            with self.subTest(apn=apn):
+                try:
+                    conn = PPPConnection("/dev/rfcomm0", apn=apn)
+                except PPPException:
+                    continue
+                # If accepted, the APN must be the safe charset and round-trip
+                # verbatim into exactly one quoted command.
+                cmds = _cgdcont_commands(conn)
+                if apn == "":
+                    self.assertEqual(cmds, [])
+                else:
+                    self.assertEqual(cmds, [f'AT+CGDCONT=1,"IP","{apn}"'])

--- a/test/plugins/mechanism/test_rfcomm.py
+++ b/test/plugins/mechanism/test_rfcomm.py
@@ -1,0 +1,84 @@
+import signal
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from blueman.plugins.mechanism.Rfcomm import Rfcomm
+
+
+def _make_rfcomm():
+    # MechanismPlugin.__init__ pulls timer/confirm_authorization off parent and
+    # calls on_load(), which only registers D-Bus methods on the (mock) parent.
+    return Rfcomm(Mock())
+
+
+def _popen_returning(ps_output: str):
+    proc = Mock()
+    proc.communicate.return_value = (ps_output.encode("UTF-8"), None)
+    return Mock(return_value=proc)
+
+
+class TestCloseRfcomm(TestCase):
+    def _run(self, ps_output: str, port_id: int = 0):
+        rfcomm = _make_rfcomm()
+        with patch("blueman.plugins.mechanism.Rfcomm.subprocess.Popen",
+                   _popen_returning(ps_output)), \
+                patch("blueman.plugins.mechanism.Rfcomm.os.kill") as kill_mock:
+            rfcomm._close_rfcomm(port_id)
+        return kill_mock
+
+    def test_kills_matching_watcher(self):
+        ps = (
+            "  PID COMMAND\n"
+            " 1234 blueman-rfcomm-watcher /dev/rfcomm0\n"
+            " 5678 some other process\n"
+        )
+        kill_mock = self._run(ps, port_id=0)
+        kill_mock.assert_called_once_with(1234, signal.SIGTERM)
+
+    def test_no_match_no_kill(self):
+        ps = " 1234 blueman-rfcomm-watcher /dev/rfcomm9\n"
+        kill_mock = self._run(ps, port_id=0)
+        kill_mock.assert_not_called()
+
+    def test_multiple_matches(self):
+        ps = (
+            " 100 blueman-rfcomm-watcher /dev/rfcomm0\n"
+            " 200 blueman-rfcomm-watcher /dev/rfcomm0\n"
+        )
+        kill_mock = self._run(ps, port_id=0)
+        self.assertEqual(kill_mock.call_count, 2)
+
+    def test_malformed_lines_do_not_crash(self):
+        # Blank line, header, single-field line, non-numeric pid -- all must be
+        # skipped rather than raising ValueError.
+        ps = (
+            "\n"
+            "PID COMMAND\n"
+            "justonetoken\n"
+            "notapid blueman-rfcomm-watcher /dev/rfcomm0\n"
+            "   \n"
+            " 4242 blueman-rfcomm-watcher /dev/rfcomm0\n"
+        )
+        kill_mock = self._run(ps, port_id=0)
+        # Only the well-formed numeric-pid match is killed.
+        kill_mock.assert_called_once_with(4242, signal.SIGTERM)
+
+    def test_empty_output(self):
+        kill_mock = self._run("", port_id=0)
+        kill_mock.assert_not_called()
+
+    def test_fuzz_arbitrary_ps_output_never_raises(self):
+        fragments = [
+            "", " ", "\t", "\n", "PID COMMAND", "0", "-1 x", "x x x",
+            "999999999999999999999 cmd", "12 a b c d e",
+            " 12 blueman-rfcomm-watcher /dev/rfcomm0",
+            "12\tblueman-rfcomm-watcher /dev/rfcomm0",
+            "  ��  ", "1.5 cmd", "+12 cmd", "0x10 cmd",
+        ]
+        # Build many pseudo-random line combinations deterministically.
+        for i in range(len(fragments)):
+            for j in range(len(fragments)):
+                ps = "\n".join([fragments[i], fragments[j], fragments[(i + j) % len(fragments)]])
+                with self.subTest(i=i, j=j):
+                    # Must not raise for any combination.
+                    self._run(ps, port_id=i % 3)


### PR DESCRIPTION
Harden three places where externally-influenced values were interpolated into command arguments without validation:

- NetConf: validate that the IPv4 address and netmask passed to apply_settings are plain IPv4 addresses before they reach ip/ifconfig/iptables, and build iptables rules from already-split argument lists instead of splitting a single string on spaces. A value containing a space can no longer inject extra iptables arguments.
- Rfcomm: the CloseRFCOMM handler parsed `ps` output with an unguarded split()/int(), so a malformed or unexpected line raised ValueError and aborted the mechanism. Skip rows that lack a numeric pid and a command.
- PPPConnection: validate the APN against the 3GPP label charset before embedding it in the quoted AT+CGDCONT command, preventing break-out of the quoted argument.

Add unit + fuzz coverage for each: IPv4 validation (valid/invalid/injection), iptables argument construction (no splitting, delete symmetry), ps-output parsing across malformed inputs, and APN acceptance/rejection with fuzzed payloads. Tests need no D-Bus or display.