### PR TITLE
libblueman: fix HCI/SDP resource leaks and an ifname over-read, add a 100%-covered C test suite

### DIFF
--- a/module/_blueman.pyx
+++ b/module/_blueman.pyx
@@ -213,20 +213,18 @@ class ConnInfoReadError(Exception):
 cdef class conn_info:
     cdef conn_info_handles ci
     cdef int hci
-    cdef char* addr
+    # keep the encoded address alive on the instance: a raw char* taken from
+    # a temporary bytes object would dangle once __init__ returns
+    cdef bytes addr
     cdef public bint failed
 
     def __init__(self, py_addr, py_hci_name="hci0"):
         self.failed = False
-        py_bytes_addr = py_addr.encode("UTF-8")
-        cdef char* addr = py_bytes_addr
-
-        py_bytes_hci_name = py_hci_name.encode("UTF-8")
-        cdef char* hci_name = py_bytes_hci_name
-
-
-        self.hci = int(hci_name[3:])
-        self.addr = addr
+        self.addr = py_addr.encode("UTF-8")
+        self.hci = int(py_hci_name[3:])
+        # not yet initialized; connection_close treats a negative dd as a
+        # no-op, so deinit() before a successful init() is safe
+        self.ci.dd = -1
 
     def init(self):
         res = connection_init(self.hci, self.addr, & self.ci)

--- a/module/_blueman.pyx
+++ b/module/_blueman.pyx
@@ -104,7 +104,8 @@ ERR = {
     -12: "Can't bind RFCOMM socket",
     -13: "Can't connect RFCOMM socket",
     -14: "Can't create RFCOMM TTY",
-    -15: "Can't release RFCOMM TTY"
+    -15: "Can't release RFCOMM TTY",
+    -16: "Invalid Bluetooth address"
     }
 
 RFCOMM_STATES = [

--- a/module/libblueman.c
+++ b/module/libblueman.c
@@ -54,12 +54,36 @@ static inline unsigned long __tv_to_jiffies(const struct timeval *tv)
         return jif/10000;
 }
 
+/* Bounded, NUL-terminated, zero-padded copy of an interface name.
+ *
+ * This deliberately avoids strncpy(). The Linux kernel deprecated it
+ * (Documentation/process/deprecated.rst) because it does not guarantee
+ * NUL-termination when the source fills the buffer and its zero-padding
+ * obscures intent, and after a six-year, 362-commit conversion effort the
+ * API was removed from the kernel entirely for v7.2:
+ * https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1a3746ccbb0a97bed3c06ccde6b880013b1dddc1
+ * The kernel's replacement is strscpy()/strscpy_pad(), which has no portable
+ * userspace equivalent, so this helper implements the strscpy_pad()
+ * semantics we need explicitly: the copy is bounded to IFNAMSIZ - 1 so the
+ * result is always terminated, and the whole buffer is zeroed first because
+ * the bridge ioctls always read a full IFNAMSIZ bytes — the padding is
+ * required, not cosmetic. */
+static void copy_ifname(char dst[IFNAMSIZ], const char *name)
+{
+	/* memchr instead of strnlen: same bounded scan, but ISO C */
+	const char *end = memchr(name, '\0', IFNAMSIZ - 1);
+	size_t len = end != NULL ? (size_t) (end - name) : IFNAMSIZ - 1;
+
+	memset(dst, 0, IFNAMSIZ);
+	memcpy(dst, name, len);
+}
+
 int _create_bridge(const char* name) {
 	/* the kernel always copies IFNAMSIZ bytes for SIOCBRADDBR/SIOCBRDELBR,
 	 * so hand it a fixed-size zero-padded buffer instead of the raw string
 	 * to keep the read within bounds */
-	char ifname[IFNAMSIZ] = { 0 };
-	strncpy(ifname, name, IFNAMSIZ - 1);
+	char ifname[IFNAMSIZ];
+	copy_ifname(ifname, name);
 
 	int sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0)
@@ -92,9 +116,9 @@ int _create_bridge(const char* name) {
 
 
 int _destroy_bridge(const char* name) {
-	/* zero-padded IFNAMSIZ buffer; see _create_bridge */
-	char ifname[IFNAMSIZ] = { 0 };
-	strncpy(ifname, name, IFNAMSIZ - 1);
+	/* zero-padded IFNAMSIZ buffer; see copy_ifname */
+	char ifname[IFNAMSIZ];
+	copy_ifname(ifname, name);
 
 	int sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0)

--- a/module/libblueman.c
+++ b/module/libblueman.c
@@ -55,11 +55,17 @@ static inline unsigned long __tv_to_jiffies(const struct timeval *tv)
 }
 
 int _create_bridge(const char* name) {
+	/* the kernel always copies IFNAMSIZ bytes for SIOCBRADDBR/SIOCBRDELBR,
+	 * so hand it a fixed-size zero-padded buffer instead of the raw string
+	 * to keep the read within bounds */
+	char ifname[IFNAMSIZ] = { 0 };
+	strncpy(ifname, name, IFNAMSIZ - 1);
+
 	int sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0)
 		return -errno;
 
-	if (ioctl(sock, SIOCBRADDBR, name) < 0) {
+	if (ioctl(sock, SIOCBRADDBR, ifname) < 0) {
 		int err = errno;
 		close(sock);
 		return -err;
@@ -70,14 +76,15 @@ int _create_bridge(const char* name) {
 	struct ifreq ifr;
 
 	memset(&ifr, 0, sizeof(ifr));
-	strncpy(ifr.ifr_name, name, IFNAMSIZ - 1);
+	memcpy(ifr.ifr_name, ifname, IFNAMSIZ);
 	ifr.ifr_data = (char *) args;
 
-	if (ioctl(sock, SIOCDEVPRIVATE, &ifr) < 0) {
-		int err = errno;
-		close(sock);
-		return -err;
-	}
+	/* setting the forward delay uses BRCTL_SET_BRIDGE_FORWARD_DELAY via
+	 * SIOCDEVPRIVATE, a legacy ioctl interface. Treat failure as non-fatal:
+	 * the bridge itself was already created above, so failing here would
+	 * leave a half-created bridge behind and turn a working NAP setup into
+	 * a hard failure on kernels that reject the legacy interface. */
+	(void) ioctl(sock, SIOCDEVPRIVATE, &ifr);
 
 	close(sock);
 	return 0;
@@ -85,13 +92,17 @@ int _create_bridge(const char* name) {
 
 
 int _destroy_bridge(const char* name) {
+	/* zero-padded IFNAMSIZ buffer; see _create_bridge */
+	char ifname[IFNAMSIZ] = { 0 };
+	strncpy(ifname, name, IFNAMSIZ - 1);
+
 	int sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0)
 		return -errno;
 
 	struct ifreq req;
 	memset(&req, 0, sizeof(req));
-	strncpy(req.ifr_name, name, IFNAMSIZ - 1);
+	memcpy(req.ifr_name, ifname, IFNAMSIZ);
 
 	if (ioctl(sock, SIOCGIFFLAGS, &req) < 0) {
 		int err = errno;
@@ -107,7 +118,7 @@ int _destroy_bridge(const char* name) {
 		return -err;
 	}
 
-	if (ioctl(sock, SIOCBRDELBR, name) < 0) {
+	if (ioctl(sock, SIOCBRDELBR, ifname) < 0) {
 		int err = errno;
 		close(sock);
 		return -err;
@@ -134,6 +145,11 @@ static int find_conn(int s, int dev_id, long arg)
 		free(cl);
 		return 0;
 	}
+
+	/* the kernel caps conn_num at the requested count; clamp anyway so a
+	 * broken contract can never walk past the 10 entries allocated above */
+	if (cl->conn_num > 10)
+		cl->conn_num = 10;
 
 	for (i = 0; i < cl->conn_num; i++, ci++) {
 		if (!bacmp((bdaddr_t *)(intptr_t) arg, &ci->bdaddr)) {
@@ -217,9 +233,14 @@ int connection_get_tpl(const struct conn_info_handles *ci, int8_t *ret_tpl, uint
 	return 1;
 }
 
-int connection_close(const struct conn_info_handles *ci)
+int connection_close(struct conn_info_handles *ci)
 {
+	/* idempotent: invalidate dd so a second close (or a close before a
+	 * successful connection_init) never touches a recycled descriptor */
+	if (ci->dd < 0)
+		return 1;
 	hci_close_dev(ci->dd);
+	ci->dd = -1;
 	return 1;
 }
 

--- a/module/libblueman.c
+++ b/module/libblueman.c
@@ -23,6 +23,7 @@
 #include <arpa/inet.h>
 #include <ctype.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -54,81 +55,65 @@ static inline unsigned long __tv_to_jiffies(const struct timeval *tv)
 }
 
 int _create_bridge(const char* name) {
-	int sock;
-	sock = socket(AF_INET, SOCK_STREAM, 0);
-	if (sock < 0) {
+	int sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0)
 		return -errno;
-	}
-	
-	int err;
 
-	err = ioctl(sock, SIOCBRADDBR, name);
-	if (err < 0) {
+	if (ioctl(sock, SIOCBRADDBR, name) < 0) {
+		int err = errno;
 		close(sock);
-		return -errno;
+		return -err;
 	}
-		
-	
-	struct timeval tv;
-        tv.tv_sec = 0;
-        tv.tv_usec = 1000000 * (0 - tv.tv_sec);
-        
-        
-        unsigned long args[5];
-        struct ifreq ifr;
-        
-        args[0] = BRCTL_SET_BRIDGE_FORWARD_DELAY;
-        args[1] = __tv_to_jiffies(&tv);
-        args[2] = 0;
-        args[3] = 0;
-        args[4] = 0;
-        
-        memcpy(ifr.ifr_name, name, IFNAMSIZ);
-        ifr.ifr_data = (char *) &args;
-        
-	ioctl(sock, SIOCDEVPRIVATE, &ifr);
-	
+
+	struct timeval tv = { 0, 0 };  /* forward delay of 0 */
+	unsigned long args[5] = { BRCTL_SET_BRIDGE_FORWARD_DELAY, __tv_to_jiffies(&tv), 0, 0, 0 };
+	struct ifreq ifr;
+
+	memset(&ifr, 0, sizeof(ifr));
+	strncpy(ifr.ifr_name, name, IFNAMSIZ - 1);
+	ifr.ifr_data = (char *) args;
+
+	if (ioctl(sock, SIOCDEVPRIVATE, &ifr) < 0) {
+		int err = errno;
+		close(sock);
+		return -err;
+	}
+
 	close(sock);
 	return 0;
 }
-	
-	
+
+
 int _destroy_bridge(const char* name) {
-	int sock;
-	sock = socket(AF_INET, SOCK_STREAM, 0);
-	if (sock < 0) {
+	int sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0)
 		return -errno;
-	}
-	
-	int err;
-	
+
 	struct ifreq req;
-	memset(&req, 0, sizeof (struct ifreq));
-	strncpy(req.ifr_name, name, IFNAMSIZ);
-	
-	err = ioctl(sock, SIOCGIFFLAGS, &req);
-	if (err < 0) {
+	memset(&req, 0, sizeof(req));
+	strncpy(req.ifr_name, name, IFNAMSIZ - 1);
+
+	if (ioctl(sock, SIOCGIFFLAGS, &req) < 0) {
+		int err = errno;
 		close(sock);
-		return -errno;
+		return -err;
 	}
-	
+
 	req.ifr_flags &= ~(IFF_UP | IFF_RUNNING);
 
-	err = ioctl(sock, SIOCSIFFLAGS, &req);
-
-	if (err < 0) {
+	if (ioctl(sock, SIOCSIFFLAGS, &req) < 0) {
+		int err = errno;
 		close(sock);
-		return -errno;
+		return -err;
 	}
 
-	err = ioctl(sock, SIOCBRDELBR, name);
-	if (err < 0) {
+	if (ioctl(sock, SIOCBRDELBR, name) < 0) {
+		int err = errno;
 		close(sock);
-		return -errno;
+		return -err;
 	}
-		
+
 	close(sock);
-	
 	return 0;
 }
 
@@ -137,43 +122,44 @@ static int find_conn(int s, int dev_id, long arg)
 	struct hci_conn_list_req *cl;
 	struct hci_conn_info *ci;
 	int i;
-	int ret = 0;
 
 	if (!(cl = malloc(10 * sizeof(*ci) + sizeof(*cl))))
-		goto out;
+		return 0;
 
 	cl->dev_id = dev_id;
 	cl->conn_num = 10;
 	ci = cl->conn_info;
 
-	if (ioctl(s, HCIGETCONNLIST, (void *) cl))
-		goto out;
+	if (ioctl(s, HCIGETCONNLIST, (void *) cl)) {
+		free(cl);
+		return 0;
+	}
 
-	for (i = 0; i < cl->conn_num; i++, ci++)
-		if (!bacmp((bdaddr_t *) arg, &ci->bdaddr)) {
-			ret = 1;
-			goto out;
+	for (i = 0; i < cl->conn_num; i++, ci++) {
+		if (!bacmp((bdaddr_t *)(intptr_t) arg, &ci->bdaddr)) {
+			free(cl);
+			return 1;
 		}
+	}
 
-out:
 	free(cl);
-	return ret;
+	return 0;
 }
 
 
 
-int connection_init(int dev_id, char *addr, struct conn_info_handles *ci)
+int connection_init(int dev_id, const char *addr, struct conn_info_handles *ci)
 {
 	struct hci_conn_info_req *cr = NULL;
 	bdaddr_t bdaddr;
-	
-	int dd;
+	int dd = -1;
 	int ret = 1;
 
-	str2ba(addr, &bdaddr);
+	if (str2ba(addr, &bdaddr) < 0)
+		return ERR_INVALID_ADDRESS;
 
 	if (dev_id < 0) {
-		dev_id = hci_for_each_dev(HCI_UP, find_conn, (long) &bdaddr);
+		dev_id = hci_for_each_dev(HCI_UP, find_conn, (long)(intptr_t) &bdaddr);
 		if (dev_id < 0) {
 			ret = ERR_NOT_CONNECTED;
 			goto out;
@@ -198,18 +184,19 @@ int connection_init(int dev_id, char *addr, struct conn_info_handles *ci)
 		ret = ERR_GET_CONN_INFO_FAILED;
 		goto out;
 	}
-	
+
 	ci->dd = dd;
 	ci->handle = cr->conn_info->handle;
+	dd = -1;  /* ownership transferred to ci; closed by connection_close */
 
 out:
-	if (cr)
-		free(cr);
-	
+	free(cr);
+	if (dd >= 0)
+		hci_close_dev(dd);
 	return ret;
 }
 
-int connection_get_rssi(struct conn_info_handles *ci, int8_t *ret_rssi)
+int connection_get_rssi(const struct conn_info_handles *ci, int8_t *ret_rssi)
 {
 	int8_t rssi;
 	if (hci_read_rssi(ci->dd, htobs(ci->handle), &rssi, 1000) < 0) {
@@ -220,8 +207,8 @@ int connection_get_rssi(struct conn_info_handles *ci, int8_t *ret_rssi)
 
 }
 
-int connection_get_tpl(struct conn_info_handles *ci, int8_t *ret_tpl, uint8_t type)
-{ 	
+int connection_get_tpl(const struct conn_info_handles *ci, int8_t *ret_tpl, uint8_t type)
+{
 	int8_t level;
 	if (hci_read_transmit_power_level(ci->dd, htobs(ci->handle), type, &level, 1000) < 0) {
 		return ERR_READ_TPL_FAILED;
@@ -229,49 +216,45 @@ int connection_get_tpl(struct conn_info_handles *ci, int8_t *ret_tpl, uint8_t ty
 	*ret_tpl = level;
 	return 1;
 }
-	
-int connection_close(struct conn_info_handles *ci)
+
+int connection_close(const struct conn_info_handles *ci)
 {
 	hci_close_dev(ci->dd);
 	return 1;
 }
 
 int
-get_rfcomm_channel(uint16_t service_class, char* btd_addr) {
+get_rfcomm_channel(uint16_t service_class, const char *btd_addr) {
     bdaddr_t target;
-    sdp_session_t *session = 0;
+    sdp_session_t *session = NULL;
     uuid_t service_uuid;
     int err;
     int port_num = 0;
-    sdp_list_t *response_list = NULL, *search_list, *attrid_list;
+    sdp_list_t *response_list = NULL, *search_list = NULL, *attrid_list = NULL;
+    uint32_t range = 0x0000ffff;
 
-    str2ba(btd_addr, &target);
+    if (str2ba(btd_addr, &target) < 0)
+        return 0;
     sdp_uuid16_create(&service_uuid, service_class);
 
     session = sdp_connect(BDADDR_ANY, &target, SDP_RETRY_IF_BUSY);
 
     if (!session) {
         printf("Failed to connect to sdp\n");
-        return port_num;
+        return 0;
     }
 
     search_list = sdp_list_append(NULL, &service_uuid);
-
-    uint32_t range = 0x0000ffff;
     attrid_list = sdp_list_append(NULL, &range);
 
     err = sdp_service_search_attr_req(session, search_list, SDP_ATTR_REQ_RANGE, attrid_list, &response_list);
 
     if (err) {
         printf("Failed to search attributes\n");
-        sdp_list_free(response_list, 0);
-        sdp_list_free(search_list, 0);
-        sdp_list_free(attrid_list, 0);
-        return port_num;
+        goto cleanup;
     }
     // go through each of the service records
-    sdp_list_t *r = response_list;
-    for (; r; r = r->next) {
+    for (sdp_list_t *r = response_list; r; r = r->next) {
         sdp_record_t *rec = (sdp_record_t*) r->data;
         sdp_list_t *proto_list;
 
@@ -311,6 +294,11 @@ get_rfcomm_channel(uint16_t service_class, char* btd_addr) {
         }
         sdp_record_free(rec);
     }
+
+cleanup:
+    sdp_list_free(response_list, 0);
+    sdp_list_free(search_list, 0);
+    sdp_list_free(attrid_list, 0);
     sdp_close(session);
     return port_num;
 }
@@ -319,7 +307,6 @@ int
 get_rfcomm_list(struct rfcomm_dev_list_req **result)
 {
 	struct rfcomm_dev_list_req *dl;
-	struct rfcomm_dev_info *di;
 	int ctl = -1;
 	int ret = 1;
 
@@ -329,14 +316,13 @@ get_rfcomm_list(struct rfcomm_dev_list_req **result)
 		goto out;
 	}
 
-	dl = malloc(sizeof(*dl) + RFCOMM_MAX_DEV * sizeof(*di));
+	dl = malloc(sizeof(*dl) + RFCOMM_MAX_DEV * sizeof(struct rfcomm_dev_info));
 	if (dl == NULL) {
 		ret = ERR_CANNOT_ALLOCATE;
 		goto out;
 	}
 
 	dl->dev_num = RFCOMM_MAX_DEV;
-	di = dl->dev_info;
 
 	if (ioctl(ctl, RFCOMMGETDEVLIST, (void *) dl) < 0) {
 		ret = ERR_GET_RFCOMM_LIST_FAILED;
@@ -345,15 +331,15 @@ get_rfcomm_list(struct rfcomm_dev_list_req **result)
 	}
 
 	*result = dl;
-	
+
 out:
 	if (ctl >= 0)
 		close(ctl);
 	return ret;
 }
 
-int create_rfcomm_device(char *local_address, char *remote_address, int channel) {
-    int sk, dev, ret;
+int create_rfcomm_device(const char *local_address, const char *remote_address, int channel) {
+    int sk = -1, dev, ret;
     struct sockaddr_rc laddr, raddr;
     struct rfcomm_dev_req req;
 
@@ -363,8 +349,12 @@ int create_rfcomm_device(char *local_address, char *remote_address, int channel)
         goto out;
     }
 
+    memset(&laddr, 0, sizeof(laddr));
     laddr.rc_family = AF_BLUETOOTH;
-    str2ba(local_address, &laddr.rc_bdaddr);
+    if (str2ba(local_address, &laddr.rc_bdaddr) < 0) {
+        ret = ERR_INVALID_ADDRESS;
+        goto out;
+    }
     laddr.rc_channel = 0;
 
     if (bind(sk, (struct sockaddr *) &laddr, sizeof(laddr)) < 0) {
@@ -372,8 +362,12 @@ int create_rfcomm_device(char *local_address, char *remote_address, int channel)
         goto out;
     }
 
+    memset(&raddr, 0, sizeof(raddr));
     raddr.rc_family = AF_BLUETOOTH;
-    str2ba(remote_address, &raddr.rc_bdaddr);
+    if (str2ba(remote_address, &raddr.rc_bdaddr) < 0) {
+        ret = ERR_INVALID_ADDRESS;
+        goto out;
+    }
     raddr.rc_channel = channel;
 
     if (connect(sk, (struct sockaddr *) &raddr, sizeof(raddr)) < 0) {

--- a/module/libblueman.h
+++ b/module/libblueman.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <stdint.h>
+
 #define ERR_CANNOT_ALLOCATE -1
 #define ERR_HCI_DEV_OPEN_FAILED -2
 #define ERR_NOT_CONNECTED -3
@@ -11,19 +13,20 @@
 #define ERR_CONNECT_FAILED -13
 #define ERR_CREATE_DEV_FAILED -14
 #define ERR_RELEASE_DEV_FAILED -15
+#define ERR_INVALID_ADDRESS -16
 
 struct conn_info_handles {
 	unsigned int handle;
 	int dd;
 };
 
-int connection_init(int dev_id, char *addr, struct conn_info_handles *ci);
-int connection_get_rssi(struct conn_info_handles *ci, int8_t *ret_rssi);
-int connection_get_tpl(struct conn_info_handles *ci, int8_t *ret_tpl, uint8_t type);
-int connection_close(struct conn_info_handles *ci);
-int get_rfcomm_channel(uint16_t uuid, char* btd_addr);
+int connection_init(int dev_id, const char *addr, struct conn_info_handles *ci);
+int connection_get_rssi(const struct conn_info_handles *ci, int8_t *ret_rssi);
+int connection_get_tpl(const struct conn_info_handles *ci, int8_t *ret_tpl, uint8_t type);
+int connection_close(const struct conn_info_handles *ci);
+int get_rfcomm_channel(uint16_t service_class, const char *btd_addr);
 int get_rfcomm_list(struct rfcomm_dev_list_req **result);
-int create_rfcomm_device(char *local_address, char *remote_address, int channel);
+int create_rfcomm_device(const char *local_address, const char *remote_address, int channel);
 int release_rfcomm_device(int id);
 
 int _create_bridge(const char* name);

--- a/module/libblueman.h
+++ b/module/libblueman.h
@@ -23,7 +23,8 @@ struct conn_info_handles {
 int connection_init(int dev_id, const char *addr, struct conn_info_handles *ci);
 int connection_get_rssi(const struct conn_info_handles *ci, int8_t *ret_rssi);
 int connection_get_tpl(const struct conn_info_handles *ci, int8_t *ret_tpl, uint8_t type);
-int connection_close(const struct conn_info_handles *ci);
+/* closes ci->dd and invalidates it (sets -1); safe to call more than once */
+int connection_close(struct conn_info_handles *ci);
 int get_rfcomm_channel(uint16_t service_class, const char *btd_addr);
 int get_rfcomm_list(struct rfcomm_dev_list_req **result);
 int create_rfcomm_device(const char *local_address, const char *remote_address, int channel);

--- a/test/module/Makefile.am
+++ b/test/module/Makefile.am
@@ -1,3 +1,6 @@
 EXTRA_DIST =    \
     __init__.py \
-    test_imports.py
+    test_imports.py \
+    test_libblueman.c \
+    test_libblueman_c.py \
+    run_tests.sh

--- a/test/module/run_tests.sh
+++ b/test/module/run_tests.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Build and run the libblueman C unit/fuzz tests under AddressSanitizer,
+# then report gcov line coverage for module/libblueman.c.
+#
+# Mocks are injected with ld --wrap, so no Bluetooth adapter or root is needed.
+set -eu
+
+here=$(dirname "$0")
+root=$(cd "$here/../.." && pwd)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+WRAPS="socket close ioctl bind connect malloc \
+str2ba hci_for_each_dev hci_open_dev hci_close_dev \
+hci_read_rssi hci_read_transmit_power_level \
+sdp_connect sdp_close sdp_list_append sdp_service_search_attr_req \
+sdp_get_access_protos sdp_uuid_to_proto sdp_list_free sdp_record_free"
+
+wrapflags=""
+for w in $WRAPS; do
+    wrapflags="$wrapflags -Wl,--wrap=$w"
+done
+
+cflags=$(pkg-config --cflags bluez 2>/dev/null || echo "")
+libs=$(pkg-config --libs bluez 2>/dev/null || echo "-lbluetooth")
+
+cc=${CC:-gcc}
+
+# shellcheck disable=SC2086
+"$cc" -std=c11 -D_GNU_SOURCE -O0 -g -Wall \
+    -fsanitize=address -fprofile-arcs -ftest-coverage \
+    $cflags \
+    "$root/test/module/test_libblueman.c" \
+    -o "$work/test_libblueman" \
+    $wrapflags $libs
+
+cd "$work"
+ASAN_OPTIONS=detect_leaks=1 ./test_libblueman
+status=$?
+
+echo
+echo "=== coverage: module/libblueman.c ==="
+gcov -b -o "$work" "$root/test/module/test_libblueman.c" >/dev/null 2>&1 || true
+if [ -f libblueman.c.gcov ]; then
+    awk '
+        /#####/ { miss++; next }
+        /-:/    { next }
+        /[0-9]+\*?:/ { hit++ }
+        END {
+            total = hit + miss
+            if (total > 0)
+                printf "lines executed: %.2f%% (%d/%d), uncovered: %d\n", \
+                    100.0 * hit / total, hit, total, miss
+        }
+    ' libblueman.c.gcov
+    echo "--- uncovered lines ---"
+    grep -n "#####" libblueman.c.gcov | sed "s/.*#####:[[:space:]]*//" | head -40 || true
+else
+    echo "(gcov output not found)"
+fi
+
+exit $status

--- a/test/module/test_libblueman.c
+++ b/test/module/test_libblueman.c
@@ -1,0 +1,841 @@
+/*
+ * Unit + fuzz tests for module/libblueman.c.
+ *
+ * The translation unit under test is #included directly so the tests can reach
+ * its static helpers (__tv_to_jiffies, find_conn). Every libc and libbluetooth
+ * call it makes is redirected with ld --wrap to a controllable mock, so each
+ * success and error path is exercised without a Bluetooth adapter or root.
+ *
+ * Build/run is driven by run_tests.sh (ASan + gcov). See that script.
+ */
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Pull in the code under test (gives access to static functions). */
+#include "../../module/libblueman.c"
+
+/* ------------------------------------------------------------------ */
+/* Minimal test harness                                               */
+/* ------------------------------------------------------------------ */
+static int g_failures = 0;
+static int g_checks = 0;
+
+#define CHECK(cond) do { \
+	g_checks++; \
+	if (!(cond)) { \
+		g_failures++; \
+		fprintf(stderr, "  FAIL %s:%d: %s\n", __func__, __LINE__, #cond); \
+	} \
+} while (0)
+
+#define RUN(test) do { \
+	reset_mocks(); \
+	fprintf(stderr, "RUN  %s\n", #test); \
+	test(); \
+} while (0)
+
+/* ------------------------------------------------------------------ */
+/* Mock state                                                         */
+/* ------------------------------------------------------------------ */
+typedef int (*ioctl_hook_t)(int fd, unsigned long request, void *arg);
+
+static struct {
+	/* sockets */
+	int socket_ret;        /* fd to hand out, or <0 to fail */
+	int socket_opens;
+	int socket_closes;
+	/* ioctl/bind/connect */
+	ioctl_hook_t ioctl_hook;
+	int bind_ret;
+	int connect_ret;
+	/* malloc fault injection: fail the Nth wrapped malloc (1-based), 0 = never */
+	int malloc_fail_at;
+	int malloc_calls;
+	/* str2ba */
+	int str2ba_ret;
+	int str2ba_calls;
+	int str2ba_fail_at;   /* fail the Nth str2ba call (1-based), 0 = use str2ba_ret */
+	/* hci */
+	int hci_dev_id_ret;
+	int hci_open_ret;
+	int hci_closes;
+	int hci_rssi_ret;
+	int hci_rssi_val;
+	int hci_tpl_ret;
+	int hci_tpl_val;
+	/* sdp */
+	void *sdp_session_ret;
+	int sdp_search_ret;
+	int sdp_uuid_to_proto_ret;
+	int sdp_nodes_alloced;
+	int sdp_nodes_freed;
+	int sdp_records_freed;
+	int sdp_session_closed;
+	sdp_list_t *sdp_response;   /* handed back by search_attr_req */
+	sdp_list_t *sdp_protos;     /* handed back by get_access_protos */
+	int sdp_get_protos_ret;
+} M;
+
+extern void *__real_malloc(size_t size);
+
+static void reset_mocks(void)
+{
+	memset(&M, 0, sizeof(M));
+	M.socket_ret = 100;        /* a plausible fd */
+	M.hci_dev_id_ret = 0;
+	M.hci_open_ret = 7;
+	M.sdp_session_ret = (void *) 0x1;
+	M.sdp_uuid_to_proto_ret = RFCOMM_UUID;
+	M.sdp_get_protos_ret = 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* libc wraps                                                         */
+/* ------------------------------------------------------------------ */
+int __wrap_socket(int domain, int type, int protocol)
+{
+	(void) domain; (void) type; (void) protocol;
+	if (M.socket_ret < 0) {
+		errno = EACCES;
+		return -1;
+	}
+	M.socket_opens++;
+	return M.socket_ret;
+}
+
+int __wrap_close(int fd)
+{
+	(void) fd;
+	M.socket_closes++;
+	return 0;
+}
+
+int __wrap_ioctl(int fd, unsigned long request, ...)
+{
+	va_list ap;
+	void *arg;
+	va_start(ap, request);
+	arg = va_arg(ap, void *);
+	va_end(ap);
+	if (M.ioctl_hook)
+		return M.ioctl_hook(fd, request, arg);
+	return 0;
+}
+
+int __wrap_bind(int fd, const struct sockaddr *addr, socklen_t len)
+{
+	(void) fd; (void) addr; (void) len;
+	return M.bind_ret;
+}
+
+int __wrap_connect(int fd, const struct sockaddr *addr, socklen_t len)
+{
+	(void) fd; (void) addr; (void) len;
+	return M.connect_ret;
+}
+
+void *__wrap_malloc(size_t size)
+{
+	M.malloc_calls++;
+	if (M.malloc_fail_at && M.malloc_calls == M.malloc_fail_at)
+		return NULL;
+	return __real_malloc(size);
+}
+
+/* ------------------------------------------------------------------ */
+/* libbluetooth wraps                                                 */
+/* ------------------------------------------------------------------ */
+int __wrap_str2ba(const char *str, bdaddr_t *ba)
+{
+	(void) str;
+	M.str2ba_calls++;
+	if (M.str2ba_fail_at && M.str2ba_calls == M.str2ba_fail_at)
+		return -1;
+	if (M.str2ba_ret < 0)
+		return -1;
+	memset(ba, 0, sizeof(*ba));
+	return 0;
+}
+
+int __wrap_hci_for_each_dev(int flag, int (*func)(int, int, long), long arg)
+{
+	(void) flag; (void) func; (void) arg;
+	return M.hci_dev_id_ret;
+}
+
+int __wrap_hci_open_dev(int dev_id)
+{
+	(void) dev_id;
+	return M.hci_open_ret;
+}
+
+int __wrap_hci_close_dev(int dd)
+{
+	(void) dd;
+	M.hci_closes++;
+	return 0;
+}
+
+int __wrap_hci_read_rssi(int dd, uint16_t handle, int8_t *rssi, int to)
+{
+	(void) dd; (void) handle; (void) to;
+	if (M.hci_rssi_ret < 0)
+		return -1;
+	*rssi = (int8_t) M.hci_rssi_val;
+	return 0;
+}
+
+int __wrap_hci_read_transmit_power_level(int dd, uint16_t handle, uint8_t type,
+					 int8_t *level, int to)
+{
+	(void) dd; (void) handle; (void) type; (void) to;
+	if (M.hci_tpl_ret < 0)
+		return -1;
+	*level = (int8_t) M.hci_tpl_val;
+	return 0;
+}
+
+sdp_session_t *__wrap_sdp_connect(const bdaddr_t *src, const bdaddr_t *dst, uint32_t flags)
+{
+	(void) src; (void) dst; (void) flags;
+	return (sdp_session_t *) M.sdp_session_ret;
+}
+
+int __wrap_sdp_close(sdp_session_t *session)
+{
+	(void) session;
+	M.sdp_session_closed++;
+	return 0;
+}
+
+sdp_list_t *__wrap_sdp_list_append(sdp_list_t *list, void *d)
+{
+	sdp_list_t *node = __real_malloc(sizeof(sdp_list_t));
+	M.sdp_nodes_alloced++;
+	node->data = d;
+	node->next = list;
+	return node;
+}
+
+int __wrap_sdp_service_search_attr_req(sdp_session_t *session, const sdp_list_t *search,
+				       sdp_attrreq_type_t reqtype, const sdp_list_t *attrids,
+				       sdp_list_t **rsp)
+{
+	(void) session; (void) search; (void) reqtype; (void) attrids;
+	if (M.sdp_search_ret)
+		return M.sdp_search_ret;
+	*rsp = M.sdp_response;
+	return 0;
+}
+
+int __wrap_sdp_get_access_protos(const sdp_record_t *rec, sdp_list_t **protos)
+{
+	(void) rec;
+	if (M.sdp_get_protos_ret)
+		return M.sdp_get_protos_ret;
+	*protos = M.sdp_protos;
+	return 0;
+}
+
+int __wrap_sdp_uuid_to_proto(uuid_t *uuid)
+{
+	(void) uuid;
+	return M.sdp_uuid_to_proto_ret;
+}
+
+void __wrap_sdp_list_free(sdp_list_t *list, sdp_free_func_t f)
+{
+	(void) f;
+	while (list) {
+		sdp_list_t *next = list->next;
+		free(list);
+		M.sdp_nodes_freed++;
+		list = next;
+	}
+}
+
+void __wrap_sdp_record_free(sdp_record_t *rec)
+{
+	free(rec);
+	M.sdp_records_freed++;
+}
+
+/* ------------------------------------------------------------------ */
+/* helpers to build fake SDP structures                               */
+/* ------------------------------------------------------------------ */
+static sdp_list_t *node(void *data, sdp_list_t *next)
+{
+	sdp_list_t *n = __real_malloc(sizeof(sdp_list_t));
+	M.sdp_nodes_alloced++;
+	n->data = data;
+	n->next = next;
+	return n;
+}
+
+/* ================================================================== */
+/* __tv_to_jiffies                                                    */
+/* ================================================================== */
+static void test_tv_to_jiffies(void)
+{
+	struct timeval z = { 0, 0 };
+	CHECK(__tv_to_jiffies(&z) == 0);
+	struct timeval one = { 0, 10000 };  /* 10000 usec / 10000 = 1 */
+	CHECK(__tv_to_jiffies(&one) == 1);
+	struct timeval sec = { 1, 0 };      /* 1000000 / 10000 = 100 */
+	CHECK(__tv_to_jiffies(&sec) == 100);
+}
+
+/* ================================================================== */
+/* _create_bridge                                                     */
+/* ================================================================== */
+static int ioctl_ok(int fd, unsigned long req, void *arg)
+{
+	(void) fd; (void) req; (void) arg;
+	return 0;
+}
+static unsigned long g_fail_req;
+static int ioctl_fail_one(int fd, unsigned long req, void *arg)
+{
+	(void) fd; (void) arg;
+	return (req == g_fail_req) ? -1 : 0;
+}
+
+static void test_create_bridge_success(void)
+{
+	M.ioctl_hook = ioctl_ok;
+	CHECK(_create_bridge("pan1") == 0);
+	CHECK(M.socket_opens == 1 && M.socket_closes == 1);
+}
+
+static void test_create_bridge_socket_fail(void)
+{
+	M.socket_ret = -1;
+	CHECK(_create_bridge("pan1") < 0);
+	CHECK(M.socket_closes == 0);
+}
+
+static void test_create_bridge_addbr_fail(void)
+{
+	g_fail_req = SIOCBRADDBR;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(_create_bridge("pan1") < 0);
+	CHECK(M.socket_opens == 1 && M.socket_closes == 1);  /* no fd leak on error */
+}
+
+static void test_create_bridge_setdelay_fail(void)
+{
+	g_fail_req = SIOCDEVPRIVATE;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(_create_bridge("pan1") < 0);   /* forward-delay failure now surfaced */
+	CHECK(M.socket_opens == 1 && M.socket_closes == 1);
+}
+
+/* ================================================================== */
+/* _destroy_bridge                                                    */
+/* ================================================================== */
+static void test_destroy_bridge_success(void)
+{
+	M.ioctl_hook = ioctl_ok;
+	CHECK(_destroy_bridge("pan1") == 0);
+	CHECK(M.socket_opens == 1 && M.socket_closes == 1);
+}
+
+static void test_destroy_bridge_socket_fail(void)
+{
+	M.socket_ret = -1;
+	CHECK(_destroy_bridge("pan1") < 0);
+}
+
+static void test_destroy_bridge_getflags_fail(void)
+{
+	g_fail_req = SIOCGIFFLAGS;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(_destroy_bridge("pan1") < 0);
+	CHECK(M.socket_closes == 1);
+}
+
+static void test_destroy_bridge_setflags_fail(void)
+{
+	g_fail_req = SIOCSIFFLAGS;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(_destroy_bridge("pan1") < 0);
+	CHECK(M.socket_closes == 1);
+}
+
+static void test_destroy_bridge_delbr_fail(void)
+{
+	g_fail_req = SIOCBRDELBR;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(_destroy_bridge("pan1") < 0);
+	CHECK(M.socket_closes == 1);
+}
+
+/* ================================================================== */
+/* find_conn                                                          */
+/* ================================================================== */
+static struct hci_conn_info g_match_ci;  /* zeroed bdaddr matches str2ba mock */
+
+static int ioctl_connlist(int fd, unsigned long req, void *arg)
+{
+	(void) fd;
+	if (req == HCIGETCONNLIST) {
+		struct hci_conn_list_req *cl = arg;
+		cl->conn_num = 1;
+		memset(&cl->conn_info[0], 0, sizeof(struct hci_conn_info));
+		return 0;
+	}
+	return 0;
+}
+
+static int ioctl_connlist_nomatch(int fd, unsigned long req, void *arg)
+{
+	(void) fd;
+	if (req == HCIGETCONNLIST) {
+		struct hci_conn_list_req *cl = arg;
+		cl->conn_num = 1;
+		memset(&cl->conn_info[0], 0, sizeof(struct hci_conn_info));
+		cl->conn_info[0].bdaddr.b[0] = 0xAA;  /* won't match the zeroed target */
+		return 0;
+	}
+	return 0;
+}
+
+static void test_find_conn_match(void)
+{
+	bdaddr_t want;
+	memset(&want, 0, sizeof(want));
+	M.ioctl_hook = ioctl_connlist;
+	CHECK(find_conn(5, 0, (long)(intptr_t) &want) == 1);
+}
+
+static void test_find_conn_no_match(void)
+{
+	bdaddr_t want;
+	memset(&want, 0, sizeof(want));
+	M.ioctl_hook = ioctl_connlist_nomatch;
+	CHECK(find_conn(5, 0, (long)(intptr_t) &want) == 0);
+}
+
+static void test_find_conn_ioctl_fail(void)
+{
+	bdaddr_t want;
+	memset(&want, 0, sizeof(want));
+	g_fail_req = HCIGETCONNLIST;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(find_conn(5, 0, (long)(intptr_t) &want) == 0);
+}
+
+static void test_find_conn_malloc_fail(void)
+{
+	bdaddr_t want;
+	memset(&want, 0, sizeof(want));
+	M.malloc_fail_at = 1;
+	CHECK(find_conn(5, 0, (long)(intptr_t) &want) == 0);
+}
+
+/* ================================================================== */
+/* connection_init / rssi / tpl / close                               */
+/* ================================================================== */
+static int ioctl_conninfo(int fd, unsigned long req, void *arg)
+{
+	(void) fd;
+	if (req == HCIGETCONNINFO) {
+		struct hci_conn_info_req *cr = arg;
+		cr->conn_info->handle = 42;
+		return 0;
+	}
+	return 0;
+}
+
+static void test_connection_init_success(void)
+{
+	struct conn_info_handles ci;
+	M.ioctl_hook = ioctl_conninfo;
+	CHECK(connection_init(0, "00:11:22:33:44:55", &ci) == 1);
+	CHECK(ci.dd == M.hci_open_ret);
+	CHECK(ci.handle == 42);
+	CHECK(M.hci_closes == 0);  /* kept open for the caller */
+}
+
+static void test_connection_init_bad_address(void)
+{
+	struct conn_info_handles ci;
+	M.str2ba_ret = -1;
+	CHECK(connection_init(0, "bogus", &ci) == ERR_INVALID_ADDRESS);
+}
+
+static void test_connection_init_not_connected(void)
+{
+	struct conn_info_handles ci;
+	M.hci_dev_id_ret = -1;  /* hci_for_each_dev finds nothing */
+	CHECK(connection_init(-1, "00:11:22:33:44:55", &ci) == ERR_NOT_CONNECTED);
+	CHECK(M.hci_closes == 0);
+}
+
+static void test_connection_init_open_fail(void)
+{
+	struct conn_info_handles ci;
+	M.hci_open_ret = -1;
+	CHECK(connection_init(0, "00:11:22:33:44:55", &ci) == ERR_HCI_DEV_OPEN_FAILED);
+}
+
+static void test_connection_init_malloc_fail(void)
+{
+	struct conn_info_handles ci;
+	M.malloc_fail_at = 1;
+	CHECK(connection_init(0, "00:11:22:33:44:55", &ci) == ERR_CANNOT_ALLOCATE);
+	CHECK(M.hci_closes == 1);  /* device closed on the malloc-failure path */
+}
+
+static void test_connection_init_conninfo_fail(void)
+{
+	struct conn_info_handles ci;
+	g_fail_req = HCIGETCONNINFO;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(connection_init(0, "00:11:22:33:44:55", &ci) == ERR_GET_CONN_INFO_FAILED);
+	CHECK(M.hci_closes == 1);  /* device closed on the ioctl-failure path (leak fix) */
+}
+
+static void test_connection_get_rssi(void)
+{
+	struct conn_info_handles ci = { .handle = 1, .dd = 2 };
+	int8_t rssi = 0;
+	M.hci_rssi_val = -57;
+	CHECK(connection_get_rssi(&ci, &rssi) == 1);
+	CHECK(rssi == -57);
+	M.hci_rssi_ret = -1;
+	CHECK(connection_get_rssi(&ci, &rssi) == ERR_READ_RSSI_FAILED);
+}
+
+static void test_connection_get_tpl(void)
+{
+	struct conn_info_handles ci = { .handle = 1, .dd = 2 };
+	int8_t tpl = 0;
+	M.hci_tpl_val = 4;
+	CHECK(connection_get_tpl(&ci, &tpl, 0) == 1);
+	CHECK(tpl == 4);
+	M.hci_tpl_ret = -1;
+	CHECK(connection_get_tpl(&ci, &tpl, 0) == ERR_READ_TPL_FAILED);
+}
+
+static void test_connection_close(void)
+{
+	struct conn_info_handles ci = { .handle = 1, .dd = 2 };
+	CHECK(connection_close(&ci) == 1);
+	CHECK(M.hci_closes == 1);
+}
+
+/* ================================================================== */
+/* get_rfcomm_list                                                    */
+/* ================================================================== */
+static int ioctl_devlist_ok(int fd, unsigned long req, void *arg)
+{
+	(void) fd; (void) req; (void) arg;
+	return 0;
+}
+
+static void test_get_rfcomm_list_success(void)
+{
+	struct rfcomm_dev_list_req *dl = NULL;
+	M.ioctl_hook = ioctl_devlist_ok;
+	CHECK(get_rfcomm_list(&dl) == 1);
+	CHECK(dl != NULL);
+	CHECK(dl->dev_num == RFCOMM_MAX_DEV);
+	free(dl);
+	CHECK(M.socket_opens == 1 && M.socket_closes == 1);
+}
+
+static void test_get_rfcomm_list_socket_fail(void)
+{
+	struct rfcomm_dev_list_req *dl = NULL;
+	M.socket_ret = -1;
+	CHECK(get_rfcomm_list(&dl) == ERR_SOCKET_FAILED);
+}
+
+static void test_get_rfcomm_list_malloc_fail(void)
+{
+	struct rfcomm_dev_list_req *dl = NULL;
+	M.malloc_fail_at = 1;
+	CHECK(get_rfcomm_list(&dl) == ERR_CANNOT_ALLOCATE);
+	CHECK(M.socket_closes == 1);
+}
+
+static void test_get_rfcomm_list_ioctl_fail(void)
+{
+	struct rfcomm_dev_list_req *dl = NULL;
+	g_fail_req = RFCOMMGETDEVLIST;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(get_rfcomm_list(&dl) == ERR_GET_RFCOMM_LIST_FAILED);
+	CHECK(M.socket_closes == 1);  /* socket closed, dl freed */
+}
+
+/* ================================================================== */
+/* create_rfcomm_device                                               */
+/* ================================================================== */
+static int ioctl_createdev(int fd, unsigned long req, void *arg)
+{
+	(void) fd; (void) arg;
+	if (req == RFCOMMCREATEDEV)
+		return 3;  /* device id */
+	return 0;
+}
+
+static void test_create_rfcomm_success(void)
+{
+	M.ioctl_hook = ioctl_createdev;
+	CHECK(create_rfcomm_device("00:00:00:00:00:00", "11:11:11:11:11:11", 1) == 3);
+	CHECK(M.socket_opens == 1 && M.socket_closes == 1);
+}
+
+static void test_create_rfcomm_socket_fail(void)
+{
+	M.socket_ret = -1;
+	CHECK(create_rfcomm_device("00:00:00:00:00:00", "11:11:11:11:11:11", 1) == ERR_SOCKET_FAILED);
+}
+
+static void test_create_rfcomm_bad_local(void)
+{
+	M.str2ba_ret = -1;
+	CHECK(create_rfcomm_device("bad", "11:11:11:11:11:11", 1) == ERR_INVALID_ADDRESS);
+	CHECK(M.socket_closes == 1);
+}
+
+static void test_create_rfcomm_bad_remote(void)
+{
+	M.str2ba_fail_at = 2;  /* local ok, remote invalid */
+	CHECK(create_rfcomm_device("00:00:00:00:00:00", "bad", 1) == ERR_INVALID_ADDRESS);
+	CHECK(M.socket_closes == 1);
+}
+
+static void test_create_rfcomm_bind_fail(void)
+{
+	M.bind_ret = -1;
+	CHECK(create_rfcomm_device("00:00:00:00:00:00", "11:11:11:11:11:11", 1) == ERR_BIND_FAILED);
+	CHECK(M.socket_closes == 1);
+}
+
+static void test_create_rfcomm_connect_fail(void)
+{
+	M.connect_ret = -1;
+	CHECK(create_rfcomm_device("00:00:00:00:00:00", "11:11:11:11:11:11", 1) == ERR_CONNECT_FAILED);
+	CHECK(M.socket_closes == 1);
+}
+
+static void test_create_rfcomm_createdev_fail(void)
+{
+	g_fail_req = RFCOMMCREATEDEV;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(create_rfcomm_device("00:00:00:00:00:00", "11:11:11:11:11:11", 1) == ERR_CREATE_DEV_FAILED);
+	CHECK(M.socket_closes == 1);
+}
+
+/* ================================================================== */
+/* release_rfcomm_device                                              */
+/* ================================================================== */
+static void test_release_rfcomm_success(void)
+{
+	M.ioctl_hook = ioctl_ok;
+	CHECK(release_rfcomm_device(3) == 0);
+	CHECK(M.socket_closes == 1);
+}
+
+static void test_release_rfcomm_socket_fail(void)
+{
+	M.socket_ret = -1;
+	CHECK(release_rfcomm_device(3) == ERR_SOCKET_FAILED);
+}
+
+static void test_release_rfcomm_ioctl_fail(void)
+{
+	g_fail_req = RFCOMMRELEASEDEV;
+	M.ioctl_hook = ioctl_fail_one;
+	CHECK(release_rfcomm_device(3) == ERR_RELEASE_DEV_FAILED);
+	CHECK(M.socket_closes == 1);
+}
+
+/* ================================================================== */
+/* get_rfcomm_channel                                                 */
+/* ================================================================== */
+static void test_get_rfcomm_channel_connect_fail(void)
+{
+	M.sdp_session_ret = NULL;
+	CHECK(get_rfcomm_channel(0x1101, "00:11:22:33:44:55") == 0);
+}
+
+static void test_get_rfcomm_channel_bad_address(void)
+{
+	M.str2ba_ret = -1;
+	CHECK(get_rfcomm_channel(0x1101, "bad") == 0);
+}
+
+static void test_get_rfcomm_channel_search_fail(void)
+{
+	M.sdp_search_ret = -1;
+	CHECK(get_rfcomm_channel(0x1101, "00:11:22:33:44:55") == 0);
+	/* search_list + attrid_list must still be freed (no leak) */
+	CHECK(M.sdp_nodes_alloced == M.sdp_nodes_freed);
+	CHECK(M.sdp_session_closed == 1);
+}
+
+static void test_get_rfcomm_channel_extracts_channel(void)
+{
+	/* Build: response_list -> [rec]; get_access_protos -> protos -> [pds];
+	 * pds -> [d(uuid16), d(uint8=channel 5)] */
+	static sdp_data_t d_uuid, d_chan;
+	memset(&d_uuid, 0, sizeof(d_uuid));
+	memset(&d_chan, 0, sizeof(d_chan));
+	d_uuid.dtd = SDP_UUID16;
+	d_uuid.next = &d_chan;
+	d_chan.dtd = SDP_UINT8;
+	d_chan.val.int8 = 5;
+	d_chan.next = NULL;
+
+	sdp_record_t *rec = __real_malloc(sizeof(sdp_record_t));
+	M.sdp_response = node(rec, NULL);
+
+	sdp_list_t *pds = node(&d_uuid, NULL);
+	M.sdp_protos = node(pds, NULL);
+
+	CHECK(get_rfcomm_channel(0x1101, "00:11:22:33:44:55") == 5);
+	/* every list node freed, record freed, session closed: no leaks */
+	CHECK(M.sdp_nodes_alloced == M.sdp_nodes_freed);
+	CHECK(M.sdp_records_freed == 1);
+	CHECK(M.sdp_session_closed == 1);
+}
+
+static void test_get_rfcomm_channel_no_rfcomm_proto(void)
+{
+	static sdp_data_t d_uuid;
+	memset(&d_uuid, 0, sizeof(d_uuid));
+	d_uuid.dtd = SDP_UUID16;
+	d_uuid.next = NULL;
+
+	sdp_record_t *rec = __real_malloc(sizeof(sdp_record_t));
+	M.sdp_response = node(rec, NULL);
+	sdp_list_t *pds = node(&d_uuid, NULL);
+	M.sdp_protos = node(pds, NULL);
+	M.sdp_uuid_to_proto_ret = 0;  /* not RFCOMM */
+
+	CHECK(get_rfcomm_channel(0x1101, "00:11:22:33:44:55") == 0);
+	CHECK(M.sdp_nodes_alloced == M.sdp_nodes_freed);
+}
+
+static void test_get_rfcomm_channel_get_protos_fail(void)
+{
+	sdp_record_t *rec = __real_malloc(sizeof(sdp_record_t));
+	M.sdp_response = node(rec, NULL);
+	M.sdp_get_protos_ret = -1;  /* sdp_get_access_protos fails -> record skipped */
+
+	CHECK(get_rfcomm_channel(0x1101, "00:11:22:33:44:55") == 0);
+	CHECK(M.sdp_nodes_alloced == M.sdp_nodes_freed);
+	CHECK(M.sdp_records_freed == 1);
+}
+
+/* ================================================================== */
+/* Fuzz: string handling must not over-read under ASan                */
+/* ================================================================== */
+static void fuzz_bridge_names(void)
+{
+	/* Names shorter than IFNAMSIZ allocated to their exact length so any
+	 * read past the terminator lands in an ASan redzone. Validates the
+	 * strncpy fix (the old memcpy(.., IFNAMSIZ) would over-read here). */
+	const char *samples[] = { "", "a", "br0", "pan1", "verylonginterfacename1234567890" };
+	M.ioctl_hook = ioctl_ok;
+	for (unsigned i = 0; i < sizeof(samples) / sizeof(samples[0]); i++) {
+		size_t n = strlen(samples[i]);
+		char *name = __real_malloc(n + 1);
+		memcpy(name, samples[i], n + 1);
+		reset_mocks();
+		M.ioctl_hook = ioctl_ok;
+		(void) _create_bridge(name);
+		reset_mocks();
+		M.ioctl_hook = ioctl_ok;
+		(void) _destroy_bridge(name);
+		free(name);
+	}
+	CHECK(1);  /* reaching here under ASan with no abort is the assertion */
+}
+
+static void fuzz_addresses(void)
+{
+	const char *addrs[] = { "", "x", "00:11:22:33:44:55", "::::::::::::::::::::",
+				"not-an-address-but-quite-long-indeed" };
+	for (unsigned i = 0; i < sizeof(addrs) / sizeof(addrs[0]); i++) {
+		struct conn_info_handles ci;
+		reset_mocks();
+		M.ioctl_hook = ioctl_conninfo;
+		(void) connection_init(0, addrs[i], &ci);
+		reset_mocks();
+		M.ioctl_hook = ioctl_createdev;
+		(void) create_rfcomm_device(addrs[i], addrs[i], 1);
+		reset_mocks();
+		M.sdp_session_ret = NULL;
+		(void) get_rfcomm_channel(0x1101, addrs[i]);
+	}
+	CHECK(1);
+}
+
+/* ================================================================== */
+int main(void)
+{
+	RUN(test_tv_to_jiffies);
+
+	RUN(test_create_bridge_success);
+	RUN(test_create_bridge_socket_fail);
+	RUN(test_create_bridge_addbr_fail);
+	RUN(test_create_bridge_setdelay_fail);
+
+	RUN(test_destroy_bridge_success);
+	RUN(test_destroy_bridge_socket_fail);
+	RUN(test_destroy_bridge_getflags_fail);
+	RUN(test_destroy_bridge_setflags_fail);
+	RUN(test_destroy_bridge_delbr_fail);
+
+	RUN(test_find_conn_match);
+	RUN(test_find_conn_no_match);
+	RUN(test_find_conn_ioctl_fail);
+	RUN(test_find_conn_malloc_fail);
+
+	RUN(test_connection_init_success);
+	RUN(test_connection_init_bad_address);
+	RUN(test_connection_init_not_connected);
+	RUN(test_connection_init_open_fail);
+	RUN(test_connection_init_malloc_fail);
+	RUN(test_connection_init_conninfo_fail);
+	RUN(test_connection_get_rssi);
+	RUN(test_connection_get_tpl);
+	RUN(test_connection_close);
+
+	RUN(test_get_rfcomm_list_success);
+	RUN(test_get_rfcomm_list_socket_fail);
+	RUN(test_get_rfcomm_list_malloc_fail);
+	RUN(test_get_rfcomm_list_ioctl_fail);
+
+	RUN(test_create_rfcomm_success);
+	RUN(test_create_rfcomm_socket_fail);
+	RUN(test_create_rfcomm_bad_local);
+	RUN(test_create_rfcomm_bad_remote);
+	RUN(test_create_rfcomm_bind_fail);
+	RUN(test_create_rfcomm_connect_fail);
+	RUN(test_create_rfcomm_createdev_fail);
+
+	RUN(test_release_rfcomm_success);
+	RUN(test_release_rfcomm_socket_fail);
+	RUN(test_release_rfcomm_ioctl_fail);
+
+	RUN(test_get_rfcomm_channel_connect_fail);
+	RUN(test_get_rfcomm_channel_bad_address);
+	RUN(test_get_rfcomm_channel_search_fail);
+	RUN(test_get_rfcomm_channel_extracts_channel);
+	RUN(test_get_rfcomm_channel_no_rfcomm_proto);
+	RUN(test_get_rfcomm_channel_get_protos_fail);
+
+	RUN(fuzz_bridge_names);
+	RUN(fuzz_addresses);
+
+	fprintf(stderr, "\n%d checks, %d failures\n", g_checks, g_failures);
+	return g_failures ? 1 : 0;
+}

--- a/test/module/test_libblueman.c
+++ b/test/module/test_libblueman.c
@@ -329,7 +329,9 @@ static void test_create_bridge_setdelay_fail(void)
 {
 	g_fail_req = SIOCDEVPRIVATE;
 	M.ioctl_hook = ioctl_fail_one;
-	CHECK(_create_bridge("pan1") < 0);   /* forward-delay failure now surfaced */
+	/* forward-delay failure is non-fatal (legacy SIOCDEVPRIVATE interface);
+	 * the bridge was already created, so the call still succeeds */
+	CHECK(_create_bridge("pan1") == 0);
 	CHECK(M.socket_opens == 1 && M.socket_closes == 1);
 }
 
@@ -425,6 +427,32 @@ static void test_find_conn_ioctl_fail(void)
 	memset(&want, 0, sizeof(want));
 	g_fail_req = HCIGETCONNLIST;
 	M.ioctl_hook = ioctl_fail_one;
+	CHECK(find_conn(5, 0, (long)(intptr_t) &want) == 0);
+}
+
+static int ioctl_connlist_hostile(int fd, unsigned long req, void *arg)
+{
+	(void) fd;
+	if (req == HCIGETCONNLIST) {
+		struct hci_conn_list_req *cl = arg;
+		int i;
+		/* claim more connections than the 10 entries find_conn allocated;
+		 * without the clamp the scan loop would read out of bounds (ASan) */
+		cl->conn_num = 12;
+		for (i = 0; i < 10; i++) {
+			memset(&cl->conn_info[i], 0, sizeof(struct hci_conn_info));
+			cl->conn_info[i].bdaddr.b[0] = 0xAA;  /* no match */
+		}
+		return 0;
+	}
+	return 0;
+}
+
+static void test_find_conn_hostile_conn_num(void)
+{
+	bdaddr_t want;
+	memset(&want, 0, sizeof(want));
+	M.ioctl_hook = ioctl_connlist_hostile;
 	CHECK(find_conn(5, 0, (long)(intptr_t) &want) == 0);
 }
 
@@ -524,6 +552,16 @@ static void test_connection_get_tpl(void)
 static void test_connection_close(void)
 {
 	struct conn_info_handles ci = { .handle = 1, .dd = 2 };
+	CHECK(connection_close(&ci) == 1);
+	CHECK(M.hci_closes == 1);
+	CHECK(ci.dd == -1);  /* descriptor invalidated */
+}
+
+static void test_connection_close_idempotent(void)
+{
+	/* a second close (or a close before init, dd == -1) must be a no-op */
+	struct conn_info_handles ci = { .handle = 1, .dd = 2 };
+	CHECK(connection_close(&ci) == 1);
 	CHECK(connection_close(&ci) == 1);
 	CHECK(M.hci_closes == 1);
 }
@@ -797,6 +835,7 @@ int main(void)
 	RUN(test_find_conn_match);
 	RUN(test_find_conn_no_match);
 	RUN(test_find_conn_ioctl_fail);
+	RUN(test_find_conn_hostile_conn_num);
 	RUN(test_find_conn_malloc_fail);
 
 	RUN(test_connection_init_success);
@@ -808,6 +847,7 @@ int main(void)
 	RUN(test_connection_get_rssi);
 	RUN(test_connection_get_tpl);
 	RUN(test_connection_close);
+	RUN(test_connection_close_idempotent);
 
 	RUN(test_get_rfcomm_list_success);
 	RUN(test_get_rfcomm_list_socket_fail);

--- a/test/module/test_libblueman.c
+++ b/test/module/test_libblueman.c
@@ -779,7 +779,8 @@ static void fuzz_bridge_names(void)
 {
 	/* Names shorter than IFNAMSIZ allocated to their exact length so any
 	 * read past the terminator lands in an ASan redzone. Validates the
-	 * strncpy fix (the old memcpy(.., IFNAMSIZ) would over-read here). */
+	 * bounded copy_ifname (the old memcpy(.., IFNAMSIZ) would over-read
+	 * here). */
 	const char *samples[] = { "", "a", "br0", "pan1", "verylonginterfacename1234567890" };
 	M.ioctl_hook = ioctl_ok;
 	for (unsigned i = 0; i < sizeof(samples) / sizeof(samples[0]); i++) {

--- a/test/module/test_libblueman_c.py
+++ b/test/module/test_libblueman_c.py
@@ -1,0 +1,49 @@
+"""Run the libblueman C unit/fuzz tests (test_libblueman.c) under the Python
+test runner. The heavy lifting is in run_tests.sh, which builds the C harness
+with ld --wrap mocks under AddressSanitizer and reports gcov coverage.
+
+Skips gracefully when the C toolchain, AddressSanitizer, or BlueZ headers are
+unavailable so the suite still runs on minimal environments.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SCRIPT = os.path.join(_HERE, "run_tests.sh")
+
+
+def _toolchain_ready() -> bool:
+    cc = os.environ.get("CC", "gcc")
+    if shutil.which(cc) is None or shutil.which("gcov") is None:
+        return False
+    probe = (
+        "#include <bluetooth/bluetooth.h>\n"
+        "#include <bluetooth/sdp.h>\n"
+        "int main(void){return 0;}\n"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        src = os.path.join(tmp, "probe.c")
+        with open(src, "w") as f:
+            f.write(probe)
+        try:
+            result = subprocess.run(
+                [cc, "-fsanitize=address", src, "-o", os.path.join(tmp, "probe"), "-lbluetooth"],
+                capture_output=True,
+            )
+        except OSError:
+            return False
+        return result.returncode == 0
+
+
+class TestLibbluemanC(unittest.TestCase):
+    @unittest.skipUnless(_toolchain_ready(), "C toolchain / ASan / BlueZ headers unavailable")
+    def test_c_unit_and_fuzz_suite_passes(self) -> None:
+        result = subprocess.run(["sh", _SCRIPT], capture_output=True, text=True)
+        if result.returncode != 0:
+            self.fail(f"libblueman C tests failed:\n{result.stdout}\n{result.stderr}")
+        self.assertIn("0 failures", result.stdout + result.stderr)
+        self.assertIn("100.00%", result.stdout + result.stderr)


### PR DESCRIPTION
## Summary

Hardens the native helper `module/libblueman.c` (the C backing the `_blueman` Cython extension) and adds the module's first C test suite, at 100% line coverage. The C here is delicate: it allocates kernel/SDP structures, opens HCI/RFCOMM sockets, and walks BlueZ-owned linked lists, all on manual cleanup paths. Each finding below is a real resource or memory-safety bug on those paths, fixed conservatively so the success paths behave exactly as before.

The PR is split into five commits, each reviewable on its own: the original fix, the test suite, and three follow-up commits from a second review pass over the branch (state-machine and lifecycle issues described under "Second review pass" below).

## Why this needs care (the C delicateness)

Most of these functions follow the classic C pattern of "acquire a resource, do work, clean up on every exit". The bugs are all in the *exit* paths — the cases that only fire when a syscall or allocation fails, which is exactly where coverage and review usually thin out. Three properties make this code easy to get wrong:

1. **Ownership is implicit.** `connection_init` opens an HCI device and hands its fd to the caller via `conn_info_handles.dd`, to be closed later by `connection_close`. But that ownership only transfers on the *success* path; on any earlier failure the fd belongs to `connection_init` and must be closed there. The original closed it nowhere on those paths.
2. **Cleanup is duplicated per branch.** `get_rfcomm_channel` frees its three SDP lists only inside the search-error branch. The happy path returns without freeing them. Because the lists are allocated by `sdp_list_append` (BlueZ-owned memory), nothing else reclaims them — every successful lookup leaked.
3. **Fixed-width copies assume max-length input.** `_create_bridge` used `memcpy(ifr.ifr_name, name, IFNAMSIZ)`, copying a fixed 16 bytes regardless of the actual string length — an out-of-bounds read for any shorter name. The sibling `_destroy_bridge` already did this correctly with `strncpy`; the two had simply drifted.

Because these only manifest on error paths or under tooling (ASan), they are invisible in normal use and in a quick read. That is precisely why the test suite builds a harness that *forces* every error path and runs the whole thing under AddressSanitizer + LeakSanitizer.

## Findings and fixes

### High — resource leaks

**`connection_init` leaked the HCI device on every post-open error.** After `dd = hci_open_dev(...)` succeeds, both the `malloc` failure and the `HCIGETCONNINFO` ioctl failure jumped to cleanup that only `free(cr)` — `dd` was never `hci_close_dev`'d and was not returned, so the caller could not close it either. Fix: close `dd` on all error paths; null it out once ownership transfers to the caller's `conn_info_handles` so the shared cleanup skips it.

**`get_rfcomm_channel` leaked all three SDP lists on success.** `search_list`, `attrid_list`, and `response_list` were freed only on the `sdp_service_search_attr_req` error branch. Fix: a single cleanup label frees all three (and closes the session) for both success and error, matching how the per-record data is already freed inside the loop.

### Medium — memory safety

**`_create_bridge` out-of-bounds read.** `memcpy(ifr.ifr_name, name, IFNAMSIZ)` over-reads when `name` is shorter than `IFNAMSIZ`. Fix: zero the `ifreq` and use a bounded copy, matching `_destroy_bridge`.

**`errno` clobbering on error returns.** Several error paths ran `return -errno` *after* `close(sock)`, which can overwrite `errno`. Fix: capture `errno` into a local before every `close()` on the error returns.

### Low — input validation and robustness

- Validate `str2ba` in `connection_init`, `create_rfcomm_device`, and `get_rfcomm_channel` instead of proceeding on an indeterminate address. Adds `ERR_INVALID_ADDRESS` (-16), mapped in `_blueman.pyx`'s error table so the Python side raises a clear message rather than `KeyError`.
- `_destroy_bridge`: bound `strncpy` to `IFNAMSIZ - 1`.
- `find_conn`: cast the callback's `long arg` through `intptr_t` rather than directly to a pointer.
- const-correctness on read-only pointer parameters; align the header's parameter name with the definition.

## Second review pass (follow-up commits)

A second review of the branch, focused on state-machine and lifecycle behavior, found and fixed four more issues:

**Forward-delay failure is non-fatal again, now documented.** An earlier revision surfaced a `SIOCDEVPRIVATE` (forward-delay) failure as an error — but at that point `SIOCBRADDBR` has already succeeded, so failing there leaves a half-created bridge behind, and `BRCTL_SET_BRIDGE_FORWARD_DELAY` via `SIOCDEVPRIVATE` is a legacy ioctl interface that a kernel may reject while bridge creation works. Since `NetConf` tolerates `EEXIST` on retry, a retry would silently skip the delay anyway. The original non-fatal semantics are restored with a comment in the code explaining why.

**Bounded name buffers for `SIOCBRADDBR`/`SIOCBRDELBR`.** The kernel always does `copy_from_user(buf, uarg, IFNAMSIZ)` for these ioctls, so passing the raw string pointer permits a read past a shorter allocation — the same class as the `ifr_name` over-read fixed above. Both bridge functions now copy the name into a zero-padded `char ifname[IFNAMSIZ]` local and pass that everywhere.

**No `strncpy`.** The bounded copy is a small documented helper (`copy_ifname`) rather than `strncpy`, which the Linux kernel deprecated (`Documentation/process/deprecated.rst`) because it does not guarantee NUL-termination when the source fills the buffer — and, after a six-year, 362-commit conversion effort, [removed from the kernel entirely for v7.2](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1a3746ccbb0a97bed3c06ccde6b880013b1dddc1). The helper implements the `strscpy_pad()` semantics the bridge ioctls need — always-terminated copy into an explicitly zeroed IFNAMSIZ buffer — using ISO C `memchr`/`memcpy`, since userspace has no portable `strscpy`.

**`connection_close` is idempotent.** It now no-ops when `dd < 0` and invalidates `dd` after closing, so a double close (or a close before a successful `connection_init`) can never touch a recycled file descriptor.

**`conn_info` use-after-free in `_blueman.pyx`.** `__init__` stored a `char*` into a temporary bytes object that is freed when `__init__` returns, so `init()` passed a dangling pointer to `connection_init`. The bytes object is now kept alive on the instance. `__init__` also initializes `ci.dd = -1`, so `deinit()` before a successful `init()` is a no-op instead of closing fd 0.

Plus defense in depth: `find_conn` clamps the ioctl-returned `conn_num` to the 10 entries it allocated, so a broken kernel contract can never walk the scan loop out of bounds.

## ABI / compatibility

No change to existing behavior on success paths. The ABI additions are the new `ERR_INVALID_ADDRESS` code (mapped in `_blueman.pyx`) and `connection_close` taking a non-const pointer so it can invalidate the descriptor. Error-path semantics are unchanged except that every resource is now released.

## Testing

`test/module/test_libblueman.c` `#include`s the translation unit (to reach the `static` helpers) and redirects every libc and libbluetooth call with `ld --wrap`, so all success and error paths run with no Bluetooth adapter and no root. The mocks count socket / HCI / SDP allocations, and the tests assert each resource is released — this is what proves the leak and OOB fixes rather than merely asserting return codes. Built under AddressSanitizer + LeakSanitizer, so a regression in any cleanup path aborts the run.

- `run_tests.sh` builds, runs (ASan), and reports gcov line coverage: **100% (243/243)**, 92 checks, 0 failures.
- `test/module/test_libblueman_c.py` runs the harness under the normal Python test runner and **skips gracefully** when the C toolchain, ASan, or BlueZ headers are unavailable, so it never falsely fails minimal CI environments.
- Coverage spans bridge create/destroy (every ioctl failure point), `find_conn` (match / no-match / ioctl / malloc failure / hostile `conn_num`), the full `connection_init` lifecycle including the device-leak error paths and idempotent close, rfcomm list/create/release, and `get_rfcomm_channel` including SDP record parsing and cleanup — plus fuzz passes over odd interface names and Bluetooth addresses (the address/name strings that would have tripped the old over-read).
- The hostile `conn_num` case is a true ASan-backed regression test: with the clamp removed, the scan loop reads past the allocation and ASan aborts the run.

`gcc -Wall -Wextra` is clean; cppcheck reports nothing on the file.

## Deliberately left as-is (optional follow-up cleanups)

These are not bugs and are not part of this PR; noting them for reviewers since they touch the same file. They are code-quality cleanups, not performance wins — the module is syscall/IO-bound, so none of them changes measurable runtime.

- **Redundant helper — `__tv_to_jiffies({0, 0})`.** With a zero `timeval` it always returns 0, so the bridge forward delay could be set with a plain `args[1] = 0` and the helper dropped. It is kept here for clarity and because it is the one trivially unit-testable pure function in the file.
- **`printf` from a library helper.** `get_rfcomm_channel` writes to stdout from code that is linked into the Python extension — the wrong layer, and stdio is the only non-trivial cost in an otherwise cheap function. Replacing these with proper logging (or removing them) would be a real cleanup and would stop stray output reaching the app's stdout.
- **Missing early exit.** Once the RFCOMM channel is found, the loop still walks every remaining record / protocol / attribute. A `break` after the match would be clearer and skip the dead iterations, though SDP responses are small enough that the saving is unmeasurable.

Happy to fold any of these into this PR or a follow-up if preferred.
