### PR TITLE
Lists: Rename path variable

### DIFF
--- a/blueman/gui/DeviceList.py
+++ b/blueman/gui/DeviceList.py
@@ -48,7 +48,7 @@ class DeviceList(GenericList):
             tabledata = []
 
         # cache for fast lookup in the list
-        self.path_to_row: dict[str, Gtk.TreeRowReference] = {}
+        self.path_to_row: dict[ObjectPath, Gtk.TreeRowReference] = {}
 
         self.manager = Manager()
         self._managerhandlers: list[int] = []
@@ -98,25 +98,25 @@ class DeviceList(GenericList):
             self.manager.disconnect(handler)
         super().destroy()
 
-    def __on_manager_signal(self, _manager: Manager, path: ObjectPath, signal_name: str) -> None:
+    def __on_manager_signal(self, _manager: Manager, object_path: ObjectPath, signal_name: str) -> None:
         if signal_name == 'adapter-removed':
-            if path == self.__adapter_path:
+            if object_path == self.__adapter_path:
                 self.clear()
                 self.Adapter = None
                 self.set_adapter()
-            self.emit("adapter-removed", path)
+            self.emit("adapter-removed", object_path)
 
         if signal_name == 'adapter-added':
             if self.Adapter is None:
-                self.set_adapter(path)
+                self.set_adapter(object_path)
 
-            self.emit("adapter-added", path)
+            self.emit("adapter-added", object_path)
 
         if signal_name == 'device-created':
-            self.device_add_event(path)
+            self.device_add_event(object_path)
 
         if signal_name == 'device-removed':
-            self.device_remove_event(path)
+            self.device_remove_event(object_path)
 
     def on_selection_changed(self, selection: Gtk.TreeSelection) -> None:
         model, tree_iter = selection.get_selected()
@@ -126,8 +126,8 @@ class DeviceList(GenericList):
             dev = row["device"]
             self.emit("device-selected", dev, tree_iter)
 
-    def _on_property_changed(self, _adapter: AnyAdapter, key: str, value: object, path: ObjectPath) -> None:
-        if not self.Adapter or self.Adapter.get_object_path() != path:
+    def _on_property_changed(self, _adapter: AnyAdapter, key: str, value: object, object_path: ObjectPath) -> None:
+        if not self.Adapter or self.Adapter.get_object_path() != object_path:
             return
 
         if key == "Discovering" and not value:
@@ -135,8 +135,8 @@ class DeviceList(GenericList):
 
         self.emit("adapter-property-changed", self.Adapter, (key, value))
 
-    def _on_device_property_changed(self, _device: AnyDevice, key: str, value: object, path: ObjectPath) -> None:
-        tree_iter = self.find_device_by_path(path)
+    def _on_device_property_changed(self, _device: AnyDevice, key: str, value: object, object_path: ObjectPath) -> None:
+        tree_iter = self.find_device_by_path(object_path)
 
         if tree_iter is not None:
             dev = self.get(tree_iter, "device")["device"]
@@ -303,7 +303,7 @@ class DeviceList(GenericList):
             return None
 
     def do_cache(self, tree_iter: Gtk.TreeIter, kwargs: dict[str, Any]) -> None:
-        object_path = None
+        object_path: ObjectPath | None = None
 
         if "device" in kwargs:
             if kwargs["device"]:
@@ -313,7 +313,7 @@ class DeviceList(GenericList):
             if kwargs["dbus_path"]:
                 object_path = kwargs['dbus_path']
             else:
-                existing = self.get(tree_iter, "dbus_path")["dbus_path"]
+                existing: ObjectPath = self.get(tree_iter, "dbus_path")["dbus_path"]
                 if existing is not None:
                     del self.path_to_row[existing]
 

--- a/blueman/gui/GenericList.py
+++ b/blueman/gui/GenericList.py
@@ -107,12 +107,12 @@ class GenericList(Gtk.TreeView):
             data[col_id] = self.liststore.get_value(tree_iter, list_col_num)
         return data
 
-    def get_iter(self, path: Gtk.TreePath | None) -> Gtk.TreeIter | None:
-        if path is None:
+    def get_iter(self, tree_path: Gtk.TreePath | None) -> Gtk.TreeIter | None:
+        if tree_path is None:
             return None
 
         try:
-            return self.liststore.get_iter(path)
+            return self.liststore.get_iter(tree_path)
         except ValueError:
             return None
 

--- a/blueman/gui/GtkAnimation.py
+++ b/blueman/gui/GtkAnimation.py
@@ -103,7 +103,7 @@ class AnimBase(GObject.GObject):
 
 class TreeRowFade(AnimBase):
     def __init__(self, tw: "ManagerDeviceList",
-                 path: Gtk.TreePath,
+                 tree_path: Gtk.TreePath,
                  columns: Collection[Gtk.TreeViewColumn] | None = None) -> None:
         super().__init__(1.0)
         self.tw = tw
@@ -111,7 +111,7 @@ class TreeRowFade(AnimBase):
 
         self.sig: int | None = self.tw.connect_after("draw", self.on_draw)
 
-        self.row = Gtk.TreeRowReference.new(self.tw.liststore, path)
+        self.row = Gtk.TreeRowReference.new(self.tw.liststore, tree_path)
         self.stylecontext = tw.get_style_context()
         self.columns = columns
 
@@ -130,12 +130,12 @@ class TreeRowFade(AnimBase):
                 self.sig = None
             return False
 
-        path = self.row.get_path()
-        if path is None:
+        tree_path = self.row.get_path()
+        if tree_path is None:
             return False
 
-        path = self.tw.filter.convert_child_path_to_path(path)
-        if path is None:
+        tree_path = self.tw.filter.convert_child_path_to_path(tree_path)
+        if tree_path is None:
             return False
 
         color = self.stylecontext.get_background_color(Gtk.StateFlags.NORMAL)
@@ -145,7 +145,7 @@ class TreeRowFade(AnimBase):
         assert self.columns is not None
 
         for col in self.columns:
-            rect = self.tw.get_background_area(path, col)
+            rect = self.tw.get_background_area(tree_path, col)
             cr.rectangle(rect.x, rect.y, rect.width, rect.height)
 
         cr.clip()
@@ -161,14 +161,14 @@ class TreeRowFade(AnimBase):
 
 
 class CellFade(AnimBase):
-    def __init__(self, tw: "ManagerDeviceList", path: Gtk.TreePath, columns: Iterable[int]) -> None:
+    def __init__(self, tw: "ManagerDeviceList", tree_path: Gtk.TreePath, columns: Iterable[int]) -> None:
         super().__init__(1.0)
         self.tw = tw
         assert self.tw.liststore is not None
 
         self.frozen = False
         self.sig: int | None = tw.connect_after("draw", self.on_draw)
-        self.row = Gtk.TreeRowReference.new(self.tw.liststore, path)
+        self.row = Gtk.TreeRowReference.new(self.tw.liststore, tree_path)
         self.selection = tw.get_selection()
         self.columns: list[Gtk.TreeViewColumn | None] = []
         for i in columns:
@@ -189,19 +189,19 @@ class CellFade(AnimBase):
                 self.sig = None
 
         assert self.tw.liststore is not None
-        path = self.row.get_path()
-        if path is None:
+        tree_path = self.row.get_path()
+        if tree_path is None:
             return False
 
-        path = self.tw.filter.convert_child_path_to_path(path)
-        if path is None:
+        tree_path = self.tw.filter.convert_child_path_to_path(tree_path)
+        if tree_path is None:
             return False
 
         # FIXME Use Gtk.render_background to render background.
         # However it does not use the correct colors/gradient.
         for col in self.columns:
-            bg_rect = self.tw.get_background_area(path, col)
-            rect = self.tw.get_cell_area(path, col)
+            bg_rect = self.tw.get_background_area(tree_path, col)
+            rect = self.tw.get_cell_area(tree_path, col)
             rect.y = bg_rect.y
             rect.height = bg_rect.height
 
@@ -211,7 +211,7 @@ class CellFade(AnimBase):
 
         maybe_selected = self.tw.selected()
         if maybe_selected is not None:
-            selected = self.tw.liststore.get_path(maybe_selected) == path
+            selected = self.tw.liststore.get_path(maybe_selected) == tree_path
         else:
             selected = False
 

--- a/blueman/gui/manager/ManagerDeviceList.py
+++ b/blueman/gui/manager/ManagerDeviceList.py
@@ -168,9 +168,9 @@ class ManagerDeviceList(DeviceList):
 
         context.finish(True, False, time)
 
-        path = self.get_path_at_pos(x, y)
-        if path:
-            tree_iter = self.get_iter(path[0])
+        tree_path = self.get_path_at_pos(x, y)
+        if tree_path:
+            tree_iter = self.get_iter(tree_path[0])
             assert tree_iter is not None
             device = self.get(tree_iter, "device")["device"]
             command = f"blueman-sendto --device={device['Address']}"
@@ -183,19 +183,19 @@ class ManagerDeviceList(DeviceList):
     def drag_motion(self, _widget: Gtk.Widget, drag_context: Gdk.DragContext, x: int, y: int, timestamp: int) -> bool:
         result = self.get_path_at_pos(x, y)
         if result is not None:
-            path = result[0]
-            assert path is not None
-            path = self.filter.convert_path_to_child_path(path)
-            if path is None:
+            tree_path = result[0]
+            assert tree_path is not None
+            tree_path = self.filter.convert_path_to_child_path(tree_path)
+            if tree_path is None:
                 return False
 
-            if not self.selection.path_is_selected(path):
-                tree_iter = self.get_iter(path)
+            if not self.selection.path_is_selected(tree_path):
+                tree_iter = self.get_iter(tree_path)
                 assert tree_iter is not None
                 has_obj_push = self._has_objpush(self.get(tree_iter, "device")["device"])
                 if has_obj_push:
                     Gdk.drag_status(drag_context, Gdk.DragAction.COPY, timestamp)
-                    self.set_cursor(path)
+                    self.set_cursor(tree_path)
                     return True
                 else:
                     Gdk.drag_status(drag_context, Gdk.DragAction.DEFAULT, timestamp)
@@ -226,10 +226,10 @@ class ManagerDeviceList(DeviceList):
         if posdata is None:
             return False
         else:
-            path = posdata[0]
-            assert path is not None
+            tree_path = posdata[0]
+            assert tree_path is not None
 
-        tree_iter = self.filter.get_iter(path)
+        tree_iter = self.filter.get_iter(tree_path)
         assert tree_iter is not None
         child_iter = self.filter.convert_iter_to_child_iter(tree_iter)
         assert child_iter is not None
@@ -551,17 +551,17 @@ class ManagerDeviceList(DeviceList):
         return fader
 
     def tooltip_query(self, _tw: Gtk.Widget, x: int, y: int, _kb: bool, tooltip: Gtk.Tooltip) -> bool:
-        path = self.get_path_at_pos(x, y)
-        if path is None:
+        tree_path = self.get_path_at_pos(x, y)
+        if tree_path is None:
             return False
 
-        if path[0] != self.tooltip_row or path[1] != self.tooltip_col:
-            self.tooltip_row = path[0]
-            self.tooltip_col = path[1]
+        if tree_path[0] != self.tooltip_row or tree_path[1] != self.tooltip_col:
+            self.tooltip_row = tree_path[0]
+            self.tooltip_col = tree_path[1]
             return False
 
-        if path[1] == self.view_columns["device_surface"]:
-            tree_iter = self.get_iter(path[0])
+        if tree_path[1] == self.view_columns["device_surface"]:
+            tree_iter = self.get_iter(tree_path[0])
             assert tree_iter is not None
 
             row = self.get(tree_iter, "connected", "trusted", "paired", "blocked")
@@ -581,14 +581,14 @@ class ManagerDeviceList(DeviceList):
             else:
                 return False
 
-            self.tooltip_row = path[0]
-            self.tooltip_col = path[1]
+            self.tooltip_row = tree_path[0]
+            self.tooltip_col = tree_path[1]
             return True
 
-        elif path[1] == self.view_columns["battery_pb"] \
-                or path[1] == self.view_columns["tpl_pb"] \
-                or path[1] == self.view_columns["rssi_pb"]:
-            tree_iter = self.get_iter(path[0])
+        elif tree_path[1] == self.view_columns["battery_pb"] \
+                or tree_path[1] == self.view_columns["tpl_pb"] \
+                or tree_path[1] == self.view_columns["rssi_pb"]:
+            tree_iter = self.get_iter(tree_path[0])
             assert tree_iter is not None
 
             dt = self.get(tree_iter, "connected")["connected"]
@@ -602,7 +602,7 @@ class ManagerDeviceList(DeviceList):
             tpl = self.get(tree_iter, "tpl")["tpl"]
 
             if battery != 0:
-                if path[1] == self.view_columns["battery_pb"]:
+                if tree_path[1] == self.view_columns["battery_pb"]:
                     lines.append(f"<b>Battery: {int(battery)}%</b>")
                 else:
                     lines.append(f"Battery: {int(battery)}%")
@@ -619,7 +619,7 @@ class ManagerDeviceList(DeviceList):
                 else:
                     rssi_state = _("Too much")
 
-                if path[1] == self.view_columns["rssi_pb"]:
+                if tree_path[1] == self.view_columns["rssi_pb"]:
                     lines.append(_("<b>Received Signal Strength: %(rssi)u%%</b> <i>(%(rssi_state)s)</i>") %
                                  {"rssi": rssi, "rssi_state": rssi_state})
                 else:
@@ -638,7 +638,7 @@ class ManagerDeviceList(DeviceList):
                 else:
                     tpl_state = _("Very High")
 
-                if path[1] == self.view_columns["tpl_pb"]:
+                if tree_path[1] == self.view_columns["tpl_pb"]:
                     lines.append(_("<b>Transmit Power Level: %(tpl)u%%</b> <i>(%(tpl_state)s)</i>") %
                                  {"tpl": tpl, "tpl_state": tpl_state})
                 else:
@@ -646,8 +646,8 @@ class ManagerDeviceList(DeviceList):
                                  {"tpl": tpl, "tpl_state": tpl_state})
 
             tooltip.set_markup("\n".join(lines))
-            self.tooltip_row = path[0]
-            self.tooltip_col = path[1]
+            self.tooltip_row = tree_path[0]
+            self.tooltip_col = tree_path[1]
             return True
         return False
 

--- a/blueman/gui/manager/ManagerDeviceMenu.py
+++ b/blueman/gui/manager/ManagerDeviceMenu.py
@@ -273,11 +273,11 @@ class ManagerDeviceMenu(Gtk.Menu):
             if posdata is None:
                 return
 
-            path = posdata[0]
-            if path is None:
+            tree_path: Gtk.TreePath | None = posdata[0]
+            if tree_path is None:
                 raise TypeError("Path should never be None")
 
-            tree_iter = self.Blueman.List.filter.get_iter(path)
+            tree_iter = self.Blueman.List.filter.get_iter(tree_path)
             assert tree_iter is not None
             child_iter = self.Blueman.List.filter.convert_iter_to_child_iter(tree_iter)
             assert child_iter is not None

--- a/blueman/gui/manager/ManagerMenu.py
+++ b/blueman/gui/manager/ManagerMenu.py
@@ -24,7 +24,7 @@ class ManagerMenu:
         self.blueman = blueman
         self.Config = Gio.Settings(schema_id="org.blueman.general")
 
-        self.adapter_items: dict[str, tuple[Gtk.RadioMenuItem, Adapter]] = {}
+        self.adapter_items: dict[ObjectPath, tuple[Gtk.RadioMenuItem, Adapter]] = {}
         self._adapters_group: Sequence[Gtk.RadioMenuItem] = []
         self._insert_adapter_item_pos = 2
 
@@ -98,9 +98,9 @@ class ManagerMenu:
         else:
             self.item_device.props.sensitive = False
 
-    def on_adapter_property_changed(self, _adapter: Adapter, name: str, value: Any, path: str) -> None:
+    def on_adapter_property_changed(self, _adapter: Adapter, name: str, value: Any, object_path: ObjectPath) -> None:
         if name == "Name" or name == "Alias":
-            item = self.adapter_items[path][0]
+            item = self.adapter_items[object_path][0]
             item.set_label(value)
         elif name == "Discovering":
             if self.Search:
@@ -142,8 +142,8 @@ class ManagerMenu:
 
         self._update_power()
 
-    def on_adapter_removed(self, _devicelist: ManagerDeviceList, adapter_path: str) -> None:
-        item, adapter = self.adapter_items.pop(adapter_path)
+    def on_adapter_removed(self, _devicelist: ManagerDeviceList, object_path: ObjectPath) -> None:
+        item, adapter = self.adapter_items.pop(object_path)
         menu = self.item_adapter.get_submenu()
         assert isinstance(menu, Gtk.Menu)
 


### PR DESCRIPTION
No functional changes. We have 3 path types in the lists, file paths, object paths and tree paths. It can get confusing so rename them as:

filepaths -> path
ObjectPaths -> object_path
TreeViewPaths -> tree_path

Also fixes a couple variables annotated as str instead of ObjectPath.